### PR TITLE
selectize dropdowns should appear on top of 'add content' buttons and…

### DIFF
--- a/public/css/modal.less
+++ b/public/css/modal.less
@@ -8,6 +8,10 @@
 // 900: out-of-flow controls such as the page settings gear and the admin bar only
 // 901: modal blackout
 // 902: modals
+// 950: dropdown (including the toggle which is its parent), however
+//   this is a descendant element so it doesn't ordinarily conflict
+//   with the z-index of modals
+// 951: selectize dropdown (must beat "Add Content" and the like)
 
 .apos-modal .apos-modal-body
 {

--- a/public/css/user.less
+++ b/public/css/user.less
@@ -1818,7 +1818,7 @@ body .ui-tooltip
     font-family: 'cabin';
     position:absolute;
     display: none;
-    z-index: 100;
+    z-index: 951;
     background-color: rgb(255, 255, 255);
     -webkit-border-radius: 2px;
             border-radius: 2px;


### PR DESCRIPTION
… everything else. However it must be done without causing their launcher buttons to 'shine through' a modal on top of them. I tested that case.