### PR TITLE
Resolve #409. Bail on asset generation if we are in a non-generation …

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,13 @@ module.exports = function(options) {
       }
       return callback(null);
     });
-  }
+  };
+
+  // Helper function for other modules to determine whether the application
+  // is running as a server or a task
+  self.isTask = function() {
+    return !!self.argv._.length;
+  };
 
   defineModules();
 

--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -293,6 +293,9 @@ module.exports = {
     // each other (modulesReady) before pushing assets.
 
     self.afterInit = function(callback) {
+      if (self.apos.isTask() && !self.isGenerationTask) {
+        return setImmediate(callback);
+      }
 
       self.tooLateToPushAssets = true;
 


### PR DESCRIPTION
…task.

Notice I also added a top level `isTask` method to the apos object. Criteria for that is whether there were additional arguments passed when we started the app.