### PR TITLE
Update package clean-css, because we had problems with shorthand

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -7,7 +7,7 @@ var fs = require('fs');
 // JS minifier and optimizer
 var uglifyJs = require('uglify-js');
 // CSS minifier https://github.com/GoalSmashers/clean-css
-var cleanCss = require('clean-css');
+var CleanCSS = require('clean-css');
 // LESS CSS compiler
 var less = require('less');
 var moment = require('moment');
@@ -651,7 +651,7 @@ module.exports = {
         if (err) {
           return callback(err);
         }
-        return callback(null, cleanCss.process(code));
+        return callback(null, new CleanCSS().minify(code).styles);
       });
     };
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "bless": "^3.0.3",
     "broadband": "^0.1.0",
     "cheerio": "^0.17.0",
-    "clean-css": "~1.0.0",
+    "clean-css": "^3.4.8",
     "clone": "~0.1.11",
     "deep-get-set": "^0.1.1",
     "diff": "~1.0.4",


### PR DESCRIPTION
We had a problem with the `clean-css` with version `1.x`, so i updated the package. Please review and check if you find some problems. Thx!

Example:
```    
font: 500 2em/1.1 'DIN Condensed',Arial,sans-serif;
```

was this after the minify-process:

```
font: 400 500 2em/1.1 'DIN Condensed',Arial,sans-serif;
```