### PR TITLE
implemented joins with the generic 'apostrophe-page' type, which lets…

### DIFF
--- a/lib/modules/apostrophe-docs/lib/api.js
+++ b/lib/modules/apostrophe-docs/lib/api.js
@@ -578,7 +578,8 @@ module.exports = function(self, options) {
 
   self.autocomplete = function(req, query, callback) {
     var criteria = {};
-    var type = self.apos.launder.string(query.field.withType);
+    var typeName = query && query.field && query.field.withType;
+    var type = self.apos.launder.string(typeName);
     var manager = self.getManager(type);
     if (!manager) {
       return callback(new Error('invalid type'));

--- a/lib/modules/apostrophe-docs/lib/routes.js
+++ b/lib/modules/apostrophe-docs/lib/routes.js
@@ -39,7 +39,7 @@ module.exports = function(self, options) {
         });
       }
     } else {
-      input[field.idField] = req.body.choices[0].value;
+      input[field.idField] = req.body.choices && req.body.choices[0] && req.body.choices[0].value;
     }
     var manager = self.getManager(field.withType);
     var receptacle = {};
@@ -58,7 +58,16 @@ module.exports = function(self, options) {
       }
       var choiceTemplate = field.choiceTemplate || manager.choiceTemplate || 'chooserChoice.html';
       var choicesTemplate = field.choicesTemplate || manager.choicesTemplate || 'chooserChoices.html';
-      return res.send(self.render(req, choicesTemplate, { choices: receptacle[field.name], choiceTemplate: choiceTemplate, relationship: field.relationship } ));
+      var choices = receptacle[field.name];
+      if (!Array.isArray(choices)) {
+        // by one case
+        if (choices) {
+          choices = [ choices ];
+        } else {
+          choices = [];
+        }
+      }
+      return res.send(self.render(req, choicesTemplate, { choices: choices, choiceTemplate: choiceTemplate, relationship: field.relationship } ));
     });
   });
 

--- a/lib/modules/apostrophe-docs/public/js/chooser.js
+++ b/lib/modules/apostrophe-docs/public/js/chooser.js
@@ -4,6 +4,11 @@ apos.define('apostrophe-docs-chooser', {
     self.options = options;
     self.field = options.field;
     self.$el = options.$el;
+    if (self.field.type === 'joinByOne') {
+      self.limit = 1;
+    } else {
+      self.limit = self.field.limit;
+    }
     // Our own module is not the right one to talk to for chooser templates
     // because the docs module delivers those. However on the server side you
     // can hook in to render them and the pieces module does do that. -Tom
@@ -212,6 +217,13 @@ apos.define('apostrophe-docs-chooser', {
       });
     };
     self.onChange = function() {
+      if (self.limit && self.choices.length >= self.limit) {
+        self.$el.addClass('apos-chooser-full');
+        self.$autocomplete.prop('disabled', true);
+      } else {
+        self.$el.removeClass('apos-chooser-full');
+        self.$autocomplete.prop('disabled', false);
+      }
       if (self.options.change) {
         self.options.change();
       }

--- a/lib/modules/apostrophe-pages/index.js
+++ b/lib/modules/apostrophe-pages/index.js
@@ -33,6 +33,7 @@ module.exports = {
   ],
 
   afterConstruct: function(self, callback) {
+    self.setManager();
     return self.ensureIndexes(callback);
   },
 

--- a/lib/modules/apostrophe-pages/lib/anyCursor.js
+++ b/lib/modules/apostrophe-pages/lib/anyCursor.js
@@ -12,7 +12,7 @@ module.exports = {
       def: true,
       after: function(results) {
         _.each(results, function(result) {
-          if (result.slug && (result.slug.match(/^\//))) {
+          if (result.slug && self.apos.pages.isPage(result)) {
             result._url = self.apos.prefix + result.slug;
           }
         });

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -618,14 +618,8 @@ module.exports = function(self, options) {
     };
 
     if (providePage) {
-      var browserOptions = {
-        action: self.action,
-        schema: self.schema,
-        types: self.types,
-        page: self.pruneCurrentPageForBrowser(req.data.bestPage)
-      };
       if (req.user) {
-        req.browserCall('apos.create("apostrophe-pages", ?)', browserOptions);
+        req.browserCall('apos.pages.setPage(?)', self.pruneCurrentPageForBrowser(req.data.bestPage));
       }
     }
 
@@ -1017,5 +1011,18 @@ module.exports = function(self, options) {
 
   self.isPage = function(doc) {
     return doc.slug.match(/^\//);
+  };
+
+  // Set the manager object for "apostrophe-page", the general case in which we're interested
+  // in all "regular pages" in the tree. Useful when you want to build navigation using
+  // schema joins
+
+  self.setManager = function() {
+    var manager = self.apos.docs.getManager('apostrophe-page');
+    // Use our find() so that we are only seeing pages, not all docs
+    manager.find = function(req, criteria, projection) {
+      return self.find(req, criteria, projection);
+    };
+    self.apos.docs.setManager('apostrophe-page', manager);
   };
 };

--- a/lib/modules/apostrophe-pages/lib/browser.js
+++ b/lib/modules/apostrophe-pages/lib/browser.js
@@ -1,11 +1,18 @@
 module.exports = function(self, options) {
   self.pushAsset('script', 'user', { when: 'user' });
+  self.pushAsset('script', 'chooser', { when: 'user' });
   self.pushAsset('script', 'editor', { when: 'user' });
   self.pushAsset('script', 'reorganize', { when: 'user' });
   self.pushAsset('script', 'vendor/tree.jquery', { when: 'user' });
   self.pushAsset('script', 'always', { when: 'always' });
   self.pushAsset('stylesheet', 'jqtree', { when: 'user' });
 
-  // singleton is instantiated via req.browserCall so we can
-  // pass information about the current page
+  var browserOptions = {
+    action: self.action,
+    schema: self.schema,
+    types: self.types
+  };
+
+  self.apos.push.browserCall('user', 'apos.create("apostrophe-pages", ?)', browserOptions);
+
 };

--- a/lib/modules/apostrophe-pages/lib/pagesCursor.js
+++ b/lib/modules/apostrophe-pages/lib/pagesCursor.js
@@ -8,6 +8,20 @@ module.exports = function(self, cursor) {
   // user has permission, which is checked for separately
   cursor.filters.published.def = null;
 
+  // When calling self.pages.find our expectation is that we will only get pages,
+  // not docs that are not a part of the page tree
+  cursor.addFilter('isPage', {
+    def: true,
+    finalize: function() {
+      var state = cursor.get('isPage');
+      if (state) {
+        cursor.and({
+          slug: /^\//
+        });
+      }
+    }
+  });
+
   cursor.addFilter('ancestors', {
     def: false,
     after: function(results, callback) {
@@ -168,6 +182,7 @@ module.exports = function(self, cursor) {
       }
     }
   });
+
 };
 
 function applySubcursorOptions(aCursor, options, ours) {

--- a/lib/modules/apostrophe-pages/public/js/chooser.js
+++ b/lib/modules/apostrophe-pages/public/js/chooser.js
@@ -1,0 +1,6 @@
+apos.define('apostrophe-pages-chooser', {
+  extend: 'apostrophe-docs-chooser',
+  // The standard manage modal is inappropriate for pages. Someday we might do something
+  // based on the page tree, but for now just stick to autocomplete only
+  browse: false
+});

--- a/lib/modules/apostrophe-pages/public/js/editor.js
+++ b/lib/modules/apostrophe-pages/public/js/editor.js
@@ -6,7 +6,7 @@ apos.define('apostrophe-pages-editor', {
   construct: function(self, options) {
     self.typeChoices = apos.pages.options.typeChoices;
     self.schema = apos.pages.options.schema;
-    self.page = apos.pages.options.page;
+    self.page = apos.pages.page;
     self.verb = self.options.verb;
     self.label = self.options.label;
 

--- a/lib/modules/apostrophe-pages/public/js/reorganize.js
+++ b/lib/modules/apostrophe-pages/public/js/reorganize.js
@@ -73,7 +73,7 @@ apos.define('apostrophe-pages-reorganize', {
 	  // navigate there or to the home page or just refresh to reflect
 	  // possible new tabs
     self.afterHide = function(callback) {
-      var page = apos.pages.options.page;
+      var page = apos.pages.page;
 	    var _id = page._id;
 	    self.api('info', { _id: _id }, function(data) {
         if (data.status !== 'ok') {

--- a/lib/modules/apostrophe-pages/public/js/user.js
+++ b/lib/modules/apostrophe-pages/public/js/user.js
@@ -1,6 +1,6 @@
 apos.define('apostrophe-pages', {
 
-  extend: 'apostrophe-context',
+  extend: 'apostrophe-docs-manager',
 
   beforeConstruct: function(self, options) {
     self.options = options;
@@ -8,6 +8,9 @@ apos.define('apostrophe-pages', {
 
   afterConstruct: function(self) {
     self.addLinks();
+    // Set ourselves up as the manager for the "apostrophe-page" type, a virtual type used
+    // when we want a join that can select any page in the tree
+    apos.docs.setManager('apostrophe-page', self);
   },
 
   construct: function(self) {
@@ -22,7 +25,7 @@ apos.define('apostrophe-pages', {
         apos.create('apostrophe-pages-reorganize', { action: self.options.action });
       });
       apos.ui.link('apos-trash', 'page', function() {
-        self.trash(self.options.page._id, function(err, parentSlug, changed) {
+        self.trash(self.page._id, function(err, parentSlug, changed) {
           if (err) {
             alert('A server error occurred.');
           } else {
@@ -41,6 +44,10 @@ apos.define('apostrophe-pages', {
       }, function() {
         return callback('network');
       });
+    };
+
+    self.setPage = function(page) {
+      self.page = page;
     };
 
     apos.pages = self;

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -631,15 +631,20 @@ apos.define('apostrophe-schemas', {
         var chooser = $fieldset.data('aposChooser');
         if (!chooser) {
           manager = apos.docs.getManager(field.withType);
-          chooser = manager.getTool('chooser', { field: field, $el: $fieldset.find('[data-chooser]') });
+          return manager.getTool('chooser', { field: field, $el: $fieldset.find('[data-chooser]') }, function(err, _chooser) {
+            if (err) {
+              return callback(err);
+            }
+            chooser = _chooser;
+            var choices = [];
+            if (data[field.idField]) {
+              choices.push({ value: data[field.idField] });
+            }
+            chooser.set(choices);
+            $fieldset.data('aposChooser', chooser);
+            return callback(null);
+          });
         }
-        var choices = [];
-        if (data[field.idField]) {
-          choices.push({ value: data[field.idField] });
-        }
-        chooser.set(choices);
-        $fieldset.data('aposChooser', chooser);
-        return setImmediate(callback);
       },
       convert: function(data, name, $field, $el, field, callback) {
         var manager;

--- a/lib/modules/apostrophe-versions/public/js/user.js
+++ b/lib/modules/apostrophe-versions/public/js/user.js
@@ -15,7 +15,7 @@ apos.define('apostrophe-versions', {
       apos.ui.link('apos-versions', 'page', function() {
         apos.create('apostrophe-versions-editor', {
           action: self.action,
-          _id: apos.pages.options.page._id,
+          _id: apos.pages.page._id,
           afterRevert: function() {
             window.location.reload(true);
           }


### PR DESCRIPTION
… you pick any page in the tree. Also fixed numerous bugs in joinByOne and completed its implementation a bit by adding support for 'limit' on the front end and treating joinByOne as a limit of '1'. The apostrophe-pages singleton on the browser side is now the manager for the apostrophe-page virtual type. On the back end apostrophe-pages subclasses the default manager object to find only pages rather than caring about a specific doc type. Pages cursors now find only pages by default.