### PR TITLE
Test fixes

### DIFF
--- a/lib/modules/apostrophe-pager/index.js
+++ b/lib/modules/apostrophe-pager/index.js
@@ -1,7 +1,6 @@
 module.exports = {
   alias: 'pager',
   construct: function(self, options) {
-    console.log('PUSH');
     self.pushAsset('stylesheet', 'user', { when: 'user' });
     self.addHelpers({
       // Generate the right range of page numbers to display in the pager.

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -1020,7 +1020,7 @@ module.exports = {
             return callback(new Error('join with type ' + field.withType + ' unrecognized'));
           }
           var titleOrId = self.apos.launder.string(data[name]);
-          var criteria = { $or: [ { sortTitle: self.apos.utils.sortify(titleOrId) }, { _id: titleOrId } ] };
+          var criteria = { $or: [ { titleSortified: self.apos.utils.sortify(titleOrId) }, { _id: titleOrId } ] };
           return manager.find(req, criteria, { _id: 1 }).joins(false).published(null).toObject(function(err, result) {
             if (err) {
               return callback(err);
@@ -1067,7 +1067,7 @@ module.exports = {
           }
           var clauses = [];
           _.each(titlesOrIds, function(titleOrId) {
-            clauses.push({ sortTitle: self.apos.utils.sortify(titleOrId) });
+            clauses.push({ titleSortified: self.apos.utils.sortify(titleOrId) });
             clauses.push({ _id: titleOrId });
           });
           return manager.find(req, { $or: clauses }, { _id: 1 }).joins(false).published(null).toArray(function(err, results) {

--- a/lib/modules/apostrophe-search/index.js
+++ b/lib/modules/apostrophe-search/index.js
@@ -34,12 +34,12 @@ module.exports = {
       var searchSummary = _.map(_.filter(texts, function(text) { return !text.silent; } ), function(text) { return text.text; }).join(" ");
       var highText = self.boilTexts(highTexts);
       var lowText = self.boilTexts(texts);
-      var sortTitle = self.apos.utils.sortify(doc.title);
+      var titleSortified = self.apos.utils.sortify(doc.title);
       var highWords = _.uniq(highText.split(/ /));
 
       // merge our doc with its various search texts
       _.assign(doc, {
-        sortTitle: sortTitle,
+        titleSortified: titleSortified,
         highSearchText: highText,
         highSearchWords: highWords,
         lowSearchText: lowText,
@@ -111,7 +111,7 @@ module.exports = {
     self.docUnversionedFields = function(req, doc, fields) {
       // Moves in the tree have knock-on effects on other
       // pages, they are not suitable for rollback
-      fields.push('sortTitle', 'highSearchText', 'highSearchWords', 'lowSearchText', 'searchSummary');
+      fields.push('titleSortified', 'highSearchText', 'highSearchWords', 'lowSearchText', 'searchSummary');
     };
 
   }

--- a/lib/modules/apostrophe-utils/lib/api.js
+++ b/lib/modules/apostrophe-utils/lib/api.js
@@ -227,7 +227,7 @@ module.exports = function(self, options) {
   // behavior which is no good for most practical purposes involving text.
   //
   // The use of this method to create sortable properties like
-  // "sortTitle" is encouraged. It should not be used for full text
+  // "titleSortified" is encouraged. It should not be used for full text
   // search, as MongoDB full text search is now available (see the
   // "search" option to apos.get and everything layered on top of it).
   // It is however used as part of our "autocomplete" search implementation.

--- a/test/docs.js
+++ b/test/docs.js
@@ -62,7 +62,7 @@ describe('Docs', function() {
 
 
   it('should make sure all of the expected indexes are configured', function(done){
-    var expectedIndexes = ['type', 'slug', 'sortTitle', 'tags', 'published'];
+    var expectedIndexes = ['type', 'slug', 'titleSortified', 'tags', 'published'];
     var actualIndexes = []
 
     apos.docs.db.indexInformation(function(err, info){

--- a/test/locales/en.json
+++ b/test/locales/en.json
@@ -1,4 +1,7 @@
 {
 	"Server error, please try again.": "Server error, please try again.",
-	"Use the Add Content button to get started.": "Use the Add Content button to get started."
+	"Use the Add Content button to get started.": "Use the Add Content button to get started.",
+	"Type Here": "Type Here",
+	"Limit Reached!": "Limit Reached!",
+	"Example label": "Example label"
 }


### PR DESCRIPTION
Should resolve failed tests referenced in #414 and #415 

Renamed all instances of `sortTitle` to `titleSortified`.
Updated `pieces-widgets` autocomplete test to use a `POST` instead of a `GET`. I also had to add a get request in order to get a CSRF token, and then had to get a modal that had the join in it to bless the join in the session. @boutell Let me know if I'm jumping through any unnecessary steps there, because it did seem a bit complicated to get that route to work.