### PR TITLE
Views fallback

### DIFF
--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -11,6 +11,10 @@
   .apos-area-widget.ui-draggable-dragging { z-index: @apos-z-index-9; }
   &.apos-empty
   {
+    // When there aren't any widgets in an area, it should have a min-height
+    // and a background color set by default.
+    min-height: 80px;
+    background-color: @apos-light;
     // When there aren't any widgets in an area, the add content controls
     // should appear absolutely positioned in the empty state.
     >.apos-ui .apos-area-controls
@@ -18,13 +22,6 @@
       position: absolute;
       bottom: @apos-padding-2;
       left: @apos-padding-2;
-    }
-    // When there aren't any widgets in an area, it should have a min-height
-    // and a background color set by default.
-    >.apos-area-widgets
-    {
-      min-height: 80px;
-      background-color: @apos-light;
     }
   }
 }

--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -39,7 +39,7 @@
   &:hover>.apos-ui .apos-area-widget-controls { opacity: 1; }
   // When an area has a limit of one, its children widgets shouldn't
   // display the arrow organization controls.
-  >.apos-ui.apos-limit-one [data-move-item] { display: none; }
+  >.apos-ui.apos-limit-one [data-apos-move-item] { display: none; }
 }
 
 .apos-area-widget-controls

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -152,7 +152,7 @@ apos.define('apostrophe-area-editor', {
 
     self.moveItem = function($el) {
       var $item = $el.closest('[data-widget], .apos-lockup');
-      var direction = $el.data('move-item');
+      var direction = $el.data('apos-move-item');
 
       if (direction === 'up') {
         $item.prev().before($item);
@@ -448,13 +448,13 @@ apos.define('apostrophe-area-editor', {
         }
         i++;
       });
-      $('[data-drag-item-separator]:not(.apos-template)').droppable(self.separatorDropSettings);
+      $('[data-apos-drag-item-separator]:not(.apos-template)').droppable(self.separatorDropSettings);
     };
 
     self.removeSeparators = function() {
       $(window).trigger('aposStopDragging');
       $('[data-area]').removeClass('apos-dragging');
-      $('[data-apos-refreshable] [data-drag-item-separator]').remove();
+      $('[data-apos-refreshable] [data-apos-drag-item-separator]').remove();
     };
 
     self.getDroppableAreas = function($draggable) {
@@ -483,7 +483,7 @@ apos.define('apostrophe-area-editor', {
     };
 
     self.newSeparator = function() {
-      var $separator = self.fromTemplate('[data-drag-item-separator]');
+      var $separator = self.fromTemplate('[data-apos-drag-item-separator]');
       return $separator;
     };
 
@@ -621,7 +621,7 @@ apos.define('apostrophe-area-editor', {
     };
 
     self.draggableSettings = {
-      handle: '[data-drag-item]',
+      handle: '[data-apos-drag-item]',
       revert: 'invalid',
       refreshPositions: true,
       tolerance: 'pointer',

--- a/lib/modules/apostrophe-areas/public/js/user.js
+++ b/lib/modules/apostrophe-areas/public/js/user.js
@@ -86,27 +86,27 @@ apos.define('apostrophe-areas', {
 
       // listen for shiftActive for power up/down nudge
       apos.on('shiftDown', function() {
-        $('[data-move-item]').each(function() {
+        $('[data-apos-move-item]').each(function() {
           $self = $(this);
-          if ($self.attr('data-move-item') === 'up') {
+          if ($self.attr('data-apos-move-item') === 'up') {
             $self.children('i').toggleClass('icon-double-angle-up');
-            $self.attr('data-move-item', 'top');
-          } else if ($self.attr('data-move-item') === 'down') {
+            $self.attr('data-apos-move-item', 'top');
+          } else if ($self.attr('data-apos-move-item') === 'down') {
             $self.children('i').toggleClass('icon-double-angle-down');
-            $self.attr('data-move-item', 'bottom');
+            $self.attr('data-apos-move-item', 'bottom');
           }
         });
       });
 
       apos.on('shiftUp', function() {
-        $('[data-move-item]').each(function() {
+        $('[data-apos-move-item]').each(function() {
           $self = $(this);
           $self.children('i').removeClass('icon-double-angle-up');
           $self.children('i').removeClass('icon-double-angle-down');
-          if ($self.attr('data-move-item') === 'top') {
-            $self.attr('data-move-item', 'up');
-          } else if ($self.attr('data-move-item') === 'bottom') {
-            $self.attr('data-move-item', 'down');
+          if ($self.attr('data-apos-move-item') === 'top') {
+            $self.attr('data-apos-move-item', 'up');
+          } else if ($self.attr('data-apos-move-item') === 'bottom') {
+            $self.attr('data-apos-move-item', 'down');
           }
         });
       });

--- a/lib/modules/apostrophe-areas/views/itemSeparator.html
+++ b/lib/modules/apostrophe-areas/views/itemSeparator.html
@@ -1,1 +1,1 @@
-<div class="apos-ui apos-area-item-separator" data-drag-item-separator></div>
+<div class="apos-ui apos-area-item-separator" data-apos-drag-item-separator></div>

--- a/lib/modules/apostrophe-areas/views/lockedItemButtons.html
+++ b/lib/modules/apostrophe-areas/views/lockedItemButtons.html
@@ -5,8 +5,8 @@
       <span class="apos-ui apos-ui-btn" title="{{ __('Move') }}" data-drag-item><i class="icon-move"></i></span>
     <!-- </span> -->
     <span class="apos-ui-btn-group">
-      <span class="apos-ui apos-ui-btn" data-move-item='up'><i class="icon-arrow-up"></i></span>{#
-    #}<span class="apos-ui apos-ui-btn" data-move-item='down'><i class="icon-arrow-down"></i></span>
+      <span class="apos-ui apos-ui-btn" data-apos-move-item='up'><i class="icon-arrow-up"></i></span>{#
+    #}<span class="apos-ui apos-ui-btn" data-apos-move-item='down'><i class="icon-arrow-down"></i></span>
     </span>
   </div>
   <div class="apos-ui-container apos-item-actions right">

--- a/lib/modules/apostrophe-docs/public/js/manager.js
+++ b/lib/modules/apostrophe-docs/public/js/manager.js
@@ -36,7 +36,6 @@ apos.define('apostrophe-docs-manager', {
 
     self.getToolType = function(name) {
       var type = self.__meta.name.replace(/\-manager$/, '') + '-' + name;
-      console.log(type);
       if (!apos.isDefined(type)) {
         // Generic one available?
         type = 'apostrophe-docs-' + name;

--- a/lib/modules/apostrophe-pieces/public/css/chooser.less
+++ b/lib/modules/apostrophe-pieces/public/css/chooser.less
@@ -4,7 +4,7 @@
   .apos-manage-view--chooser
   {
     .apos-inline-block;
-    float: right;
+    float: left;
     max-width: 75%;
     .apos-table { padding-left: @apos-padding-2; }
   }

--- a/lib/modules/apostrophe-pieces/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/manager-modal.js
@@ -84,7 +84,7 @@ apos.define('apostrophe-pieces-manager-modal', {
           self.refresh();
         };
         filter.setDefault();
-        self.link(filter.name, filter.handler);
+        self.link('apos-' + filter.name, filter.handler);
       });
     };
 

--- a/lib/modules/apostrophe-pieces/views/manageListPage.html
+++ b/lib/modules/apostrophe-pieces/views/manageListPage.html
@@ -4,7 +4,7 @@
     <td>{{fields.checkbox(data.options.name + '-select')}}</td>
     {% for column in data.columns %}
       <td class="apos-manage-{{ data.options.name | css }}-{{ column.name | css }}">
-        <span><a href="#" data-edit-{{ data.options.name | css }}="{{ piece._id }}">
+        <span><a href="#" data-apos-edit-{{ data.options.name | css }}="{{ piece._id }}">
           {%- if column.partial -%}
             {{ column.partial(piece[column.name]) }}
           {%- else -%}

--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -335,6 +335,9 @@ module.exports = {
       });
       // Final class should win
       dirs.reverse();
+      if (options.viewsFolderFallback) {
+        dirs.push(options.viewsFolderFallback);
+      }
       return dirs;
     };
 

--- a/lib/modules/apostrophe-widgets/index.js
+++ b/lib/modules/apostrophe-widgets/index.js
@@ -41,13 +41,14 @@ module.exports = {
 
   construct: function(self, options) {
 
+    self.template = options.template || 'widget';
     self.schema = self.apos.schemas.compose(options);
 
     // Outputs the widget. Invoked by
     // apos.widget in Nunjucks.
 
     self.output = function(widget, options) {
-      var result = self.partial('widget', { widget: widget, options: options, manager: self });
+      var result = self.partial(self.template, { widget: widget, options: options, manager: self });
       return result;
     };
 


### PR DESCRIPTION
@boutell @colpanik 

- Added an option to pass an optional path at project level to set a fallback folder for views for all modules, essentially allowing a developer to declare a global views folder.
- Added an option to set a different template for widgets (though it still falls back to `widget.html` if not set)