### PR TITLE
JSON output in HTML markup must not crash on illegal unicode characte…

### DIFF
--- a/lib/templates.js
+++ b/lib/templates.js
@@ -139,6 +139,9 @@ module.exports = function(self) {
     data = JSON.stringify(data); // , null, '  ');
     data = data.replace(/<\!\-\-/g, '<\\!--');
     data = data.replace(/<\/script\>/gi, '<\\/script>');
+    // unicode line separator and paragraph separator break JavaScript parsing
+    data = data.replace("\u2028", "\\u2028");
+    data = data.replace("\u2029", "\\u2029");
     return data;
   };
 


### PR DESCRIPTION
…rs (the line separator and paragraph separator unicode characters) fixes #397