### PR TITLE
Contextual pieces

### DIFF
--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -70,14 +70,14 @@ apos.define('apostrophe-area-editor', {
 
     self.registerClickHandlers = function() {
 
-      self.link('add-item', self.addItem);
-      self.link('edit-item', self.editItem);
-      self.link('move-item', self.moveItem);
-      self.link('trash-item', self.trashItem);
+      self.link('apos-add-item', self.addItem);
+      self.link('apos-edit-item', self.editItem);
+      self.link('apos-move-item', self.moveItem);
+      self.link('apos-trash-item', self.trashItem);
 
       // Lockup controls
-      self.link('lockup-type', self.switchLockup);
-      self.link('unlock-item', self.destroyLockup);
+      self.link('apos-lockup-type', self.switchLockup);
+      self.link('apos-unlock-item', self.destroyLockup);
     };
 
     self.registerEventHandlers = function() {

--- a/lib/modules/apostrophe-areas/views/areaControls.html
+++ b/lib/modules/apostrophe-areas/views/areaControls.html
@@ -4,7 +4,7 @@
     {%- if not data.widgetManagers[name] -%}
       {{ apos.log("Your area contains a widget of type " + name + " but there is no manager for that type. Maybe you forgot to configure the " + name + "-widgets module?") }}
     {%- else -%}
-      <li class="apos-dropdown-item" data-add-item="{{ name }}">{{ __(data.widgetManagers[name].label) }}</li>
+      <li class="apos-dropdown-item" data-apos-add-item="{{ name }}">{{ __(data.widgetManagers[name].label) }}</li>
     {%- endif -%}
   {%- endfor -%}
 {%- endmacro -%}

--- a/lib/modules/apostrophe-attachments/public/js/user.js
+++ b/lib/modules/apostrophe-attachments/public/js/user.js
@@ -106,7 +106,7 @@ apos.define('apostrophe-attachments', {
     };
 
     self.addHandlers = function() {
-      apos.ui.link('trash', 'attachment', function($el, _id) {
+      apos.ui.link('apos-trash', 'attachment', function($el, _id) {
         self.api('trash', { _id: _id }, function(result) {
           if (result.status !== 'ok') {
             return;
@@ -116,7 +116,7 @@ apos.define('apostrophe-attachments', {
         });
         return false;
       });
-      apos.ui.link('crop', 'attachment', function($el, _id) {
+      apos.ui.link('apos-crop', 'attachment', function($el, _id) {
         var attachment = $el.closest('[data-existing]').data('existing');
         var $fieldset = $el.closest('fieldset');
         // TODO what about minSize, etc. in this context?

--- a/lib/modules/apostrophe-custom-pages/lib/dispatch.js
+++ b/lib/modules/apostrophe-custom-pages/lib/dispatch.js
@@ -38,7 +38,7 @@ module.exports = function(self, options) {
       }
     });
     if (!matched) {
-      req.notfound = true;
+      req.notFound = true;
       return callback(null);
     }
 

--- a/lib/modules/apostrophe-docs/public/js/chooser.js
+++ b/lib/modules/apostrophe-docs/public/js/chooser.js
@@ -97,10 +97,10 @@ apos.define('apostrophe-docs-chooser', {
     };
 
     self.enableLinks = function() {
-      self.link('delete', 'item', function($button, _id) {
+      self.link('apos-delete', 'item', function($button, _id) {
         self.remove(_id);
       });
-      self.link('raise', 'item', function($button, _id) {
+      self.link('apos-raise', 'item', function($button, _id) {
         var index = _.findIndex(self.choices, { value: _id });
         if (index === -1) {
           return;
@@ -113,7 +113,7 @@ apos.define('apostrophe-docs-chooser', {
         self.choices[index] = tmp;
         return self.refresh();
       });
-      self.link('lower', 'item', function($button, _id) {
+      self.link('apos-lower', 'item', function($button, _id) {
         var index = _.findIndex(self.choices, { value: _id });
         if (index === -1) {
           return;
@@ -126,7 +126,7 @@ apos.define('apostrophe-docs-chooser', {
         self.choices[index] = tmp;
         return self.refresh();
       });
-      self.link('relate', 'item', function($button, _id) {
+      self.link('apos-relate', 'item', function($button, _id) {
         var choice = _.find(self.choices, { value: _id });
         if (!choice) {
           return;
@@ -139,7 +139,7 @@ apos.define('apostrophe-docs-chooser', {
           chooser: self
         });
       });
-      self.link('browse', function() {
+      self.link('apos-browse', function() {
         self.launchBrowser();
       });
     };

--- a/lib/modules/apostrophe-docs/views/chooser.html
+++ b/lib/modules/apostrophe-docs/views/chooser.html
@@ -1,5 +1,6 @@
+{%- import 'apostrophe-ui:components/buttons.html' as buttons with context -%}
 {% if data.browse %}
-  <a class="apos-button" data-browse>Browse...</a>
+  {{ buttons.action('Browse', { action: 'browse', icon: 'caret-right' }) }}
 {% endif %}
 {# Existing selections #}
 <div data-choices>

--- a/lib/modules/apostrophe-files/public/js/files.js
+++ b/lib/modules/apostrophe-files/public/js/files.js
@@ -8,7 +8,7 @@ apos.define('apostrophe-files', {
     self.uploadsUrl = self.options.uploadsUrl || '';
 
     self.addLinks = function() {
-      apos.ui.link('launch', 'mediaLibrary', function() {
+      apos.ui.link('apos-launch', 'mediaLibrary', function() {
         if (!self.mediaLibrary) {
           self.mediaLibrary = apos.create('apostrophe-media-library', self.options);
         }

--- a/lib/modules/apostrophe-modal/public/js/modal.js
+++ b/lib/modules/apostrophe-modal/public/js/modal.js
@@ -92,11 +92,12 @@ apos.define('apostrophe-modal', {
     };
 
     self.enableButtonEvents = function() {
-      self.$controls.on('click', '[data-cancel]', function() {
+      // TODO this should use .link for consistency
+      self.$controls.on('click', '[data-apos-cancel]', function() {
         return self.cancel();
       });
 
-      self.$controls.on('click', '[data-save]', function() {
+      self.$controls.on('click', '[data-apos-save]', function() {
         var $button = $(this);
         self.save(function(err) {
           if (err) {

--- a/lib/modules/apostrophe-pieces-pages/index.js
+++ b/lib/modules/apostrophe-pieces-pages/index.js
@@ -59,7 +59,42 @@ module.exports = {
     self.showPage = function(req, callback) {
       var cursor = self.pieces.find(req, { slug: req.params.slug });
 
+      if (self.pieces.contextual) {
+        cursor.published(null);
+      }
+
       cursor.toObject(function(err, doc) {
+        if (!doc) {
+          req.notFound = true;
+          return callback(null);
+        }
+        req.contextMenu = [
+          {
+            name: 'insert-page',
+            action: 'insert-page',
+            label: 'Create ' + self.pieces.label
+          },
+          {
+            name: 'update-page',
+            action: 'update-page',
+            label: 'Update ' + self.pieces.label
+          },
+          {
+            name: 'versions-page',
+            action: 'versions-page',
+            label: 'GOING'
+          },
+          {
+            name: 'trash-page',
+            action: 'trash-page',
+            label: 'ON'
+          },
+          {
+            name: 'reorganize-page',
+            action: 'reorganize-page',
+            label: 'YO'
+          }
+        ];
         req.template = self.renderer('show');
         req.data.piece = doc;
         return callback(null);

--- a/lib/modules/apostrophe-pieces-pages/index.js
+++ b/lib/modules/apostrophe-pieces-pages/index.js
@@ -21,22 +21,23 @@ module.exports = {
 
     self.piecesModuleName = self.options.piecesModuleName || self.__meta.name.replace(/\-pages$/, '');
     self.pieces = self.apos.modules[self.piecesModuleName];
+    self.piecesCssName = self.apos.utils.cssName(self.pieces.name);
 
     self.contextMenu = options.contextMenu || [
       {
-        name: 'create-' + self.pieces.name,
-        action: 'create-' + self.pieces.name,
+        name: 'create-' + self.piecesCssName,
+        action: 'create-' + self.piecesCssName,
         label: 'Create ' + self.pieces.label
       },
       {
-        name: 'edit-' + self.pieces.name,
-        action: 'edit-' + self.pieces.name,
+        name: 'edit-' + self.piecesCssName,
+        action: 'edit-' + self.piecesCssName,
         label: 'Update ' + self.pieces.label,
         value: true
       },
       {
-        name: 'manage-' + self.pieces.name,
-        action: 'manage-' + self.pieces.name,
+        name: 'manage-' + self.piecesCssName,
+        action: 'manage-' + self.piecesCssName,
         label: 'Manage ' + self.pieces.label
       },
       {
@@ -46,8 +47,8 @@ module.exports = {
         value: true
       },
       {
-        name: 'trash-' + self.pieces.name,
-        action: 'trash-' + self.pieces.name,
+        name: 'trash-' + self.piecesCssName,
+        action: 'trash-' + self.piecesCssName,
         label: 'Trash ' + self.pieces.label,
         value: true
       }

--- a/lib/modules/apostrophe-pieces-pages/index.js
+++ b/lib/modules/apostrophe-pieces-pages/index.js
@@ -70,29 +70,27 @@ module.exports = {
         }
         req.contextMenu = [
           {
-            name: 'insert-page',
-            action: 'insert-page',
+            name: 'create-' + self.pieces.name,
+            action: 'create-' + self.pieces.name,
             label: 'Create ' + self.pieces.label
           },
           {
-            name: 'update-page',
-            action: 'update-page',
-            label: 'Update ' + self.pieces.label
+            name: 'edit-' + self.pieces.name,
+            action: 'edit-' + self.pieces.name,
+            label: 'Update ' + self.pieces.label,
+            value: doc._id
           },
           {
             name: 'versions-page',
             action: 'versions-page',
-            label: 'GOING'
+            label: self.pieces.label + ' Versions',
+            value: doc._id
           },
           {
-            name: 'trash-page',
-            action: 'trash-page',
-            label: 'ON'
-          },
-          {
-            name: 'reorganize-page',
-            action: 'reorganize-page',
-            label: 'YO'
+            name: 'trash-' + self.pieces.name,
+            action: 'trash-' + self.pieces.name,
+            label: 'Trash ' + self.pieces.label,
+            value: doc._id
           }
         ];
         req.template = self.renderer('show');

--- a/lib/modules/apostrophe-pieces-pages/index.js
+++ b/lib/modules/apostrophe-pieces-pages/index.js
@@ -22,6 +22,37 @@ module.exports = {
     self.piecesModuleName = self.options.piecesModuleName || self.__meta.name.replace(/\-pages$/, '');
     self.pieces = self.apos.modules[self.piecesModuleName];
 
+    self.contextMenu = options.contextMenu || [
+      {
+        name: 'create-' + self.pieces.name,
+        action: 'create-' + self.pieces.name,
+        label: 'Create ' + self.pieces.label
+      },
+      {
+        name: 'edit-' + self.pieces.name,
+        action: 'edit-' + self.pieces.name,
+        label: 'Update ' + self.pieces.label,
+        value: true
+      },
+      {
+        name: 'manage-' + self.pieces.name,
+        action: 'manage-' + self.pieces.name,
+        label: 'Manage ' + self.pieces.label
+      },
+      {
+        name: 'versions-page',
+        action: 'versions-page',
+        label: self.pieces.label + ' Versions',
+        value: true
+      },
+      {
+        name: 'trash-' + self.pieces.name,
+        action: 'trash-' + self.pieces.name,
+        label: 'Trash ' + self.pieces.label,
+        value: true
+      }
+    ];
+
     self.indexPage = function(req, callback) {
       var cursor = self.pieces.find(req, {})
         .queryToFilters(req.query, 'public')
@@ -68,31 +99,14 @@ module.exports = {
           req.notFound = true;
           return callback(null);
         }
-        req.contextMenu = [
-          {
-            name: 'create-' + self.pieces.name,
-            action: 'create-' + self.pieces.name,
-            label: 'Create ' + self.pieces.label
-          },
-          {
-            name: 'edit-' + self.pieces.name,
-            action: 'edit-' + self.pieces.name,
-            label: 'Update ' + self.pieces.label,
-            value: doc._id
-          },
-          {
-            name: 'versions-page',
-            action: 'versions-page',
-            label: self.pieces.label + ' Versions',
-            value: doc._id
-          },
-          {
-            name: 'trash-' + self.pieces.name,
-            action: 'trash-' + self.pieces.name,
-            label: 'Trash ' + self.pieces.label,
-            value: doc._id
-          }
-        ];
+        if (self.pieces.contextual) {
+          req.contextMenu = _.map(self.contextMenu, function(item) {
+            if (item.value) {
+              item.value = doc._id;
+            }
+            return item;
+          });
+        }
         req.template = self.renderer('show');
         req.data.piece = doc;
         return callback(null);

--- a/lib/modules/apostrophe-pieces/index.js
+++ b/lib/modules/apostrophe-pieces/index.js
@@ -34,8 +34,9 @@ module.exports = {
     self.label = options.label;
     self.pluralLabel = options.pluralLabel;
     self.manageViews = options.manageViews;
+    self.contextual = options.contextual;
 
-    options.addColumns = [
+    self.defaultColumns = [
       {
         name: 'title',
         label: 'Title'
@@ -54,7 +55,19 @@ module.exports = {
           return self.partial('managePublished', { value: value });
         }
       }
-    ].concat(options.addColumns || []);
+    ];
+
+    if (self.contextual) {
+      self.defaultColumns.push({
+        name: '_url',
+        label: 'Link',
+        partial: function(value) {
+          return self.partial('manageLink', { value: value });
+        }
+      })
+    }
+
+    options.addColumns = self.defaultColumns.concat(options.addColumns || []);
 
     options.addSorts = [
       {

--- a/lib/modules/apostrophe-pieces/index.js
+++ b/lib/modules/apostrophe-pieces/index.js
@@ -36,6 +36,18 @@ module.exports = {
     self.manageViews = options.manageViews;
     self.contextual = options.contextual;
 
+    if (self.contextual) {
+      // If the piece is edited contextually, default the published state to false
+      options.addFields = [
+        {
+          type: 'boolean',
+          name: 'published',
+          label: 'Published',
+          def: false
+        }
+      ].concat(options.addFields || []);
+    }
+
     self.defaultColumns = [
       {
         name: 'title',

--- a/lib/modules/apostrophe-pieces/lib/api.js
+++ b/lib/modules/apostrophe-pieces/lib/api.js
@@ -10,7 +10,6 @@ module.exports = function(self, options) {
     return cursor;
   };
 
-
   // middleware for JSON API routes that expect the ID of
   // an existing piece at req.body._id
   self.requirePiece = function(req, res, next) {
@@ -110,6 +109,26 @@ module.exports = function(self, options) {
 
   self.convert = function(req, piece, callback) {
     return self.apos.schemas.convert(req, self.schema, 'form', req.body, piece, callback);
+  };
+
+  self.findIfContextual = function(req, piece, callback) {
+    if (!self.contextual) {
+      return setImmediate(callback);
+    }
+    return self.find(req, { _id: piece._id })
+      .permission('edit')
+      .published(null)
+      .toObject(function(err, _piece) {
+        if (err) {
+          return callback(err);
+        }
+        if (!piece) {
+          return callback('notfound');
+        }
+        _.assign(piece, _piece);
+        return callback(null);
+      }
+    );
   };
 
   self.afterConvert = function(req, piece, callback) {

--- a/lib/modules/apostrophe-pieces/lib/api.js
+++ b/lib/modules/apostrophe-pieces/lib/api.js
@@ -122,7 +122,7 @@ module.exports = function(self, options) {
         if (err) {
           return callback(err);
         }
-        if (!piece) {
+        if (!_piece) {
           return callback('notfound');
         }
         _.assign(piece, _piece);

--- a/lib/modules/apostrophe-pieces/lib/browser.js
+++ b/lib/modules/apostrophe-pieces/lib/browser.js
@@ -30,6 +30,7 @@ module.exports = function(self, options) {
     options.browser.filters = self.filters;
     options.browser.columns = self.columns;
     options.browser.sorts = self.sorts;
+    options.browser.contextual = self.contextual;
     self.apos.push.browserCall('user', 'apos.create(?, ?)', self.__meta.name, self.options.browser);
   };
 };

--- a/lib/modules/apostrophe-pieces/lib/routes.js
+++ b/lib/modules/apostrophe-pieces/lib/routes.js
@@ -50,6 +50,9 @@ module.exports = function(self, options) {
       insert: function(callback) {
         return self.insert(req, piece, callback);
       },
+      findIfContextual: function(callback) {
+        return self.findIfContextual(req, piece, callback);
+      },
       afterCreate: function(callback) {
         return self.afterCreate(req, piece, callback);
       },

--- a/lib/modules/apostrophe-pieces/public/css/manager.less
+++ b/lib/modules/apostrophe-pieces/public/css/manager.less
@@ -74,3 +74,8 @@
     }
   }
 }
+
+.apos-ui .apos-table .apos-manage-project--url .apos-manage-link {
+  &.fa { .fa; }
+  color: @apos-primary;
+}

--- a/lib/modules/apostrophe-pieces/public/js/create-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/create-modal.js
@@ -1,4 +1,10 @@
 apos.define('apostrophe-pieces-create-modal', {
   extend: 'apostrophe-pieces-editor-modal',
-  source: 'create'
+  source: 'create',
+
+  construct: function(self, options) {
+    self.displayResponse = function(result, callback) {
+      window.location.href = result.data._url;
+    };
+  }
 });

--- a/lib/modules/apostrophe-pieces/public/js/create-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/create-modal.js
@@ -3,7 +3,13 @@ apos.define('apostrophe-pieces-create-modal', {
   source: 'create',
 
   construct: function(self, options) {
+    var superDisplayResponse = self.displayResponse;
     self.displayResponse = function(result, callback) {
+      if (!result.data._url) {
+        return superDisplayResponse(result, callback);
+      }
+      // If the response contains a _url populated, we should redirect to the
+      // _url to edit the piece contextually.
       window.location.href = result.data._url;
     };
   }

--- a/lib/modules/apostrophe-pieces/public/js/editor-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/editor-modal.js
@@ -108,8 +108,7 @@ apos.define('apostrophe-pieces-editor-modal', {
             alert('An error occurred. Please try again.');
             return callback('error');
           }
-          apos.change(result.data);
-          return callback(null);
+          return self.displayResponse(result, callback);
         }, function() {
           alert('An error occurred. Please try again');
           return callback(err);
@@ -123,6 +122,11 @@ apos.define('apostrophe-pieces-editor-modal', {
 
     self.afterConvert = function(piece, callback) {
       return setImmediate(callback);
+    };
+
+    self.displayResponse = function(result, callback) {
+      apos.change(result.data);
+      return callback(null);
     };
 
     self.trash = function($el, next) {

--- a/lib/modules/apostrophe-pieces/public/js/editor-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/editor-modal.js
@@ -7,11 +7,11 @@ apos.define('apostrophe-pieces-editor-modal', {
     self.beforeShow = function(callback) {
       self.$form = self.$el.find('[data-apos-form]');
 
-      self.link('trash', function($el) {
+      self.link('apos-trash', function($el) {
         self.trash($el);
       });
 
-      self.link('versions', function($el) {
+      self.link('apos-versions', function($el) {
         apos.create('apostrophe-versions-editor', {
           action: self.action,
           _id: self._id,

--- a/lib/modules/apostrophe-pieces/public/js/user.js
+++ b/lib/modules/apostrophe-pieces/public/js/user.js
@@ -13,13 +13,13 @@ apos.define('apostrophe-pieces', {
     self.name = self.options.name;
 
     self.clickHandlers = function() {
-      apos.ui.link('manage', self.name, function() {
+      apos.ui.link('apos-manage', self.name, function() {
         self.manage();
       });
-      apos.ui.link('edit', self.name, function($button, _id) {
+      apos.ui.link('apos-edit', self.name, function($button, _id) {
         self.edit(_id);
       });
-      apos.ui.link('create', self.name, function($button) {
+      apos.ui.link('apos-create', self.name, function($button) {
         self.create();
       });
     };

--- a/lib/modules/apostrophe-pieces/views/manageLink.html
+++ b/lib/modules/apostrophe-pieces/views/manageLink.html
@@ -1,0 +1,1 @@
+<a class="apos-manage-link fa fa-external-link" href="{{ data.value }}"></a>

--- a/lib/modules/apostrophe-pieces/views/menu.html
+++ b/lib/modules/apostrophe-pieces/views/menu.html
@@ -1,11 +1,11 @@
 {% import 'apostrophe-ui:components/dropdowns.html' as dropdowns with context -%}
 {%- macro listMenu() -%}
-  <li href="#" class="apos-dropdown-item" data-create-{{ data.options.name | css }}>{{ __('New %s', __(data.options.label)) }}</li>
-  <li href="#" class="apos-dropdown-item" data-manage-{{ data.options.name | css }}>{{ __('Manage %s', __(data.options.pluralLabel)) }}</li>
+  <li href="#" class="apos-dropdown-item" data-apos-create-{{ data.options.name | css }}>{{ __('New %s', __(data.options.label)) }}</li>
+  <li href="#" class="apos-dropdown-item" data-apos-manage-{{ data.options.name | css }}>{{ __('Manage %s', __(data.options.pluralLabel)) }}</li>
   {%- if data.options.import -%}
-    <li href="#" class="apos-dropdown-item" data-import-{{ data.options.name | css }}>{{ __('Import %s', __(data.options.pluralLabel) ) }}</li>
+    <li href="#" class="apos-dropdown-item" data-apos-import-{{ data.options.name | css }}>{{ __('Import %s', __(data.options.pluralLabel) ) }}</li>
     {%- if data.options.export -%}
-      <li href="#" class="apos-dropdown-item" data-export-{{ data.options.name | css }}>{{ __('Export %s', __(data.options.pluralLabel) ) }}</li>
+      <li href="#" class="apos-dropdown-item" data-apos-export-{{ data.options.name | css }}>{{ __('Export %s', __(data.options.pluralLabel) ) }}</li>
     {%- endif -%}
   {%- endif -%}
 {%- endmacro -%}

--- a/lib/modules/apostrophe-ui/public/css/components/buttons.less
+++ b/lib/modules/apostrophe-ui/public/css/components/buttons.less
@@ -38,6 +38,8 @@
       .apos-rotate();
     }
   }
+
+  i { margin-left: 4px; }
 }
 
 // SPINNER =====================

--- a/lib/modules/apostrophe-ui/public/js/ui.js
+++ b/lib/modules/apostrophe-ui/public/js/ui.js
@@ -457,7 +457,7 @@ apos.define('apostrophe-ui', {
     // "fn" with the jQuery element clicked and the value
     // of the attribute.
     //
-    // self.link('manage', 'blogPost', fn)
+    // self.link('apos-manage', 'blogPost', fn)
     //
     // When a click occurs anywhere on the page
     // on something with a data-manage-blog-post

--- a/lib/modules/apostrophe-ui/views/components/buttons.html
+++ b/lib/modules/apostrophe-ui/views/components/buttons.html
@@ -1,5 +1,5 @@
 {% macro base(label, options, classes) -%}
-  <a {{ ('href=' + options.url) if options.url }} class="apos-button {{ classes }}" {{ options.attributes }} data-{{ options.action | css }}{% if options.value %}='{{ options.value }}'{% endif %}><span class="apos-button-label">{{ label }}</span>{% if options.icon %}<i class="fa fa-{{ options.icon }}"></i>{% endif %}</a>
+  <a {{ ('href=' + options.url) if options.url }} class="apos-button {{ classes }}" {{ options.attributes }} data-apos-{{ options.action | css }}{% if options.value %}='{{ options.value }}'{% endif %}><span class="apos-button-label">{{ label }}</span>{% if options.icon %}<i class="fa fa-{{ options.icon }}"></i>{% endif %}</a>
 {%- endmacro -%}
 
 {% macro normal(label, options) -%}

--- a/lib/modules/apostrophe-ui/views/components/dropdowns.html
+++ b/lib/modules/apostrophe-ui/views/components/dropdowns.html
@@ -1,7 +1,7 @@
 {% import 'apostrophe-ui:components/buttons.html' as buttons with context %}
 
 {% macro menuItem(content, options) -%}
-  <li class="apos-dropdown-item" data-apos-{{ content.action }} >
+  <li class="apos-dropdown-item" data-apos-{{ content.action }}{% if content.value %}="{{ content.value }}"{% endif %}>
     {{ content.label }}
   </li>
 {%- endmacro %}
@@ -16,9 +16,9 @@
   <div class="apos-dropdown apos-dropdown--{{ type }} apos-dropdown--{{ direction }}{% if options.class %} apos-dropdown--{{ options.class}}{% endif %}" data-apos-dropdown={{ direction }} data-apos-actionable>
     {%- if type == 'button' -%}
       {%- if options.buttonType -%}
-        {{ buttons[options.buttonType](menu.label, { action: 'apos-dropdown-button-label' }) }}
+        {{ buttons[options.buttonType](menu.label, { action: 'dropdown-button-label' }) }}
       {%- else -%}
-        {{ buttons.normal(menu.label, { action: 'apos-dropdown-button-label' }) }}
+        {{ buttons.normal(menu.label, { action: 'dropdown-button-label' }) }}
       {%- endif -%}
     {%- elif type == 'admin' -%}
       <div class="apos-admin-bar-item-inner">

--- a/lib/modules/apostrophe-versions/public/js/user.js
+++ b/lib/modules/apostrophe-versions/public/js/user.js
@@ -12,7 +12,7 @@ apos.define('apostrophe-versions', {
 
   construct: function(self) {
     self.addLinks = function() {
-      apos.ui.link('versions', 'page', function() {
+      apos.ui.link('apos-versions', 'page', function() {
         apos.create('apostrophe-versions-editor', {
           action: self.action,
           _id: apos.pages.options.page._id,


### PR DESCRIPTION
@boutell @colpanik 

This PR has two major components:

- Namespacing all of the data attributes that I could find with `apos` and fixing their corresponding click handlers. (We’ll want to keep an eye out for any of these that fell through the cracks, but we needed to do this at some point).
- Adding a `contextual` option to pieces, which if turned to true, defaults the published state to false and redirects users to the created piece upon creation. If a piece type is contextual, the corresponding `pieces-pages` allows editor users to view unpublished show pages. If the `_url` field isn’t populated, which means there isn’t a corresponding pieces page, we don’t redirect. The `contextual` option also adds an extra column for Links, which link to the piece using the `_url` property.

I'm down to chat about this further if we want to.

One thing that would still be nice to add is some indicator in Apostrophe if the piece (or page for that matter) you are currently looking at is unpublished. Maybe a badge on the `Page Settings` menu or something? @stuartromanek 