### PR TITLE
fix false file requirement when cropping is given in options.crop

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -1239,6 +1239,7 @@ module.exports = {
         path = self.uploadfs.getUrl() + path;
       }
       if (file.crop) {
+        // @todo: include options.cropping inside here!
         var c = file.crop;
         path += '.' + c.left + '.' + c.top + '.' + c.width + '.' + c.height;
       }


### PR DESCRIPTION
Found out, that cropping-information provided in the `options-parameter` to the `filePath()`- e.g. `aposFilePath()`-Function is not included.