### PR TITLE
support the "all" option for pieces widgets, also a significant refac…

### DIFF
--- a/lib/modules/apostrophe-docs/lib/cursor.js
+++ b/lib/modules/apostrophe-docs/lib/cursor.js
@@ -698,6 +698,8 @@ module.exports = {
       return self.state[key];
     };
 
+    // Apply filters present in a query object (often from req.query), skipping all filters not declared as
+    // safe for the given domain (such as "public" or "manage")
 
     self.queryToFilters = function(query, safeFor) {
       _.each(query, function(value, name) {
@@ -720,6 +722,15 @@ module.exports = {
       });
 
       return self;
+    };
+
+    // Apply the filters present in the query object, without checking for safety or laundering
+    // the data in any way. Use queryToFilters instead for anything coming from the user
+
+    self.applyFilters = function(query) {
+      _.each(query, function(val, name) {
+        self[name](val);
+      });
     };
 
     // Applies all defaults and transformations prior

--- a/lib/modules/apostrophe-pieces-widgets/index.js
+++ b/lib/modules/apostrophe-pieces-widgets/index.js
@@ -2,7 +2,10 @@ var _ = require('lodash');
 var async = require('async');
 
 module.exports = {
+
   extend: 'apostrophe-widgets',
+
+  loadManyById: true,
 
   beforeConstruct: function(self, options) {
     self.piecesModuleName = options.piecesModuleName || self.__meta.name.replace(/\-widgets$/, '');
@@ -26,8 +29,8 @@ module.exports = {
       {
         value: 'all',
         label: options.byAllLabel || 'All',
-        showFields: [ 'limitAll' ]
-      },    
+        showFields: [ 'limitByAll' ]
+      },
       {
         value: 'id',
         label: 'Individually',
@@ -52,7 +55,7 @@ module.exports = {
 
     addFields.push({
       type: 'integer',
-      name: 'limitAll',
+      name: 'limitByAll',
       label: 'Maximum displayed',
       def: 5
     });
@@ -82,108 +85,168 @@ module.exports = {
   },
 
   construct: function(self, options) {
-    // Load the appropriate pieces for each widget in the array.
+
+    self.joinById = _.find(self.schema, { name: '_pieces' });
+
+    // Load the appropriate pieces for each widget in the array. Apostrophe will try to feed
+    // us as many at once as it can to cut down on database queries. We'll take all the
+    // widgets for which pieces were chosen "by id" and do a single query, via
+    // self.loadManyById. For everything we'll call self.loadOne individually, via
+    // self.loadOthersOneAtATime. But in ALL cases, we invoke self.afterLoadOne for
+    // each widget, allowing an opportunity to do custom work without thinking
+    // about all this.
+
     self.load = function(req, widgets, callback) {
+      if (!self.options.loadManyById) {
+        // Carrying out one big query for all widgets that select pieces by id has been
+        // disabled for this module
+        return self.loadOthersOneAtATime(req, widgets, callback);
+      }
 
-      // For performance, avoid multiple database calls. Instead,
-      // create a query that matches all relevant pieces, then
-      // scatter them out to the relevant widgets. This takes
-      // extra code and duplicates some of the logic for joinByArray
-      // and relationships, but the performance win is large. -Tom
+      var byId = _.filter(widgets, { by: 'id' });
+      var byOther = _.difference(widgets, byId);
+      return async.series([
+        _.partial(self.loadManyById, req, byId),
+        _.partial(self.loadOthersOneAtATime, req, byOther)
+      ], callback);
+    };
 
-      var clauses = [];
-      var ids = [];
-      var tags = [];
-      var criteria = {};
+    // Load many widgets, all of which were set to choose pieces "by id." This allows
+    // Apostrophe to work efficiently when a page contains many pieces widgets in an
+    // array, etc. This method is called by self.load, you don't need to call it yourself.
+    //
+    // This method still calls afterLoadOne for each widget, so there is still a simple
+    // way to go beyond this if you need to do something fancy after a widget has been
+    // through the normal loading process.
+
+    self.loadManyById = function(req, widgets, callback) {
+
+      // scatter-gather thing, then...
+      var ids = _.reduce(widgets, function(ids, widget) {
+        return ids.concat(widget.pieceIds || []);
+      }, []);
+
+      var widgetsByPieceId = {};
+
       _.each(widgets, function(widget) {
-        if (widget.by === 'tag') {
-          tags = tags.concat(widget.tags || []);
-        } else {
-          ids = ids.concat(widget.pieceIds || []);
-        }
+        widget._pieces = [];
+        widget._piecesById = {};
+        _.each(widget.pieceIds || [], function(_id) {
+          if (!_.has(widgetsByPieceId, _id)) {
+            widgetsByPieceId[_id] = [];
+          }
+          widgetsByPieceId[_id].push(widget);
+        });
       });
-      if (ids.length) {
-        clauses.push({ _id: { $in: ids } });
-        clauses.push({ tags: { $in: tags } });
-      }
-      if (!clauses.length) {
-        criteria = {};
-      } else {
-        criteria = { $or: clauses };
-      }
 
-      var cursor = self.widgetCursor(req, criteria);
+      var cursor = self.widgetCursor(req, { _id: { $in: ids } });
 
-      var join = _.find(self.schema, { name: '_pieces' });
+      cursor.applyFilters(self.joinById.filters || {});
 
       return cursor.toArray(function(err, pieces) {
         if (err) {
           return callback(err);
         }
-        var widgetsByPieceId = {};
-        var widgetsByTag = {};
-        _.each(widgets, function(widget) {
-          widget._pieces = [];
-          widget._piecesById = {};
-          if (widget.by === 'tag') {
-            _.each(widget.tags, function(tag) {
-              if (!_.has(widgetsByTag, tag)) {
-                widgetsByTag[tag] = [];
-              }
-              widgetsByTag[tag].push(widget);
-            });
-          } else {
-            _.each(widget.pieceIds, function(_id) {
-              if (!_.has(widgetsByPieceId, _id)) {
-                widgetsByPieceId[_id] = [];
-              }
-              widgetsByPieceId[_id].push(widget);
-            });
-          }
-        });
         _.each(pieces, function(piece) {
           if (_.has(widgetsByPieceId, piece._id)) {
             _.each(widgetsByPieceId[piece._id], function(widget) {
               if (!_.has(widget._piecesById, piece._id)) {
-                push(widget, piece);
+                self.pushPieceForWidget(widget, piece);
                 widget._piecesById[piece._id] = true;
               }
             });
           }
-          _.each(piece.tags, function(tag) {
-            if (_.has(widgetsByTag, tag)) {
-              _.each(widgetsByTag[tag], function(widget) {
-                if (!_.has(widget._piecesById, piece._id)) {
-                  if (widget._pieces.length < widget.limitByTag) {
-                    push(widget, piece);
-                  }
-                  widget._piecesById[piece._id] = true;
-                }
-              });
-            }
-          });
-          function push(widget, piece) {
-            if (join.relationship && (widget.by === 'id')) {
-              widget._pieces.push({
-                item: piece,
-                relationship: (widget[join.relationshipsField] || {})[piece._id]
-              });
-            } else {
-              widget._pieces.push(piece);
-            }
-          }
         });
 
-        // Make sure pieces are returned in the order requested
+        // Make sure pieces are returned in the order they appear in the list chosen by the user
         _.each(widgets, function(widget) {
-          if (widget.by === 'id') {
-            var key = join.relationship ? 'item._id' : '_id';
-            widget._pieces = self.apos.utils.orderById(widget.pieceIds, widget._pieces, key);
-          }
+          self.orderPiecesForWidget(widget);
         });
+        // Give every widget a chance to have special sauce in its afterLoadOne method
+        return async.eachSeries(widgets, _.partial(self.afterLoadOne, req), callback);
+      });
 
+    };
+
+    // Load widgets that were NOT set to choose pieces "by id." Feeds them all
+    // through self.loadOne and self.afterLoadOne. You don't have to call this,
+    // self.load calls it for you.
+
+    self.loadOthersOneAtATime = function(req, widgets, callback) {
+
+      return async.eachSeries(widgets, function(widget, callback) {
+        return async.series([ _.partial(self.loadOne, req, widget), _.partial(self.afterLoadOne, req, widget) ], callback);
+      }, callback);
+    };
+
+    self.loadOne = function(req, widget, callback) {
+      // Go get stuff by tag / by all, with limit, attach to widget, then...
+      var cursor = self.widgetCursor(req, {});
+      if (widget.by === 'tag') {
+        cursor.and({ tags: { $in: widget.tags } });
+        cursor.limit(widget.limitByTag || 5);
+      } else if (widget.by === 'all') {
+        // We are interested in everything
+        cursor.limit(widget.limitByAll || 5);
+      } else if (widget.by === 'id') {
+        // By default, "by id" goes through a separate path, but support it here
+        // so that the loadOne method can be used directly and naively to load
+        // a widget, no matter how it is set up. Also useful if the loadManyById
+        // option is disabled
+        cursor.and({ _id: { $in: widget.pieceIds || [] } });
+        cursor.applyFilters(self.joinById.filters || {});
+      }
+      return cursor.toArray(function(err, pieces) {
+        if (err) {
+          return callback(err);
+        }
+        self.attachPiecesToWidget(widget, pieces);
         return callback(null);
       });
+    };
+
+    // Given an array of pieces, this method attaches them to the widget
+    // as the _pieces property correctly with pushPiecesToWidget, and
+    // orders them correctly if the user chose them in a specific order
+
+    self.attachPiecesToWidget = function(widget, pieces) {
+      widget._pieces = [];
+      _.each(pieces, function(piece) {
+        self.pushPieceForWidget(widget, piece);
+      });
+      self.orderPiecesForWidget(widget);
+    };
+
+    // A utility method that puts the pieces loaded for the widget in the
+    // order requested by the user. widget._pieces should already be loaded
+    // at this point. Called for you by the widget loader methods; useful
+    // if you are overriding loadOne and disabling loadManyById
+
+    self.orderPiecesForWidget = function(widget) {
+      if (widget.by !== 'id') {
+        return;
+      }
+      var key = self.joinById.relationship ? 'item._id' : '_id';
+      widget._pieces = self.apos.utils.orderById(widget.pieceIds, widget._pieces, key);
+    };
+
+    // A utility method to append a piece to the ._pieces array for the given widget correctly,
+    // whether the join has relationship properties or not.
+
+    self.pushPieceForWidget = function(widget, piece) {
+      if (self.joinById.relationship && (widget.by === 'id')) {
+        widget._pieces.push({
+          item: piece,
+          relationship: (widget[self.joinById.relationshipsField] || {})[piece._id]
+        });
+      } else {
+        widget._pieces.push(piece);
+      }
+    };
+
+    self.afterLoadOne = function(req, widget, callback) {
+      // This ALWAYS gets called, so you can do special handling here no matter what.
+      return setImmediate(callback);
     };
 
     // Hook to modify cursor before the load method is invoked


### PR DESCRIPTION
…toring. You can now write a simple afterLoadOne method that is invoked for every widget loaded, no matter whether it was loaded efficiently with other pieces widgets or singly on its own. The code in general is much easier to understand and broken out in a way that will help you if you need to override the way a pieces widget is loaded. You can set the loadManyById option to false if that feature is not right for your subclass. The performance win from 0.5 has been retained and extended.