### PR TITLE
Bugfix szint 2696 remove low search text and search summary

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -7,7 +7,7 @@ var fs = require('fs');
 // JS minifier and optimizer
 var uglifyJs = require('uglify-js');
 // CSS minifier https://github.com/GoalSmashers/clean-css
-var cleanCss = require('clean-css');
+var CleanCSS = require('clean-css');
 // LESS CSS compiler
 var less = require('less');
 var moment = require('moment');
@@ -651,7 +651,7 @@ module.exports = {
         if (err) {
           return callback(err);
         }
-        return callback(null, cleanCss.process(code));
+        return callback(null, new CleanCSS().minify(code).styles);
       });
     };
 

--- a/lib/pages.js
+++ b/lib/pages.js
@@ -251,6 +251,22 @@ module.exports = function(self) {
       var sortTitle = self.sortify(page.title);
       var highWords = _.uniq(highText.split(/ /));
 
+      /**
+       * Remove these fields, because the lead to errors on pages
+       * where several blog-posts were rendered.
+       *
+       * In our case it was the homepage were all blog-posts were rendered
+       * also some snippets (so called mediagalerys) were rendered on this page.
+       * This lead to a way to long searchSummary and lowSearchText because
+       * all contents of all articles and snippets were involved to this fields.
+       *
+       * Even worse is the fact, that some strings weren't escaped which lead to
+       * a destroyed js on client –> which leads to the fact that no one could
+       * add new pages for example...
+       */
+      lowText = '';
+      searchSummary = '';      
+
       return self.pages.update({ slug: page.slug }, { $set: { sortTitle: sortTitle, highSearchText: highText, highSearchWords: highWords, lowSearchText: lowText, searchSummary: searchSummary } }, callback);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "0.5.345",
+  "version": "0.5.346",
   "description": "Apostrophe is a user-friendly content management system. You'll need more than this core module. See apostrophenow.org to get started.",
   "main": "./lib/apostrophe.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "bless": "^3.0.3",
     "broadband": "^0.1.0",
     "cheerio": "^0.17.0",
-    "clean-css": "~1.0.0",
+    "clean-css": "^3.4.8",
     "clone": "~0.1.11",
     "deep-get-set": "^0.1.1",
     "diff": "~1.0.4",

--- a/views/formMacros.html
+++ b/views/formMacros.html
@@ -197,7 +197,7 @@
       <li class="apos-fieldset-selective-item" data-item>
         <div class="apos-ui-container apos-fieldset-selective-item-inner">
           <div class="apos-fieldset-selective-item-inner-bg apos-ui-btn apos-ui--dark">
-            <span class="apos-remove" data-remove><i8 class="icon icon-remove"></i></span>
+            <span class="apos-remove" data-remove><i class="icon icon-remove"></i></span>
             <span class="apos-selective-label" data-label>
               {{ __(Title) }}
             </span>


### PR DESCRIPTION
```
/**
* Remove these fields, because the lead to errors on pages
* where several blog-posts were rendered.
*
* In our case it was the homepage were all blog-posts were rendered
* also some snippets (so called mediagalerys) were rendered on this page.
* This lead to a way to long searchSummary and lowSearchText because
* all contents of all articles and snippets were involved to this fields.
*
* Even worse is the fact, that some strings weren't escaped which lead to
* a destroyed js on client –> which leads to the fact that no one could
* add new pages for example...
*/
```