### PR TITLE
when a media item is replaced, hide the old version in uploadfs. Crea…

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -493,6 +493,7 @@ module.exports = {
       res.header("Content-Type", "text/plain");
       // TODO: reduce redundancy with /apos/upload-files
       var id = req.query.id;
+      var originalFile;
       return self.files.findOne({ _id: id }, function(err, file) {
         if (err || (!file)) {
           return self.fail(req, res);
@@ -500,6 +501,7 @@ module.exports = {
         if (!self.permissions.can(req, 'edit-file', file)) {
           return self.fail(req, res);
         }
+        originalFile = _.clone(file);
         var newFiles = req.files.files;
         if (!(newFiles instanceof Array)) {
           newFiles = [ newFiles ];
@@ -597,6 +599,16 @@ module.exports = {
           }
         }
 
+        function hideOld(callback) {
+          return self.hideInUploadfs(originalFile, true, false, function(err, affected) {
+            if (err) {
+              return callback(err);
+            }
+            file.oldVersions = (file.oldVersions || []).concat(affected);
+            return callback(null);
+          });
+        }
+
         function db(callback) {
           self.pruneTemporaryProperties(file);
           self.files.update({ _id: file._id }, file, function(err, count) {
@@ -604,7 +616,7 @@ module.exports = {
           });
         }
 
-        async.series([ md5, copyIn, db ], function(err) {
+        async.series([ md5, copyIn, hideOld, db ], function(err) {
           if (err) {
             return self.fail(req, res);
           }
@@ -1100,14 +1112,29 @@ module.exports = {
     // or make it web-accessible again (if trash is false). Normally
     // called only by apos.updateTrash but it is also invoked by the
     // apostrophe:hide-trash legacy migration task.
+    //
+    // For images, if keepThumbnail is true, or only three arguments are provided,
+    // the image sizes configured for display in the trash can are
+    // kept.
 
-    self.hideInUploadfs = function(file, trash, callback) {
+    self.hideInUploadfs = function(file, trash, keepThumbnail, callback) {
+      if (arguments.length === 3) {
+        callback = keepThumbnail;
+        keepThumbnail = true;
+      }
       var info = file;
+      var affected = [];
       return async.series({
         disableOriginal: function(callback) {
           var name = '/files/' + info._id + '-' + info.name + '.' + info.extension;
           var method = trash ? self.uploadfs.disable : self.uploadfs.enable;
-          return method(name, callback);
+          return method(name, function(err) {
+            if (err) {
+              return callback(err);
+            }
+            affected.push(name);
+            return callback(null);
+          });
         },
         disableSizes: function(callback) {
           if (info.group !== 'images') {
@@ -1115,17 +1142,30 @@ module.exports = {
           }
           return async.eachSeries(self.uploadfs.getImageSizes(),
             function(size, callback) {
-              if (_.contains(self.trashImageSizes, size.name)) {
-                // We preserve this particular size for the sake of
-                // the admin interface to the trash folder
-                return callback(null);
+              if (keepThumbnail) {
+                if (_.contains(self.trashImageSizes, size.name)) {
+                  // We preserve this particular size for the sake of
+                  // the admin interface to the trash folder
+                  return callback(null);
+                }
               }
               var name = '/files/' + info._id + '-' + info.name + '.' + size.name + '.' + info.extension;
               var method = trash ? self.uploadfs.disable : self.uploadfs.enable;
-              return method(name, callback);
+              return method(name, function(err) {
+                if (err) {
+                  return callback(err);
+                }
+                affected.push(name);
+                return callback(null);
+              });
             }, callback);
         }
-      }, callback);
+      }, function(err) {
+        if (err) {
+          return callback(err);
+        }
+        return callback(null, affected);
+      });
     };
 
     // Given a file object, really-no-fooling DELETE it from uploadfs and

--- a/lib/tasks/emptyTrash.js
+++ b/lib/tasks/emptyTrash.js
@@ -27,6 +27,8 @@ module.exports = function(apos, argv, callback) {
             _.each(apos.uploadfs.getImageSizes(), function(size) {
               paths.push(apos.filePath(file, { size: size.name, uploadfsPath: true }));
             });
+            // Also permanently remove old versions of replaced files
+            paths = paths.concat(file.oldVersions || []);
             return async.eachSeries(paths, function(path, callback) {
               return async.series({
                 restore: function(callback) {


### PR DESCRIPTION
…te an array of uploadfs paths to the old versions and be sure to remove them in apostrophe:empty-trash