### PR TITLE
Refactor Areas

### DIFF
--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -9,7 +9,7 @@
   &.apos-limit-reached
   {
     >.apos-ui .apos-area-controls,
-    >[data-widgets]>[data-apos-widget-wrapper]>.apos-ui .apos-area-controls { display: none; }
+    >[data-apos-widgets]>[data-apos-widget-wrapper]>.apos-ui .apos-area-controls { display: none; }
   }
   // When we are dragging a widget, we want it to be at the forefront.
   .apos-area-widget.ui-draggable-dragging { z-index: @apos-z-index-9; }

--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -6,7 +6,11 @@
   // When an area's limit is reached, it shouldn't display controls
   // to add more content. We use direct children selectors to in order
   // to support nested areas.
-  &.apos-limit-reached>.apos-ui .apos-area-controls { display: none; }
+  &.apos-limit-reached
+  {
+    >.apos-ui .apos-area-controls,
+    >[data-widgets]>.apos-ui .apos-area-controls { display: none; }
+  }
   // When we are dragging a widget, we want it to be at the forefront.
   .apos-area-widget.ui-draggable-dragging { z-index: @apos-z-index-9; }
   &.apos-empty
@@ -28,15 +32,28 @@
 
 .apos-area-controls
 {
-  display: none;
+  position: relative;
+  max-height: 0;
+  opacity: 0;
   z-index: @apos-z-index-5;
+  .apos-transition;
 }
 
-.apos-area:hover
+.apos-area-widget-wrapper:hover>.apos-ui>.apos-area-controls
 {
-  >.apos-ui>.apos-area-controls,
-  >[data-widgets]>.apos-ui>.apos-area-controls { display: inline-block; }
+  max-height: 100px;
+  opacity: 1;
 }
+
+[data-apos-area-controls-original] .apos-area-controls { opacity: 1; max-height: inherit; }
+
+// [data-apos-area-controls][data-apos-area-controls-original] .apos-area-controls
+// {
+//   opacity: 0;
+//   position: relative;
+//   max-height: 100px !important;
+// }
+// [data-apos-area-controls][data-apos-area-controls-original] .apos-area-controls:hover { max-height: 100px !important; opacity: 1; }
 
 .apos-area-widget {
   >.apos-ui .apos-area-widget-controls { opacity: 0; }

--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -38,12 +38,14 @@
   max-height: 0;
   opacity: 0;
   .apos-transition;
+  z-index: @apos-z-index-1;
 }
 
 .apos-area-widget-wrapper:hover>.apos-ui>.apos-area-controls
 {
   max-height: 100px;
   opacity: 1;
+  z-index: @apos-z-index-5;
 }
 
 .apos-area-widget {

--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -28,7 +28,14 @@
 
 .apos-area-controls
 {
+  display: none;
   z-index: @apos-z-index-5;
+}
+
+.apos-area:hover
+{
+  >.apos-ui>.apos-area-controls,
+  >[data-widgets]>.apos-ui>.apos-area-controls { display: inline-block; }
 }
 
 .apos-area-widget {

--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -11,9 +11,9 @@
   .apos-area-widget.ui-draggable-dragging { z-index: @apos-z-index-9; }
   &.apos-empty
   {
-    // When there aren't any widgets in an area, it should have a min-height
+    // When there aren't any widgets in an area, it should have a height
     // and a background color set by default.
-    min-height: 80px;
+    height: 80px;
     background-color: @apos-light;
     // When there aren't any widgets in an area, the add content controls
     // should appear absolutely positioned in the empty state.
@@ -62,8 +62,24 @@
 // Styles for the drag-target separator between widgets.
 .apos-area-item-separator
 {
-  padding: @apos-padding-2;
-  margin: @apos-margin-1 0;
-  border: 4px dashed @apos-mid;
-  &.apos-hover { background-color: @apos-light; }
+  opacity: 0;
+  padding: 0;
+  margin: 0;
+  border: 0px dashed @apos-primary;
+  &.apos-hover { background-color: fade(@apos-primary, 50%); }
+  .apos-transition;
+}
+
+.apos-dragging .apos-area-item-separator
+{
+  border-width: 1px;
+  opacity: 1;
+  padding: @apos-padding-1;
+  margin: @apos-margin-1/2 0;
+}
+
+.apos-empty .apos-area-item-separator
+{
+  height: 100%;
+  padding: 0;
 }

--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -46,14 +46,6 @@
   opacity: 1;
 }
 
-// [data-apos-area-controls][data-apos-area-controls-original] .apos-area-controls
-// {
-//   opacity: 0;
-//   position: relative;
-//   max-height: 100px !important;
-// }
-// [data-apos-area-controls][data-apos-area-controls-original] .apos-area-controls:hover { max-height: 100px !important; opacity: 1; }
-
 .apos-area-widget {
   >.apos-ui .apos-area-widget-controls { opacity: 0; }
   &:hover>.apos-ui .apos-area-widget-controls { opacity: 1; }

--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -9,7 +9,7 @@
   &.apos-limit-reached
   {
     >.apos-ui .apos-area-controls,
-    >[data-widgets]>.apos-ui .apos-area-controls { display: none; }
+    >[data-widgets]>[data-apos-widget-wrapper]>.apos-ui .apos-area-controls { display: none; }
   }
   // When we are dragging a widget, we want it to be at the forefront.
   .apos-area-widget.ui-draggable-dragging { z-index: @apos-z-index-9; }
@@ -30,12 +30,13 @@
   }
 }
 
-.apos-area-controls
+.apos-area-controls { z-index: @apos-z-index-5; }
+
+.apos-area-widget-wrapper>.apos-ui>.apos-area-controls
 {
   position: relative;
   max-height: 0;
   opacity: 0;
-  z-index: @apos-z-index-5;
   .apos-transition;
 }
 
@@ -44,8 +45,6 @@
   max-height: 100px;
   opacity: 1;
 }
-
-[data-apos-area-controls-original] .apos-area-controls { opacity: 1; max-height: inherit; }
 
 // [data-apos-area-controls][data-apos-area-controls-original] .apos-area-controls
 // {

--- a/lib/modules/apostrophe-areas/public/js/always.js
+++ b/lib/modules/apostrophe-areas/public/js/always.js
@@ -24,9 +24,9 @@ apos.define('apostrophe-areas', {
     self.enablePlayers = function() {
       apos.on('enhance', function($el) {
 
-        $el.find('[data-widget]').each(enhance);
+        $el.find('[data-apos-widget]').each(enhance);
         // Also works if $el itself is a widget
-        $el.filter('[data-widget]').each(enhance);
+        $el.filter('[data-apos-widget]').each(enhance);
 
         function enhance() {
           var $widget = $(this);
@@ -36,7 +36,7 @@ apos.define('apostrophe-areas', {
           var data = self.getWidgetData($widget);
           var options = self.getWidgetOptions($widget);
 
-          var manager = self.getWidgetManager($widget.attr('data-widget'));
+          var manager = self.getWidgetManager($widget.attr('data-apos-widget'));
           if (manager && manager.play) {
             manager.play($widget, data, options);
           }
@@ -52,7 +52,7 @@ apos.define('apostrophe-areas', {
     };
 
     self.getWidgetData = function($widget) {
-      var manager = self.getWidgetManager($widget.attr('data-widget'));
+      var manager = self.getWidgetManager($widget.attr('data-apos-widget'));
       return manager.getData($widget);
     };
 

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -26,11 +26,6 @@ apos.define('apostrophe-area-editor', {
     self.$body = $('body');
     self.action = apos.areas.options.action;
 
-    // Selectors to locate items and lockups without crossing into
-    // the rendered content of a widget such as the blog widget
-    self.selItems = '[data-widget]:not([data-widget] [data-widget])';
-    self.selLockups = '.apos-lockup:not([data-widget] .apos-lockup)';
-
     self.init = function() {
       // So we don't reinitialize it on every call to enableAll()
       self.$el.attr('data-initialized', 'true');
@@ -57,14 +52,7 @@ apos.define('apostrophe-area-editor', {
         self.enhanceWidgetControls($widget);
         self.addAreaControls($widget);
       });
-      // TODO get lockups working again -Jimmy
-      // $items = self.$el.find(self.selLockups);
-      // $items.each(function() {
-      //   var $item = $(this);
-      //   self.addButtonsToLockup($item);
-      // });
       self.respectLimit();
-
     };
 
     self.registerClickHandlers = function() {
@@ -73,10 +61,6 @@ apos.define('apostrophe-area-editor', {
       self.link('apos-edit-item', self.editItem);
       self.link('apos-move-item', self.moveItem);
       self.link('apos-trash-item', self.trashItem);
-
-      // Lockup controls
-      self.link('apos-lockup-type', self.switchLockup);
-      self.link('apos-unlock-item', self.destroyLockup);
     };
 
     self.registerEventHandlers = function() {
@@ -160,40 +144,6 @@ apos.define('apostrophe-area-editor', {
       self.respectLimit();
     };
 
-    // Switch a lockup between types (left, right, etc)
-    self.switchLockup = function($el) {
-      var type = $el.data('lockup-type');
-      var $lockup = $el.closest('.apos-lockup');
-      var oldType = self.getLockupType($lockup);
-      if (oldType !== type) {
-
-        // The type of the lockup is actually stored as an attribute of
-        // its widget
-        var $widget = $lockup.find('.apos-widget');
-        var data = self.getWidgetData($widget);
-        data.lockup = type;
-        self.setWidgetData($widget, data);
-
-        // The lockup also gets a class
-        $lockup.removeClass(oldType);
-        $lockup.addClass(type);
-
-        // Re-render the widget to reflect changes to things like
-        // the size option of slideshows
-        self.reRenderWidget($widget);
-
-        // Show which option is currently active
-        $lockup.find('[data-lockup-type]').removeClass('apos-active');
-        $el.addClass('apos-active');
-      }
-      return false;
-    };
-
-    self.destroyLockup = function($el) {
-      var $lockup = $el.closest('.apos-lockup');
-      return self.unlock($lockup);
-    };
-
     self.getWidgets = function() {
       return self.$el.findSafe('[data-widget]', '[data-area]');
     }
@@ -238,53 +188,6 @@ apos.define('apostrophe-area-editor', {
       return $widget.is('[data-widget="apostrophe-rich-text"]');
     };
 
-    // Add controls to a lockup, and make it draggable as appropriate
-    self.addButtonsToLockup = function($lockup) {
-      var $lockupButtons;
-      $lockup.find('[data-apos-area-locked-item-controls]:not(.apos-template)').remove();
-      $lockupButtons = self.fromTemplate('[data-apos-area-locked-item-controls]');
-      // $lockupButtons = self.fromTemplate('.apos-editor2-lockup-buttons');
-
-      var $typeTemplate = $lockupButtons.find('[data-lockup-type]');
-      var lockups = self.getLockupsForArea($lockup.closest('[data-area]'));
-      if (lockups) {
-        $lockup.closest('[data-area]').find('[data-lockups-menu]').removeClass('apos-template');
-      }
-      var $previous = $typeTemplate;
-      _.each(lockups, function(lockup, name) {
-        var $button = self.fromTemplate($typeTemplate);
-        if (lockup.tooltip) {
-          $button.attr('title', lockup.tooltip);
-        } else {
-          $button.attr('title', lockup.label);
-        }
-        if (lockup.icon) {
-          $button.find('i').attr('class', lockup.icon);
-        }
-
-        $button.append(lockup.label);
-
-        $button.attr('data-lockup-type', name);
-        $previous.after($button);
-      });
-      $typeTemplate.remove();
-
-      var type = self.getLockupType($lockup);
-      $lockupButtons.find('[data-lockup-type="' + type + '"]').addClass('apos-active');
-
-      $lockup.prepend($lockupButtons);
-
-      $lockup.find('[data-content-menu-toggle]').click(function(e) {
-        $(this).next().toggleClass('apos-active');
-      });
-      $lockup.draggable(self.draggableSettings);
-    };
-
-    self.isItemLocked = function($item) {
-      var $lockup = $item.parent('.apos-lockup');
-      return !!$lockup.length;
-    };
-
     // Insert a newly created apos-widget, typically called by the
     // widget's editor on save of a new widget
 
@@ -321,16 +224,14 @@ apos.define('apostrophe-area-editor', {
     };
 
     // Replace an existing widget, preserving any classes and
-    // attributes specific to the area editor, like lockups. Typically
+    // attributes specific to the area editor. Typically
     // called by the widget's editor on save, so it can change
     // attributes of the widget element itself
 
     self.replaceWidget = function($old, $widget) {
       var data = self.getWidgetData($old);
-      var lockup = data.lockup;
       self.enhanceWidgetControls($widget);
       data = self.getWidgetData($widget);
-      data.lockup = lockup;
       self.setWidgetData($widget, data);
       $old.replaceWith($widget);
       apos.emit('enhance', $widget);
@@ -371,16 +272,7 @@ apos.define('apostrophe-area-editor', {
       var i = 0;
       $widgets.each(function() {
         var $widget = $(this);
-        var good = true;
-        // Individual items inside lockups don't get dropzones above and below them
-        if ($widget.parent('.apos-lockup').length) {
-          good = false;
-          // There should be no dropzone immediately below or above the element
-          // being dragged
-        } else if (($widgets[i] === $draggable[0]) || (((i + 1) < $widgets.length) && ($widgets[i + 1] === $draggable[0]))) {
-          good = false;
-        }
-        if (good) {
+        if (!(($widgets[i] === $draggable[0]) || (((i + 1) < $widgets.length) && ($widgets[i + 1] === $draggable[0])))) {
           $widget.after(self.newSeparator());
         }
         i++;
@@ -405,62 +297,21 @@ apos.define('apostrophe-area-editor', {
       if ($widget.hasClass('apos-rich-text-item')) {
         richText = true;
       }
-      // Lockups can only be dragged within the current area
-      var $areas;
-      var betweenAreas = !$widget.hasClass('apos-lockup');
-      if (betweenAreas) {
-        // Only the current area, and areas that are not full; also
-        // rule out areas that do not allow the widget type in question
-        $areas = $('[data-area]').filter(function() {
-          var editor = $(this).data('editor');
-          if ((!editor.limitReached()) || ($widget.data('areaEditor') === editor)) {
-            if ((richText && (editor.options.richText !== false)) || _.has(editor.options.widgets, $widget.attr('data-widget'))) {
-              return true;
-            }
+      // Only the current area, and areas that are not full; also
+      // rule out areas that do not allow the widget type in question
+      return $('[data-area]').filter(function() {
+        var editor = $(this).data('editor');
+        if ((!editor.limitReached()) || ($widget.data('areaEditor') === editor)) {
+          if ((richText && (editor.options.richText !== false)) || _.has(editor.options.widgets, $widget.attr('data-widget'))) {
+            return true;
           }
-        });
-      } else {
-        $areas = $widget.closest('[data-area]');
-      }
-      return $areas;
+        }
+      });
     };
 
     self.newSeparator = function() {
       var $separator = self.fromTemplate('[data-apos-drag-item-separator]');
       return $separator;
-    };
-
-    self.enableDropOnText = function($draggable) {
-      var $areas = self.getDroppableAreas($draggable);
-      $areas.find("[data-widgets] [data-widget='apostrophe-rich-text']:not([data-widget] [data-widget='apostrophe-rich-text'])").each(function() {
-        var $item = $(this);
-        // What we accept depends on which lockups allow which widgets. We can
-        // automatically switch lockups if one lockup supports widget A and the
-        // other supports widget B
-        var type = $draggable.attr('data-type');
-        var good = false;
-        if (type === 'apostrophe-rich-text') {
-          // Great, always acceptable to drag to other text
-          good = true;
-        } else {
-          var areaOptions = self.getAreaOptions($item.closest('[data-area]'));
-          if (!areaOptions.lockups) {
-            // No lockups at all - text is a drag target only for other text
-          } else {
-            var lockupWidgetTypes = [];
-            _.some(areaOptions.lockups, function(lockupName) {
-              var lockup = apos.data.lockups[lockupName];
-              if (lockup && _.contains(lockup.widgets, type)) {
-                good = true;
-                return true;
-              }
-            });
-          }
-        }
-        if (good) {
-          $item.droppable(self.richTextDropSettings);
-        }
-      });
     };
 
     self.disableDropOnText = function() {
@@ -562,14 +413,10 @@ apos.define('apostrophe-area-editor', {
 
     self.enableDroppables = function($draggable) {
       self.addSeparators($draggable);
-      // TODO bring back with lockups
-      // self.enableDropOnText($draggable);
     };
 
     self.disableDroppables = function($draggable) {
       self.removeSeparators();
-      // TODO bring back with lockups
-      // self.disableDropOnText();
     };
 
     self.separatorDropSettings = {
@@ -582,11 +429,6 @@ apos.define('apostrophe-area-editor', {
         // TODO: after the drop we should re-render the dropped item to
         // reflect the options of its new parent area
         var $item = $(ui.draggable);
-        // If it's not a lockup itself, dragging it somewhere else automatically busts it out
-        // of any lockup it may currently be in
-        if (!$item.hasClass('apos-lockup')) {
-          self.unlock($item);
-        }
         // Get rid of the hardcoded position provided by jquery UI draggable,
         // but don't remove the position: relative without which we can't see the
         // element move when we try to drag it again later
@@ -600,117 +442,8 @@ apos.define('apostrophe-area-editor', {
       }
     };
 
-    self.richTextDropSettings = {
-      accept: '[data-widget]',
-      activeClass: 'apos-editor2-active',
-      hoverClass: 'apos-editor2-hover',
-      tolerance: 'pointer',
-
-      drop: function(event, ui) {
-        if (!self.isText(ui.draggable)) {
-          // TODO: after the drop we should re-render both the widget and the
-          // target text to reflect the options of the area and the lockup, if any
-
-          // Widget dragged to text - create a lockup
-          var $newWidget = $(ui.draggable);
-          var $richTextItem = $(event.target);
-          // If the rich text is already part of a lockup, undo that
-          self.unlock($richTextItem);
-          // Create a lockup containing this text and this widget
-          var $lockup = $('<div class="apos-lockup"></div>');
-          // use the first lockup allowed in this area which is compatible
-          // with the widget type
-          var type = $newWidget.attr('data-type');
-          var lockups = self.getLockupsForArea($richTextItem.closest('[data-area]'));
-          // Should always be defined because we check for this when enabling droppables
-          var key;
-          var lockupName;
-          for (key in lockups) {
-            var lockup = lockups[key];
-            if (_.contains(lockup.widgets, type)) {
-              lockupName = key;
-              break;
-            }
-          }
-          if (lockupName) {
-            $lockup.addClass(lockupName);
-          }
-          // Position the lockup where the text was, then move the widget and text into it
-          $richTextItem.before($lockup);
-          $lockup.append($newWidget);
-          $lockup.append($richTextItem);
-          // Otherwise it stays offset where dropped
-          $newWidget.removeAttr('style');
-          var data = self.getWidgetData($newWidget);
-          data.lockup = lockupName;
-          self.setWidgetData($newWidget, data);
-          self.reRenderWidget($newWidget);
-          // self.addButtonsToLockup($lockup);
-        } else {
-          // Text dragged to text - append the text
-          var $contents = $(ui.draggable).find('[data-rich-text]').contents();
-          $(event.target).find('[data-rich-text]').append($contents);
-          $(ui.draggable).remove();
-        }
-        self.disableDroppables();
-        // $item is not defined here, get the item from the event
-        self.changeOwners($(ui.draggable));
-      }
-    };
-
-    self.getLockupsForArea = function($area) {
-      var options = self.getAreaOptions($area);
-      var names = options.lockups || [];
-      var lockups = {};
-      _.each(names, function(name) {
-        if (_.has(apos.data.lockups, name)) {
-          lockups[name] = apos.data.lockups[name];
-        }
-      });
-      return lockups;
-    };
-
-    self.getLockupType = function($lockup) {
-      var $widget = $lockup.find('[data-widget]');
-      var data = self.getWidgetData($widget);
-      return data.lockup;
-    };
-
-    // Given an item that may be part of a lockup, bust it and its
-    // peers, if any, out of the lockup so they can be dragged separately again
-    self.unlock = function($item) {
-      var $lockup;
-      if ($item.hasClass('apos-lockup')) {
-        $lockup = $item;
-      } else {
-        $lockup = $item.parent('.apos-lockup');
-        if (!$lockup.length) {
-          return;
-        }
-      }
-      var $items = $lockup.children('[data-widget]');
-      $items.each(function() {
-        var $item = $(this);
-        if (!self.isText($item)) {
-          var data = self.getWidgetData($item);
-          if (data.lockup) {
-            delete data.lockup;
-          }
-          self.setWidgetData($item, data);
-          self.reRenderWidget($item);
-        }
-      });
-      $lockup.before($items);
-      $lockup.remove();
-      // Actually, we may already be over the limit at this point,
-      // but we give the user until they leave the page to do
-      // something about that (TODO: a visual indication that their
-      // content is in peril would be best).
-      self.respectLimit();
-    };
-
     // Get the server to re-render a widget for us, applying the
-    // options appropriate to its new context at area and possibly lockup level
+    // options appropriate to its new context at area
     // TODO: we should prevent input during this time
     self.reRenderWidget = function($widget) {
       self.stopEditingRichText();
@@ -751,7 +484,6 @@ apos.define('apostrophe-area-editor', {
     };
 
     // Get the options that apply to the widget in its current context
-    // (area and possibly lockup)
     self.getWidgetOptions = function($widget) {
       var $area = $widget.closest('[data-area]');
       var data = self.getWidgetData($widget);
@@ -760,10 +492,6 @@ apos.define('apostrophe-area-editor', {
       var type = $widget.attr('data-type');
       if (areaOptions) {
         $.extend(true, options, areaOptions[type] || {});
-      }
-      if (data.lockup) {
-        var lockupOptions = apos.data.lockups[data.lockup];
-        $.extend(true, options, lockupOptions[type] || {});
       }
       return options;
     };

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -302,7 +302,7 @@ apos.define('apostrophe-area-editor', {
         $controls.addClass('apos-limit-one')
       }
       self.checkEmptyWidget($widget);
-      $widget.draggable(self.draggableSettings);
+      $widget.parent('[data-apos-widget-wrapper]').draggable(self.draggableSettings);
     };
 
     self.addAreaControls = function($widget) {
@@ -365,7 +365,7 @@ apos.define('apostrophe-area-editor', {
         $area.find('[data-widgets]:first').prepend(self.newSeparator());
       });
 
-      var $widgets = $areas.findSafe('[data-widget]', '[data-area]');
+      var $widgets = $areas.findSafe('[data-apos-widget-wrapper]', '[data-area]');
       $(window).trigger('aposDragging', [$widgets]);
       // Counter so we can peek ahead
       var i = 0;
@@ -400,26 +400,27 @@ apos.define('apostrophe-area-editor', {
     };
 
     self.getDroppableAreas = function($draggable) {
+      var $widget = $draggable.find('[data-widget]').first();
       var richText;
-      if ($draggable.hasClass('apos-rich-text-item')) {
+      if ($widget.hasClass('apos-rich-text-item')) {
         richText = true;
       }
       // Lockups can only be dragged within the current area
       var $areas;
-      var betweenAreas = !$draggable.hasClass('apos-lockup');
+      var betweenAreas = !$widget.hasClass('apos-lockup');
       if (betweenAreas) {
         // Only the current area, and areas that are not full; also
         // rule out areas that do not allow the widget type in question
         $areas = $('[data-area]').filter(function() {
           var editor = $(this).data('editor');
-          if ((!editor.limitReached()) || ($draggable.data('areaEditor') === editor)) {
-            if ((richText && (editor.options.richText !== false)) || _.has(editor.options.widgets, $draggable.attr('data-widget'))) {
+          if ((!editor.limitReached()) || ($widget.data('areaEditor') === editor)) {
+            if ((richText && (editor.options.richText !== false)) || _.has(editor.options.widgets, $widget.attr('data-widget'))) {
               return true;
             }
           }
         });
       } else {
-        $areas = $draggable.closest('[data-area]');
+        $areas = $widget.closest('[data-area]');
       }
       return $areas;
     };
@@ -572,7 +573,7 @@ apos.define('apostrophe-area-editor', {
     };
 
     self.separatorDropSettings = {
-      accept: '[data-widget],.apos-lockup',
+      accept: '[data-apos-widget-wrapper]',
       activeClass: 'apos-active',
       hoverClass: 'apos-hover',
       tolerance: 'pointer',

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -41,7 +41,7 @@ apos.define('apostrophe-area-editor', {
       if (self.$el.parents('[data-area]').length) {
         self.$el.removeAttr('data-autosave');
       }
-      self.$controls = self.$el.find('[data-apos-area-controls]');
+      self.$controls = self.$el.findSafe('[data-apos-area-controls]', '[data-widget]');
     };
 
     self.addEmptyClass = function() {
@@ -51,8 +51,6 @@ apos.define('apostrophe-area-editor', {
     };
 
     self.enhanceExistingWidgetControls = function() {
-      // Use the :not selector to avoid recursing into widgets that include
-      // areas in their rendered output
       var $widgets = self.getWidgets();
       $widgets.each(function() {
         var $widget = $(this);
@@ -142,13 +140,22 @@ apos.define('apostrophe-area-editor', {
       var direction = $el.data('apos-move-item');
 
       if (direction === 'up') {
-        $widget.prev().before($widget);
+        swap($widget.prevAll('[data-widget]').first(), $widget);
+        // $widget.prev().before($widget);
       } else if (direction === 'down') {
-        $widget.next().after($widget);
+        swap($widget, $widget.nextAll('[data-widget]').first());
+        // $widget.next().after($widget);
       } else if (direction === 'top') {
         $widget.parent().children(':first').before($widget);
       } else if (direction === 'bottom') {
         $widget.parent().children(':last').after($widget);
+      }
+      function swap($one, $two) {
+        self.removeAreaControls($one);
+        self.removeAreaControls($two);
+        $two.after($one);
+        self.addAreaControls($one);
+        self.addAreaControls($two);
       }
     };
 
@@ -156,6 +163,7 @@ apos.define('apostrophe-area-editor', {
       var $widget = $el.closest('[data-widget]');
       self.stopEditingRichText();
       self.unlock($widget);
+      self.removeAreaControls($widget);
       $widget.remove();
       self.checkEmptyAreas();
       self.respectLimit();
@@ -304,11 +312,20 @@ apos.define('apostrophe-area-editor', {
       }
       self.checkEmptyWidget($widget);
       $widget.draggable(self.draggableSettings);
+      $widget.hover(function() {
+        $widget.next('[data-apos-area-controls]').addClass('apos-hover');
+      }, function() {
+        $widget.next('[data-apos-area-controls]').removeClass('apos-hover');
+      });
     };
 
     self.addAreaControls = function($widget) {
-      $widget.after(self.$controls.clone().removeAttr('data-apos-area-controls-original'));
-    }
+      $widget.parent('[data-apos-widget-wrapper]').append(self.$controls.clone().removeAttr('data-apos-area-controls-original'));
+    };
+
+    self.removeAreaControls = function($widget) {
+      $widget.parent('[data-apos-widget-wrapper]').find('[data-apos-area-controls]').remove();
+    };
 
     self.checkEmptyWidget = function($widget) {
       var type = $widget.attr('data-widget');

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -125,25 +125,14 @@ apos.define('apostrophe-area-editor', {
       // the default from aposLocals.
       self.removeInitialContent(self.$el, true);
 
-      if (value === 'apostrophe-rich-text') {
-        return self.addRichText();
-      } else {
-        return self.addWidget(value);
-      }
+      return self.addWidget(value);
     };
 
     self.editItem = function($el) {
       var $item = $el.closest('[data-widget], .apos-lockup');
       if ($item.hasClass('apos-lockup')) {
+        // TODO figure out lockup logic
         $item = $item.find('.apos-rich-text-item');
-      }
-      if ($item.data('widget') === 'apostrophe-rich-text') {
-        self.editRichText($item);
-        // Follow that up with a focus call so ckeditor decides to show itself
-        // if it is already present, but dormant. We don't have to or want to do
-        // this on click events on the text so this code is specific to this button
-        $item.find('[data-rich-text]:first').focus();
-        return false;
       } else if ($item.is('[data-widget]')) {
         self.editWidget($item);
         return false;
@@ -228,16 +217,6 @@ apos.define('apostrophe-area-editor', {
       });
     };
 
-    self.editRichText = function($widget) {
-      // Remove any initial "click to type" content when we
-      // start actual editing
-      self.removeInitialContent(self.$el);
-      self.stopEditingRichText();
-      $widget.removeClass('apos-empty');
-      apos.areas.getWidgetManager('apostrophe-rich-text').startEditing($widget);
-      return false;
-    };
-
     self.removeInitialContent = function($el, entireItem) {
       if (entireItem) {
         // We added a real item to an area that only contains a
@@ -254,60 +233,12 @@ apos.define('apostrophe-area-editor', {
       if (!self.$activeRichText) {
         return;
       }
-
       apos.areas.getWidgetManager('apostrophe-rich-text').stopEditing(self.$activeRichText);
-
       self.$activeRichText = undefined;
     };
 
     self.isText = function($item) {
       return $item.is('[data-widget="apostrophe-rich-text"]');
-    };
-
-    // We decorate widgets and texts the same way in this editor. This is also a good place
-    // to make the item draggable. You may call this more than once to replace the buttons
-    self.addButtonsToItem = function($item) {
-      // This allows css to be scoped to the admin ui buttons when the widget is hovered
-      $item.addClass("apos-item");
-
-      var $itemButtons;
-      $item.find('[data-apos-widget-controls],[data-apos-area-locked-item-controls]').remove();
-
-      // Items in a lockup get a restricted set of buttons. The rich text itself still
-      // has all of them
-      var isLocked = self.isItemLocked($item);
-      if (self.isItemLocked($item) && !self.isText($item)) {
-        $itemButtons = self.fromTemplate('[data-apos-area-locked-item-controls]');
-      } else if (self.isItemLocked($item)) {
-        $itemButtons = self.fromTemplate('[data-apos-area-lockup-controls]');
-      } else {
-        $itemButtons = self.fromTemplate('[data-apos-widget-controls]');
-      }
-
-      $item.prepend($itemButtons);
-
-      // Horizontally center a locked widget w/ unknown height
-      if ($item.find('.apos-ui-container').hasClass('center')) {
-        var buttonsWidth = $item.find('.apos-ui-container').width();
-        var widgetWidth = $item.width();
-        var left = (widgetWidth / 2) - (buttonsWidth / 2);
-        $item.find('.center').css('left', left + 'px');
-      }
-
-      if (isLocked) {
-        // If we let the text of a lockup be draggable and a widget is floated left
-        // next to it, the widget will not be reachable by the mouse, so we don't permit
-        // this. Instead you can get the items out again by breaking the lockup with its
-        // "unlock" button
-        if ($item.hasClass('ui-draggable')) {
-          // Do this after yield to avoid a crash in jquery UI
-          setImmediate(function() {
-            $item.draggable('destroy');
-          });
-        }
-      } else {
-        $item.draggable(self.draggableSettings);
-      }
     };
 
     // Add controls to a lockup, and make it draggable as appropriate
@@ -419,7 +350,7 @@ apos.define('apostrophe-area-editor', {
       $areas.each(function() {
         var $area = $(this);
         var $ancestor = $draggable.closest('[data-area]');
-        $area.addClass('apos-dragging');
+        // $area.addClass('apos-dragging');
 
         if (($area[0] === $ancestor[0]) && (!$draggable.prev().length)) {
           return;
@@ -428,33 +359,38 @@ apos.define('apostrophe-area-editor', {
         $area.find('[data-widgets]:first').prepend(self.newSeparator());
       });
 
-      var $elements = $areas.find(self.selItems + ',' + self.selLockups);
-      $(window).trigger('aposDragging', [$elements]);
+      var $widgets = $areas.findSafe('[data-widget]', '[data-area]');
+      $(window).trigger('aposDragging', [$widgets]);
       // Counter so we can peek ahead
       var i = 0;
-      $elements.each(function() {
-        var $element = $(this);
+      $widgets.each(function() {
+        var $widget = $(this);
         var good = true;
         // Individual items inside lockups don't get dropzones above and below them
-        if ($element.parent('.apos-lockup').length) {
+        if ($widget.parent('.apos-lockup').length) {
           good = false;
           // There should be no dropzone immediately below or above the element
           // being dragged
-        } else if (($elements[i] === $draggable[0]) || (((i + 1) < $elements.length) && ($elements[i + 1] === $draggable[0]))) {
+        } else if (($widgets[i] === $draggable[0]) || (((i + 1) < $widgets.length) && ($widgets[i + 1] === $draggable[0]))) {
           good = false;
         }
         if (good) {
-          $element.after(self.newSeparator());
+          $widget.after(self.newSeparator());
         }
         i++;
       });
       $('[data-apos-drag-item-separator]:not(.apos-template)').droppable(self.separatorDropSettings);
+      setImmediate(function() {
+        $areas.addClass('apos-dragging');
+      });
     };
 
     self.removeSeparators = function() {
       $(window).trigger('aposStopDragging');
       $('[data-area]').removeClass('apos-dragging');
-      $('[data-apos-refreshable] [data-apos-drag-item-separator]').remove();
+      $('[data-apos-refreshable] [data-apos-drag-item-separator]').on('transitionend webkitTransitionEnd oTransitionEnd', function() {
+        $(this).remove();
+      })
     };
 
     self.getDroppableAreas = function($draggable) {
@@ -463,8 +399,8 @@ apos.define('apostrophe-area-editor', {
         richText = true;
       }
       // Lockups can only be dragged within the current area
-      var betweenAreas = !$draggable.hasClass('apos-lockup');
       var $areas;
+      var betweenAreas = !$draggable.hasClass('apos-lockup');
       if (betweenAreas) {
         // Only the current area, and areas that are not full; also
         // rule out areas that do not allow the widget type in question
@@ -558,26 +494,6 @@ apos.define('apostrophe-area-editor', {
       );
     };
 
-    self.addRichText = function(html, editNow) {
-      self.stopEditingRichText();
-      var $text = self.fromTemplate('.apos-rich-text-item');
-      // Populate the options just as if this widget had
-      // been rendered as part of an existing page
-      $text.attr('data-options', JSON.stringify(self.options.widgets['apostrophe-rich-text'] || {}));
-      // Every widget needs an _id for participation in versioning
-      $text.attr('data', JSON.stringify({ _id: apos.utils.generateId(), type: 'apostrophe-rich-text' }));
-      self.addButtonsToItem($text);
-      self.insertItem($text);
-      if (html !== undefined) {
-        $text.find('[data-rich-text]').html(html);
-      }
-      if (editNow || (editNow === undefined)) {
-        self.editRichText($text);
-      }
-      self.respectLimit();
-      return false;
-    };
-
     self.checkEmptyAreas = function() {
       $('[data-area]').each(function() {
         var $el = $(this);
@@ -613,7 +529,7 @@ apos.define('apostrophe-area-editor', {
               var $widget = $($.parseHTML($.trim(html), null, true));
               self.insertWidget($widget);
               self.checkEmptyAreas();
-              return callback(null);
+              return callback(null, $widget);
             }
           );
         }
@@ -716,9 +632,6 @@ apos.define('apostrophe-area-editor', {
           $richTextItem.before($lockup);
           $lockup.append($newWidget);
           $lockup.append($richTextItem);
-          // Redecorate the items to account for the fact that they are now stuck in a lockup
-          // self.addButtonsToItem($newWidget);
-          // self.addButtonsToItem($richTextItem);
           // Otherwise it stays offset where dropped
           $newWidget.removeAttr('style');
           var data = self.getWidgetData($newWidget);
@@ -782,9 +695,6 @@ apos.define('apostrophe-area-editor', {
       });
       $lockup.before($items);
       $lockup.remove();
-      // $items.each(function() {
-      //   self.addButtonsToItem($(this));
-      // });
       // Actually, we may already be over the limit at this point,
       // but we give the user until they leave the page to do
       // something about that (TODO: a visual indication that their

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -9,7 +9,7 @@ apos.define('apostrophe-area-editor', {
 
     self.init();
     self.addEmptyClass();
-    self.linkItemsToAreaEditor();
+    self.linkWidgetsToAreaEditor();
     self.enhanceExistingWidgetControls();
     self.registerClickHandlers();
     self.registerEventHandlers();
@@ -41,6 +41,7 @@ apos.define('apostrophe-area-editor', {
       if (self.$el.parents('[data-area]').length) {
         self.$el.removeAttr('data-autosave');
       }
+      self.$controls = self.$el.find('[data-apos-area-controls]');
     };
 
     self.addEmptyClass = function() {
@@ -50,11 +51,10 @@ apos.define('apostrophe-area-editor', {
     };
 
     self.enhanceExistingWidgetControls = function() {
-      var $items;
       // Use the :not selector to avoid recursing into widgets that include
       // areas in their rendered output
-      $items = self.getItems();
-      $items.each(function() {
+      var $widgets = self.getWidgets();
+      $widgets.each(function() {
         var $widget = $(this);
         self.enhanceWidgetControls($widget);
       });
@@ -112,7 +112,7 @@ apos.define('apostrophe-area-editor', {
       // If this is not empty then we want to append the new item after this item.
       // If it is empty then we want to prepend it to the area (we used the content menu
       // at the top of the area, rather than one nested in an item).
-      // self.$insertItemContext = $el.closest('[data-widget],.apos-lockup');
+      self.$insertItemContext = $el.closest('[data-apos-area-controls]:not([data-apos-area-controls-original])');
 
       // We may have come from a context content menu associated with a specific item;
       // if so dismiss it, but note we waited until after calling closest() to figure out
@@ -129,36 +129,33 @@ apos.define('apostrophe-area-editor', {
     };
 
     self.editItem = function($el) {
-      var $item = $el.closest('[data-widget], .apos-lockup');
-      if ($item.hasClass('apos-lockup')) {
-        // TODO figure out lockup logic
-        $item = $item.find('.apos-rich-text-item');
-      } else if ($item.is('[data-widget]')) {
-        self.editWidget($item);
+      var $widget = $el.closest('[data-widget]');
+      if ($widget) {
+        self.editWidget($widget);
         return false;
       }
     };
 
     self.moveItem = function($el) {
-      var $item = $el.closest('[data-widget], .apos-lockup');
+      var $widget = $el.closest('[data-widget]');
       var direction = $el.data('apos-move-item');
 
       if (direction === 'up') {
-        $item.prev().before($item);
+        $widget.prev().before($widget);
       } else if (direction === 'down') {
-        $item.next().after($item);
+        $widget.next().after($widget);
       } else if (direction === 'top') {
-        $item.parent().children(':first').before($item);
+        $widget.parent().children(':first').before($widget);
       } else if (direction === 'bottom') {
-        $item.parent().children(':last').after($item);
+        $widget.parent().children(':last').after($widget);
       }
     };
 
     self.trashItem = function($el) {
-      var $item = $el.closest('[data-widget],.apos-lockup');
+      var $widget = $el.closest('[data-widget]');
       self.stopEditingRichText();
-      self.unlock($item);
-      $item.remove();
+      self.unlock($widget);
+      $widget.remove();
       self.checkEmptyAreas();
       self.respectLimit();
     };
@@ -197,7 +194,7 @@ apos.define('apostrophe-area-editor', {
       return self.unlock($lockup);
     };
 
-    self.getItems = function() {
+    self.getWidgets = function() {
       return self.$el.findSafe('[data-widget]', '[data-area]');
     }
 
@@ -207,13 +204,13 @@ apos.define('apostrophe-area-editor', {
       // self.$el.find('[data-apos-dropdown]').removeClass('apos-active');
     };
 
-    self.linkItemsToAreaEditor = function() {
+    self.linkWidgetsToAreaEditor = function() {
       // Every item should know its area editor so we can talk
       // to other area editors after drag-and-drop
-      var $items = self.getItems();
-      $items.each(function() {
-        var $item = $(this);
-        $item.data('areaEditor', self);
+      var $widgets = self.getWidgets();
+      $widgets.each(function() {
+        var $widget = $(this);
+        $widget.data('areaEditor', self);
       });
     };
 
@@ -237,8 +234,8 @@ apos.define('apostrophe-area-editor', {
       self.$activeRichText = undefined;
     };
 
-    self.isText = function($item) {
-      return $item.is('[data-widget="apostrophe-rich-text"]');
+    self.isText = function($widget) {
+      return $widget.is('[data-widget="apostrophe-rich-text"]');
     };
 
     // Add controls to a lockup, and make it draggable as appropriate
@@ -338,6 +335,7 @@ apos.define('apostrophe-area-editor', {
       } else {
         self.$el.find('[data-widgets]:first').prepend($item);
       }
+      $item.after(self.$controls.clone().removeAttr('data-apos-area-controls-original'));
     };
 
     // This method recreates separators throughout the entire page as appropriate
@@ -765,7 +763,7 @@ apos.define('apostrophe-area-editor', {
     // storage in an area.
     self.serialize = function() {
       var items = [];
-      self.getItems().each(function() {
+      self.getWidgets().each(function() {
         var $item = $(this);
         var item = self.getWidgetData($item);
         items.push(item);
@@ -813,7 +811,7 @@ apos.define('apostrophe-area-editor', {
     };
 
     self.respectLimit = function() {
-      var count = self.getItems().length;
+      var count = self.getWidgets().length;
       var $toggles = self.$el.find('[data-content-menu-toggle]');
       if (self.limitReached()) {
         self.$el.addClass('apos-limit-reached');
@@ -825,7 +823,7 @@ apos.define('apostrophe-area-editor', {
     };
 
     self.limitReached = function() {
-      var count = self.getItems().length;
+      var count = self.getWidgets().length;
       return (self.options.limit && (count >= self.options.limit));
     };
 

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -162,9 +162,8 @@ apos.define('apostrophe-area-editor', {
     self.trashItem = function($el) {
       var $widget = $el.closest('[data-widget]');
       self.stopEditingRichText();
-      self.unlock($widget);
       self.removeAreaControls($widget);
-      $widget.remove();
+      $widget.parent('[data-apos-widget-wrapper]').remove();
       self.checkEmptyAreas();
       self.respectLimit();
     };
@@ -297,10 +296,10 @@ apos.define('apostrophe-area-editor', {
     // Insert a newly created apos-widget, typically called by the
     // widget's editor on save of a new widget
 
-    self.insertWidget = function($widget) {
-      $widget.addClass('apos-item');
+    self.insertWidget = function($wrapper) {
+      var $widget = $wrapper.children('[data-widget]').first();
       self.enhanceWidgetControls($widget);
-      self.insertItem($widget);
+      self.insertItem($wrapper);
       self.respectLimit();
       apos.emit('enhance', $widget);
     };

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -184,10 +184,6 @@ apos.define('apostrophe-area-editor', {
       self.$activeRichText = undefined;
     };
 
-    self.isText = function($widget) {
-      return $widget.is('[data-apos-widget="apostrophe-rich-text"]');
-    };
-
     // Insert a newly created apos-widget, typically called by the
     // widget's editor on save of a new widget
 
@@ -228,7 +224,8 @@ apos.define('apostrophe-area-editor', {
     // called by the widget's editor on save, so it can change
     // attributes of the widget element itself
 
-    self.replaceWidget = function($old, $widget) {
+    self.replaceWidget = function($old, $wrapper) {
+      var $widget = $wrapper.findSafe('[data-apos-widget]', '[data-apos-area]');
       var data = self.getWidgetData($old);
       self.enhanceWidgetControls($widget);
       data = self.getWidgetData($widget);
@@ -286,23 +283,22 @@ apos.define('apostrophe-area-editor', {
     self.removeSeparators = function() {
       $(window).trigger('aposStopDragging');
       $('[data-apos-area]').removeClass('apos-dragging');
-      $('[data-apos-refreshable] [data-apos-drag-item-separator]').on('transitionend webkitTransitionEnd oTransitionEnd', function() {
-        $(this).remove();
-      })
+      $('[data-apos-refreshable] [data-apos-drag-item-separator]')
+        .off('transitionend webkitTransitionEnd oTransitionEnd')
+        .on('transitionend webkitTransitionEnd oTransitionEnd', function() {
+          $(this).remove();
+        }
+      );
     };
 
     self.getDroppableAreas = function($draggable) {
       var $widget = $draggable.find('[data-apos-widget]').first();
-      var richText;
-      if ($widget.hasClass('apos-rich-text-item')) {
-        richText = true;
-      }
       // Only the current area, and areas that are not full; also
       // rule out areas that do not allow the widget type in question
       return $('[data-apos-area]').filter(function() {
         var editor = $(this).data('editor');
         if ((!editor.limitReached()) || ($widget.data('areaEditor') === editor)) {
-          if ((richText && (editor.options.richText !== false)) || _.has(editor.options.widgets, $widget.attr('data-apos-widget'))) {
+          if (_.has(editor.options.widgets, $widget.attr('data-apos-widget'))) {
             return true;
           }
         }
@@ -441,8 +437,9 @@ apos.define('apostrophe-area-editor', {
     // Get the server to re-render a widget for us, applying the
     // options appropriate to its new context at area
     // TODO: we should prevent input during this time
-    self.reRenderWidget = function($widget) {
+    self.reRenderWidget = function($wrapper) {
       self.stopEditingRichText();
+      var $widget = $wrapper.find('[data-apos-widget]');
       var type = $widget.attr('data-apos-widget');
       var data = self.getWidgetData($widget, true)
       var options = self.options[type] || {};
@@ -539,7 +536,7 @@ apos.define('apostrophe-area-editor', {
     // Take an item that might belong to a different
     // area and make it ours
     self.changeOwners = function($item) {
-      $item.data('areaEditor', self);
+      $item.find('[data-apos-widget]').data('areaEditor', self);
       self.respectLimit();
     };
 

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -57,6 +57,7 @@ apos.define('apostrophe-area-editor', {
       $widgets.each(function() {
         var $widget = $(this);
         self.enhanceWidgetControls($widget);
+        self.addAreaControls($widget);
       });
       // TODO get lockups working again -Jimmy
       // $items = self.$el.find(self.selLockups);
@@ -305,6 +306,10 @@ apos.define('apostrophe-area-editor', {
       $widget.draggable(self.draggableSettings);
     };
 
+    self.addAreaControls = function($widget) {
+      $widget.after(self.$controls.clone().removeAttr('data-apos-area-controls-original'));
+    }
+
     self.checkEmptyWidget = function($widget) {
       var type = $widget.attr('data-widget');
       if (apos.areas.getWidgetManager(type).isEmpty($widget)) {
@@ -335,7 +340,7 @@ apos.define('apostrophe-area-editor', {
       } else {
         self.$el.find('[data-widgets]:first').prepend($item);
       }
-      $item.after(self.$controls.clone().removeAttr('data-apos-area-controls-original'));
+      self.addAreaControls($item);
     };
 
     // This method recreates separators throughout the entire page as appropriate

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -111,7 +111,7 @@ apos.define('apostrophe-area-editor', {
       // If this is not empty then we want to append the new item after this item.
       // If it is empty then we want to prepend it to the area (we used the content menu
       // at the top of the area, rather than one nested in an item).
-      self.$insertItemContext = $el.closest('[data-apos-area-controls]:not([data-apos-area-controls-original])');
+      self.$insertItemContext = $el.parentsUntil('[data-area]').filter('[data-apos-widget-wrapper]', self.$el);
 
       // We may have come from a context content menu associated with a specific item;
       // if so dismiss it, but note we waited until after calling closest() to figure out
@@ -136,26 +136,18 @@ apos.define('apostrophe-area-editor', {
     };
 
     self.moveItem = function($el) {
-      var $widget = $el.closest('[data-widget]');
+      // We move the widget wrapper, with its associated area controls
+      var $wrapper = $el.closest('[data-apos-widget-wrapper]');
       var direction = $el.data('apos-move-item');
 
       if (direction === 'up') {
-        swap($widget.prevAll('[data-widget]').first(), $widget);
-        // $widget.prev().before($widget);
+        $wrapper.prev().before($wrapper);
       } else if (direction === 'down') {
-        swap($widget, $widget.nextAll('[data-widget]').first());
-        // $widget.next().after($widget);
+        $wrapper.next().after($wrapper);
       } else if (direction === 'top') {
-        $widget.parent().children(':first').before($widget);
+        $wrapper.parent().children(':first').before($wrapper);
       } else if (direction === 'bottom') {
-        $widget.parent().children(':last').after($widget);
-      }
-      function swap($one, $two) {
-        self.removeAreaControls($one);
-        self.removeAreaControls($two);
-        $two.after($one);
-        self.addAreaControls($one);
-        self.addAreaControls($two);
+        $wrapper.parent().children(':last').after($wrapper);
       }
     };
 
@@ -311,11 +303,6 @@ apos.define('apostrophe-area-editor', {
       }
       self.checkEmptyWidget($widget);
       $widget.draggable(self.draggableSettings);
-      $widget.hover(function() {
-        $widget.next('[data-apos-area-controls]').addClass('apos-hover');
-      }, function() {
-        $widget.next('[data-apos-area-controls]').removeClass('apos-hover');
-      });
     };
 
     self.addAreaControls = function($widget) {
@@ -356,7 +343,7 @@ apos.define('apostrophe-area-editor', {
       } else {
         self.$el.find('[data-widgets]:first').prepend($item);
       }
-      self.addAreaControls($item);
+      self.addAreaControls($item.findSafe('[data-widget]', 'data-area'));
     };
 
     // This method recreates separators throughout the entire page as appropriate
@@ -545,10 +532,10 @@ apos.define('apostrophe-area-editor', {
               // This rather intense code works around
               // various situations in which jquery is
               // picky about HTML
-              var $widget = $($.parseHTML($.trim(html), null, true));
-              self.insertWidget($widget);
+              var $wrapper = $($.parseHTML($.trim(html), null, true));
+              self.insertWidget($wrapper);
               self.checkEmptyAreas();
-              return callback(null, $widget);
+              return callback(null, $wrapper.findSafe('[data-widget]', '[data-area]'));
             }
           );
         }

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -33,14 +33,14 @@ apos.define('apostrophe-area-editor', {
       self.$el.data('editor', self);
       // Receive options from the DOM too
       _.extend(self.options, JSON.parse(self.$el.attr('data-options')));
-      if (self.$el.parents('[data-area]').length) {
+      if (self.$el.parents('[data-apos-area]').length) {
         self.$el.removeAttr('data-autosave');
       }
-      self.$controls = self.$el.findSafe('[data-apos-area-controls]', '[data-widget]');
+      self.$controls = self.$el.findSafe('[data-apos-area-controls]', '[data-apos-widget]');
     };
 
     self.addEmptyClass = function() {
-      if (self.$el.find('[data-widgets]').html() === "") {
+      if (self.$el.find('[data-apos-widgets]').html() === "") {
         self.$el.addClass('apos-empty');
       }
     };
@@ -95,7 +95,7 @@ apos.define('apostrophe-area-editor', {
       // If this is not empty then we want to append the new item after this item.
       // If it is empty then we want to prepend it to the area (we used the content menu
       // at the top of the area, rather than one nested in an item).
-      self.$insertItemContext = $el.parentsUntil('[data-area]').filter('[data-apos-widget-wrapper]', self.$el);
+      self.$insertItemContext = $el.parentsUntil('[data-apos-area]').filter('[data-apos-widget-wrapper]', self.$el);
 
       // We may have come from a context content menu associated with a specific item;
       // if so dismiss it, but note we waited until after calling closest() to figure out
@@ -112,7 +112,7 @@ apos.define('apostrophe-area-editor', {
     };
 
     self.editItem = function($el) {
-      var $widget = $el.closest('[data-widget]');
+      var $widget = $el.closest('[data-apos-widget]');
       if ($widget) {
         self.editWidget($widget);
         return false;
@@ -136,7 +136,7 @@ apos.define('apostrophe-area-editor', {
     };
 
     self.trashItem = function($el) {
-      var $widget = $el.closest('[data-widget]');
+      var $widget = $el.closest('[data-apos-widget]');
       self.stopEditingRichText();
       self.removeAreaControls($widget);
       $widget.parent('[data-apos-widget-wrapper]').remove();
@@ -145,7 +145,7 @@ apos.define('apostrophe-area-editor', {
     };
 
     self.getWidgets = function() {
-      return self.$el.findSafe('[data-widget]', '[data-area]');
+      return self.$el.findSafe('[data-apos-widget]', '[data-apos-area]');
     }
 
     self.dismissContextContentMenu = function() {
@@ -168,7 +168,7 @@ apos.define('apostrophe-area-editor', {
       if (entireItem) {
         // We added a real item to an area that only contains a
         // placeholder item which should be removed in its entirety
-        $el.find('[data-widget="apostrophe-rich-text"]:has([data-initial-content])').remove();
+        $el.find('[data-apos-widget="apostrophe-rich-text"]:has([data-initial-content])').remove();
       } else {
         // We started editing such an item. Don't trash it,
         // just remove the initial content <p> tag
@@ -185,14 +185,14 @@ apos.define('apostrophe-area-editor', {
     };
 
     self.isText = function($widget) {
-      return $widget.is('[data-widget="apostrophe-rich-text"]');
+      return $widget.is('[data-apos-widget="apostrophe-rich-text"]');
     };
 
     // Insert a newly created apos-widget, typically called by the
     // widget's editor on save of a new widget
 
     self.insertWidget = function($wrapper) {
-      var $widget = $wrapper.children('[data-widget]').first();
+      var $widget = $wrapper.children('[data-apos-widget]').first();
       self.enhanceWidgetControls($widget);
       self.insertItem($wrapper);
       self.respectLimit();
@@ -200,7 +200,7 @@ apos.define('apostrophe-area-editor', {
     };
 
     self.enhanceWidgetControls = function($widget) {
-      $controls = $widget.findSafe('[data-apos-widget-controls]', '[data-area]');
+      $controls = $widget.findSafe('[data-apos-widget-controls]', '[data-apos-area]');
       if (self.options.limit == 1) {
         $controls.addClass('apos-limit-one')
       }
@@ -217,7 +217,7 @@ apos.define('apostrophe-area-editor', {
     };
 
     self.checkEmptyWidget = function($widget) {
-      var type = $widget.attr('data-widget');
+      var type = $widget.attr('data-apos-widget');
       if (apos.areas.getWidgetManager(type).isEmpty($widget)) {
         $widget.addClass('apos-empty');
       }
@@ -242,9 +242,9 @@ apos.define('apostrophe-area-editor', {
       if (self.$insertItemContext && self.$insertItemContext.length) {
         self.$insertItemContext.after($item);
       } else {
-        self.$el.find('[data-widgets]:first').prepend($item);
+        self.$el.find('[data-apos-widgets]:first').prepend($item);
       }
-      self.addAreaControls($item.findSafe('[data-widget]', 'data-area'));
+      self.addAreaControls($item.findSafe('[data-apos-widget]', '[data-apos-area]'));
     };
 
     // This method recreates separators throughout the entire page as appropriate
@@ -256,17 +256,17 @@ apos.define('apostrophe-area-editor', {
 
       $areas.each(function() {
         var $area = $(this);
-        var $ancestor = $draggable.closest('[data-area]');
+        var $ancestor = $draggable.closest('[data-apos-area]');
         // $area.addClass('apos-dragging');
 
         if (($area[0] === $ancestor[0]) && (!$draggable.prev().length)) {
           return;
         }
 
-        $area.find('[data-widgets]:first').prepend(self.newSeparator());
+        $area.find('[data-apos-widgets]:first').prepend(self.newSeparator());
       });
 
-      var $widgets = $areas.findSafe('[data-apos-widget-wrapper]', '[data-area]');
+      var $widgets = $areas.findSafe('[data-apos-widget-wrapper]', '[data-apos-area]');
       $(window).trigger('aposDragging', [$widgets]);
       // Counter so we can peek ahead
       var i = 0;
@@ -285,24 +285,24 @@ apos.define('apostrophe-area-editor', {
 
     self.removeSeparators = function() {
       $(window).trigger('aposStopDragging');
-      $('[data-area]').removeClass('apos-dragging');
+      $('[data-apos-area]').removeClass('apos-dragging');
       $('[data-apos-refreshable] [data-apos-drag-item-separator]').on('transitionend webkitTransitionEnd oTransitionEnd', function() {
         $(this).remove();
       })
     };
 
     self.getDroppableAreas = function($draggable) {
-      var $widget = $draggable.find('[data-widget]').first();
+      var $widget = $draggable.find('[data-apos-widget]').first();
       var richText;
       if ($widget.hasClass('apos-rich-text-item')) {
         richText = true;
       }
       // Only the current area, and areas that are not full; also
       // rule out areas that do not allow the widget type in question
-      return $('[data-area]').filter(function() {
+      return $('[data-apos-area]').filter(function() {
         var editor = $(this).data('editor');
         if ((!editor.limitReached()) || ($widget.data('areaEditor') === editor)) {
-          if ((richText && (editor.options.richText !== false)) || _.has(editor.options.widgets, $widget.attr('data-widget'))) {
+          if ((richText && (editor.options.richText !== false)) || _.has(editor.options.widgets, $widget.attr('data-apos-widget'))) {
             return true;
           }
         }
@@ -314,10 +314,6 @@ apos.define('apostrophe-area-editor', {
       return $separator;
     };
 
-    self.disableDropOnText = function() {
-      $('[data-area] [data-widgets] [data-widget="apostrophe-rich-text"]').droppable('destroy');
-    };
-
     self.getAreaOptions = function($area) {
       // TODO: this could be a lot of parsing done over and over
       return JSON.parse($area.attr('data-options') || '{}');
@@ -325,7 +321,7 @@ apos.define('apostrophe-area-editor', {
 
     self.editWidget = function($widget) {
       self.stopEditingRichText();
-      var type = $widget.attr('data-widget');
+      var type = $widget.attr('data-apos-widget');
       var options = self.options.widgets[type] || {};
 
       apos.areas.getWidgetManager(type).edit(
@@ -353,9 +349,9 @@ apos.define('apostrophe-area-editor', {
     };
 
     self.checkEmptyAreas = function() {
-      $('[data-area]').each(function() {
+      $('[data-apos-area]').each(function() {
         var $el = $(this);
-        if ($el.find('[data-widget]').length === 0) {
+        if ($el.find('[data-apos-widget]').length === 0) {
           $el.addClass('apos-empty');
         } else {
           $el.removeClass('apos-empty');
@@ -387,7 +383,7 @@ apos.define('apostrophe-area-editor', {
               var $wrapper = $($.parseHTML($.trim(html), null, true));
               self.insertWidget($wrapper);
               self.checkEmptyAreas();
-              return callback(null, $wrapper.findSafe('[data-widget]', '[data-area]'));
+              return callback(null, $wrapper.findSafe('[data-apos-widget]', '[data-apos-area]'));
             }
           );
         }
@@ -447,7 +443,7 @@ apos.define('apostrophe-area-editor', {
     // TODO: we should prevent input during this time
     self.reRenderWidget = function($widget) {
       self.stopEditingRichText();
-      var type = $widget.attr('data-widget');
+      var type = $widget.attr('data-apos-widget');
       var data = self.getWidgetData($widget, true)
       var options = self.options[type] || {};
 
@@ -472,20 +468,20 @@ apos.define('apostrophe-area-editor', {
     };
 
     self.getWidgetData = function($widget) {
-      var type = $widget.attr('data-widget');
+      var type = $widget.attr('data-apos-widget');
       var manager = apos.areas.getWidgetManager(type);
       return manager.getData($widget);
     };
 
     self.setWidgetData = function($widget, data) {
-      var type = $widget.attr('data-widget');
+      var type = $widget.attr('data-apos-widget');
       var manager = apos.areas.getWidgetManager(type);
       return manager.setData($widget, data);
     };
 
     // Get the options that apply to the widget in its current context
     self.getWidgetOptions = function($widget) {
-      var $area = $widget.closest('[data-area]');
+      var $area = $widget.closest('[data-apos-area]');
       var data = self.getWidgetData($widget);
       var options = {};
       var areaOptions = self.getAreaOptions($area);
@@ -572,7 +568,7 @@ apos.define('apostrophe-area-editor', {
       self.$el.off('aposRichTextStarted');
       self.on('aposRichTextStarted', function(e) {
         self.$activeRichText = $(e.target);
-        $(e.target).find('[data-area-item-buttons]:first').hide();
+        $(e.target).find('[data-apos-area-item-buttons]:first').hide();
       });
       self.$el.off('aposRichTextStopped');
       self.on('aposRichTextStopped', function(e) {
@@ -600,9 +596,9 @@ apos.define('apostrophe-area-editor', {
       if (arguments.length === 2) {
         fn = selector;
         selector = undefined;
-        self.$el.onSafe(eventType, '[data-area]', fn);
+        self.$el.onSafe(eventType, '[data-apos-area]', fn);
       } else {
-        self.$el.onSafe(eventType, selector, '[data-area]', fn);
+        self.$el.onSafe(eventType, selector, '[data-apos-area]', fn);
       }
     };
   }

--- a/lib/modules/apostrophe-areas/public/js/user.js
+++ b/lib/modules/apostrophe-areas/public/js/user.js
@@ -34,8 +34,7 @@ apos.define('apostrophe-areas', {
     };
 
     self.fromTemplate = function(sel) {
-      // console.log($('[data-area-editor-templates]').find(sel));
-      return $('[data-area-editor-templates]').find(sel).clone();
+      return $('[data-apos-area-editor-templates]').find(sel).clone();
     };
 
     self.enableCkeditor = function() {
@@ -73,7 +72,7 @@ apos.define('apostrophe-areas', {
       if (!sel) {
         sel = 'body';
       }
-      $(sel).find('[data-area-edit]').each(function() {
+      $(sel).find('[data-apos-area-edit]').each(function() {
         var $el = $(this);
         if ($el.attr('data-initialized')) {
           return;

--- a/lib/modules/apostrophe-areas/views/area.html
+++ b/lib/modules/apostrophe-areas/views/area.html
@@ -1,8 +1,9 @@
 {# area needs its own copy of the widget options as #}
 {# JSON, for adding new widgets #}
+{%- set isSingleton = data.options.limit == 1 and data.options.type -%}
 <div class="apos-area" data-area{%- if data.area._edit %} data-area-edit{% if not data.options.virtual %} data-autosave{% endif %} data-options='{{ apos.utils.omit(data.options, 'area') | jsonAttribute({ single: true }) }}' data-doc-id="{{ data.area._docId }}" data-dot-path="{{ data.area._dotPath }}"{%- endif -%}>
   {%- if data.area._edit -%}
-    {%- if data.options.limit == 1 and data.options.type -%}
+    {%- if isSingleton -%}
       {% include "singletonControls.html" %}
     {%- else -%}
       {% include "areaControls.html" %}

--- a/lib/modules/apostrophe-areas/views/area.html
+++ b/lib/modules/apostrophe-areas/views/area.html
@@ -1,14 +1,14 @@
 {# area needs its own copy of the widget options as #}
 {# JSON, for adding new widgets #}
 {%- set isSingleton = data.options.limit == 1 and data.options.type -%}
-<div class="apos-area" data-area{%- if data.area._edit %} data-area-edit{% if not data.options.virtual %} data-autosave{% endif %} data-options='{{ apos.utils.omit(data.options, 'area') | jsonAttribute({ single: true }) }}' data-doc-id="{{ data.area._docId }}" data-dot-path="{{ data.area._dotPath }}"{%- endif -%}>
+<div class="apos-area" data-apos-area{%- if data.area._edit %} data-apos-area-edit{% if not data.options.virtual %} data-autosave{% endif %} data-options='{{ apos.utils.omit(data.options, 'area') | jsonAttribute({ single: true }) }}' data-doc-id="{{ data.area._docId }}" data-dot-path="{{ data.area._dotPath }}"{%- endif -%}>
   {%- if data.area._edit -%}
     {%- if isSingleton -%}
       {% include "singletonControls.html" %}
     {%- else -%}
       {% include "areaControls.html" %}
     {%- endif -%}
-    <div class="apos-area-widgets" data-widgets>
+    <div class="apos-area-widgets" data-apos-widgets>
   {%- endif -%}
   {%- for widget in data.area.items -%}
     {{ apos.areas.widget(widget, data.options.widgets[widget.type]) }}

--- a/lib/modules/apostrophe-areas/views/areaControls.html
+++ b/lib/modules/apostrophe-areas/views/areaControls.html
@@ -8,7 +8,7 @@
     {%- endif -%}
   {%- endfor -%}
 {%- endmacro -%}
-<div class="apos-ui">
+<div class="apos-ui" data-apos-area-controls data-apos-area-controls-original>
   <div class="apos-area-controls">
     {{ dropdowns.base(
       {

--- a/lib/modules/apostrophe-areas/views/editor.html
+++ b/lib/modules/apostrophe-areas/views/editor.html
@@ -1,5 +1,5 @@
 <div class="apos-ui">
-  <div class="apos-templates" data-area-editor-templates>
+  <div class="apos-templates" data-apos-area-editor-templates>
     {% include "widgetControls.html" %}
     {% include "lockedItemButtons.html" %}
     {% include "lockedWidgetButtons.html" %}

--- a/lib/modules/apostrophe-areas/views/richText.html
+++ b/lib/modules/apostrophe-areas/views/richText.html
@@ -1,4 +1,4 @@
 {# Instantiated by areaEditor.js every time someone adds another rich text to an area #}
-<div data-widget="apostrophe-rich-text" class="apos-rich-text-item apos-item apos-empty">
+<div data-apos-widget="apostrophe-rich-text" class="apos-rich-text-item apos-item apos-empty">
   <div class="apos-rich-text" data-rich-text></div>
 </div>

--- a/lib/modules/apostrophe-areas/views/widget.html
+++ b/lib/modules/apostrophe-areas/views/widget.html
@@ -3,6 +3,8 @@
 {# get them if you need them (TODO: consider ways of #}
 {# whitelisting them for the inline JSON attributes) #}
 <div class="apos-area-widget-wrapper" data-apos-widget-wrapper="{{ data.widget.type }}">
+  {# This wrapper exists for editor.js to inject contextual widget insertion controls into,
+    since those are area level controls rather than widget level #}
   <div class="apos-area-widget{% if data.manager.options.contextualOnly %} apos-area-widget--contextual{% endif %}" data-apos-widget="{{ data.widget.type }}" data='{{ data.dataFiltered | jsonAttribute({ single: true }) }}' data-options='{{ apos.utils.omit(data.options, 'area') | jsonAttribute({ single: true }) }}'>
     {%- if data.widget._edit and data.options.edit != false -%}
       {%- include 'widgetControls.html' -%}

--- a/lib/modules/apostrophe-areas/views/widget.html
+++ b/lib/modules/apostrophe-areas/views/widget.html
@@ -2,9 +2,15 @@
 {# however ginormous joined objects are elided. Use APIs to #}
 {# get them if you need them (TODO: consider ways of #}
 {# whitelisting them for the inline JSON attributes) #}
+{%- if data.widget._edit -%}
+  <div class="apos-area-widget-wrapper" data-apos-widget-wrapper>
+{%- endif -%}
 <div class="apos-area-widget{% if data.manager.options.contextualOnly %} apos-area-widget--contextual{% endif %}" data-widget="{{ data.widget.type }}" data='{{ data.dataFiltered | jsonAttribute({ single: true }) }}' data-options='{{ apos.utils.omit(data.options, 'area') | jsonAttribute({ single: true }) }}'>
   {%- if data.widget._edit and data.options.edit != false -%}
     {%- include 'widgetControls.html' -%}
   {%- endif -%}
   {{ data.output() | safe }}
 </div>
+{%- if data.widget._edit -%}
+  </div>
+{%- endif -%}

--- a/lib/modules/apostrophe-areas/views/widget.html
+++ b/lib/modules/apostrophe-areas/views/widget.html
@@ -3,7 +3,7 @@
 {# get them if you need them (TODO: consider ways of #}
 {# whitelisting them for the inline JSON attributes) #}
 <div class="apos-area-widget-wrapper" data-apos-widget-wrapper="{{ data.widget.type }}">
-  <div class="apos-area-widget{% if data.manager.options.contextualOnly %} apos-area-widget--contextual{% endif %}" data-widget="{{ data.widget.type }}" data='{{ data.dataFiltered | jsonAttribute({ single: true }) }}' data-options='{{ apos.utils.omit(data.options, 'area') | jsonAttribute({ single: true }) }}'>
+  <div class="apos-area-widget{% if data.manager.options.contextualOnly %} apos-area-widget--contextual{% endif %}" data-apos-widget="{{ data.widget.type }}" data='{{ data.dataFiltered | jsonAttribute({ single: true }) }}' data-options='{{ apos.utils.omit(data.options, 'area') | jsonAttribute({ single: true }) }}'>
     {%- if data.widget._edit and data.options.edit != false -%}
       {%- include 'widgetControls.html' -%}
     {%- endif -%}

--- a/lib/modules/apostrophe-areas/views/widget.html
+++ b/lib/modules/apostrophe-areas/views/widget.html
@@ -2,15 +2,11 @@
 {# however ginormous joined objects are elided. Use APIs to #}
 {# get them if you need them (TODO: consider ways of #}
 {# whitelisting them for the inline JSON attributes) #}
-{%- if data.widget._edit -%}
-  <div class="apos-area-widget-wrapper" data-apos-widget-wrapper>
-{%- endif -%}
-<div class="apos-area-widget{% if data.manager.options.contextualOnly %} apos-area-widget--contextual{% endif %}" data-widget="{{ data.widget.type }}" data='{{ data.dataFiltered | jsonAttribute({ single: true }) }}' data-options='{{ apos.utils.omit(data.options, 'area') | jsonAttribute({ single: true }) }}'>
-  {%- if data.widget._edit and data.options.edit != false -%}
-    {%- include 'widgetControls.html' -%}
-  {%- endif -%}
-  {{ data.output() | safe }}
-</div>
-{%- if data.widget._edit -%}
+<div class="apos-area-widget-wrapper" data-apos-widget-wrapper="{{ data.widget.type }}">
+  <div class="apos-area-widget{% if data.manager.options.contextualOnly %} apos-area-widget--contextual{% endif %}" data-widget="{{ data.widget.type }}" data='{{ data.dataFiltered | jsonAttribute({ single: true }) }}' data-options='{{ apos.utils.omit(data.options, 'area') | jsonAttribute({ single: true }) }}'>
+    {%- if data.widget._edit and data.options.edit != false -%}
+      {%- include 'widgetControls.html' -%}
+    {%- endif -%}
+    {{ data.output() | safe }}
   </div>
-{%- endif -%}
+</div>

--- a/lib/modules/apostrophe-images-widgets/public/css/user.less
+++ b/lib/modules/apostrophe-images-widgets/public/css/user.less
@@ -1,7 +1,7 @@
 
 // Image Widget Editor within Modal
 
-.apos-modal-body [data-widget="apostrophe-images"]
+.apos-modal-body [data-apos-widget="apostrophe-images"]
 {
 
   [data-slideshow] [data-slideshow-items]

--- a/lib/modules/apostrophe-rich-text-widgets/index.js
+++ b/lib/modules/apostrophe-rich-text-widgets/index.js
@@ -3,48 +3,16 @@ var sanitizeHtml = require('sanitize-html');
 var jsDiff = require('diff');
 
 module.exports = {
+  extend: 'apostrophe-widgets',
 
   label: 'Rich Text',
 
-  afterConstruct: function(self) {
-
-    self.label = self.options.label;
-
-    self.name = self.options.name || self.__meta.name.replace(/\-widgets$/, '');
-
-    self.apos.areas.setWidgetManager(self.name, self);
-
-    self.pushAsset('script', 'always', { when: 'always' });
-
-    self.pushAsset('script', 'user', { when: 'user' });
-
-    self.pushAsset('script', 'editor', { when: 'user' });
-
-    self.pushAsset('stylesheet', 'user', { when: 'user' });
-
-
-    self.apos.push.browserCall('always', 'apos.define(?, ?)',
-      self.__meta.name,
-      {
-        name: self.name,
-        label: self.label,
-        action: self.action,
-        schema: self.schema
-      }
-    );
-
-    self.apos.push.browserCall('always', 'apos.create(?, {})',
-      self.__meta.name);
-  },
-
   construct: function(self, options) {
 
-    // Outputs the widget. Invoked by
-    // apos.widget in Nunjucks.
-
-    self.output = function(widget, options) {
-      var result = self.partial('widget', { widget: widget, options: options, manager: self });
-      return result;
+    // TODO We may want to use the default widget load, if we start having nested
+    // areas in rich text widgets to support lockups
+    self.load = function(req, widgets, callback) {
+      return setImmediate(callback);
     };
 
     self.sanitize = function(req, input, callback) {
@@ -57,8 +25,7 @@ module.exports = {
 
     // Rich text editor content is found in the
     // div itself as markup, so don't redundantly
-    // represent it as a data attribute. - Tom and Sam 💁
-
+    // represent it as a data attribute.
     self.filterForDataAttribute = function(widget) {
       return _.omit(widget, 'content');
     };
@@ -68,7 +35,6 @@ module.exports = {
     };
 
     self.compare = function(old, current) {
-
       var oldContent = old.content;
       if (oldContent === undefined) {
         oldContent = '';
@@ -118,7 +84,12 @@ module.exports = {
       }
 
       return changes;
+    };
 
+    var superPushAssets = self.pushAssets;
+    self.pushAssets = function() {
+      superPushAssets();
+      self.pushAsset('stylesheet', 'user', { when: 'user' });
     };
 
   }

--- a/lib/modules/apostrophe-rich-text-widgets/public/css/components/rich-text-widget.less
+++ b/lib/modules/apostrophe-rich-text-widgets/public/css/components/rich-text-widget.less
@@ -1,4 +1,4 @@
-[data-widget="apostrophe-rich-text"]
+[data-apos-widget="apostrophe-rich-text"]
 {
   // Specific positioning of widget controls for rich text widgets.
   >.apos-ui

--- a/lib/modules/apostrophe-rich-text-widgets/public/js/always.js
+++ b/lib/modules/apostrophe-rich-text-widgets/public/js/always.js
@@ -1,20 +1,9 @@
 apos.define('apostrophe-rich-text-widgets', {
+  extend: 'apostrophe-widgets',
 
   label: 'Text',
 
-  // do not extend apostrophe-widgets, that is intended
-  // for simple modal widgets. -Tom
-
-  afterConstruct: function(self) {
-    // Declare ourselves the manager for this widget type
-    apos.areas.setWidgetManager(self.name, self);
-  },
-
   construct: function(self, options) {
-
-    self.options = options;
-    self.name = options.name;
-    self.label = options.label;
 
     self.getData = function($widget) {
       // our data is our markup

--- a/lib/modules/apostrophe-rich-text-widgets/public/js/editor.js
+++ b/lib/modules/apostrophe-rich-text-widgets/public/js/editor.js
@@ -69,7 +69,7 @@ apos.define('apostrophe-rich-text-editor', {
           },
           ckeditorInstanceReady: function(ck) {
             ck.editor.a2Area = self;
-            ck.editor.$a2Item = self.$richText.closest('[data-widget]');
+            ck.editor.$a2Item = self.$richText.closest('[data-apos-widget]');
             ck.editor.removeMenuItem('tablecellproperties');
           }
         }

--- a/lib/modules/apostrophe-rich-text-widgets/public/js/user.js
+++ b/lib/modules/apostrophe-rich-text-widgets/public/js/user.js
@@ -1,10 +1,23 @@
 apos.define('apostrophe-rich-text-widgets', {
   construct: function(self, options) {
 
+    self.edit = function(data, options, save) {
+      data = data || {};
+      if (!data._id) {
+        data._id = apos.utils.generateId();
+      }
+      if (!data.content) {
+        data.content = '';
+      }
+      return save(data, function(err, $widget) {
+        self.startEditing($widget);
+      });
+    };
+
     // does not use a modal, start and stop editing
     // contextually via ckeditor instead
-
     self.startEditing = function($widget) {
+      $widget.removeClass('apos-empty');
       if ($widget.data('editor')) {
         $widget.data('editor').start();
         return;

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -221,7 +221,7 @@ apos.define('apostrophe-schemas', {
     };
 
     self.contextualConvertArea = function(data, name, $el, field) {
-      var editor = $el.findSafe('[data-area][data-dot-path$="' + name + '"]', '[data-area]').data('editor');
+      var editor = $el.findSafe('[data-apos-area][data-dot-path$="' + name + '"]', '[data-apos-area]').data('editor');
       if (editor) {
         data[name] = {
           type: 'area',
@@ -273,7 +273,7 @@ apos.define('apostrophe-schemas', {
     self.getArea = function($el, name) {
       var $fieldset = self.findFieldset($el, name);
       var $property = self.findSafe($fieldset, '[data-' + name + '-edit-view]');
-      return $property.find('[data-area]:first').data('editor').serialize();
+      return $property.find('[data-apos-area]:first').data('editor').serialize();
     };
 
     self.addFieldType = function(type) {

--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -322,10 +322,7 @@ module.exports = {
       if (_.has(self.envs, name)) {
         return self.envs[name];
       }
-
-      dirs = self.getViewFolders(module);
-
-      self.envs[name] = self.newEnv(name, dirs);
+      self.envs[name] = self.newEnv(name, self.getViewFolders(module));
       return self.envs[name];
     };
 

--- a/lib/modules/apostrophe-ui/public/js/ui.js
+++ b/lib/modules/apostrophe-ui/public/js/ui.js
@@ -156,6 +156,7 @@ apos.define('apostrophe-ui', {
 
       setTimeout(function() {
         if (!$bar.hasClass('apos-admin-bar--clicked')) {
+          $bar.css('overflow', '');
           $bar.removeClass('apos-active');
         }
       }, 3000);

--- a/lib/modules/apostrophe-ui/public/js/ui.js
+++ b/lib/modules/apostrophe-ui/public/js/ui.js
@@ -138,16 +138,15 @@ apos.define('apostrophe-ui', {
       $bar.css('overflow', 'visible');
 
       // on transitionend, turn overflow on so we can see dropdowns!
-      $bar.find('[data-apos-admin-bar-items]').on('transitionend', function() {
+      $bar.find('[data-apos-admin-bar-items]').on('transitionend webkitTransitionEnd oTransitionEnd', function() {
         if ($bar.hasClass('apos-active')) {
           $bar.css('overflow', 'visible');
-        } else {
-          $bar.css('overflow', '');
         }
       });
 
-      // when we collapse the menu, turn all dropdowns off
-      $bar.find('[data-apos-admin-bar-logo]').on('click', function(){
+      // when we collapse the menu, turn all dropdowns off. Don't show overflow while transitioning
+      $bar.find('[data-apos-admin-bar-logo]').on('click', function() {
+        $bar.css('overflow', '');
         $bar.find('[data-apos-dropdown]').removeClass('apos-active');
       });
 

--- a/lib/modules/apostrophe-widgets/index.js
+++ b/lib/modules/apostrophe-widgets/index.js
@@ -8,33 +8,12 @@ module.exports = {
     if (!self.options.label) {
       throw new Error('You must specify the label option when subclassing apostrophe-widgets');
     }
-
     self.label = self.options.label;
-
     self.name = self.options.name || self.__meta.name.replace(/\-widgets$/, '');
     self.apos.areas.setWidgetManager(self.name, self);
 
-    self.pushAsset('script', 'always', { when: 'always' });
-
-    self.pushAsset('script', 'user', { when: 'user' });
-
-    self.pushAsset('script', 'editor', { when: 'user' });
-
-    self.apos.push.browserMirrorCall('always', self);
-
-    self.apos.push.browserCall('always', 'apos.define(?, ?)',
-      self.__meta.name,
-      {
-        name: self.name,
-        label: self.label,
-        action: self.action,
-        schema: self.schema,
-        contextualOnly: self.options.contextualOnly
-      }
-    );
-
-    self.apos.push.browserCall('always', 'apos.create(?, {})',
-      self.__meta.name);
+    self.pushAssets();
+    self.pushCreateSingleton();
   },
 
   construct: function(self, options) {
@@ -101,6 +80,29 @@ module.exports = {
 
     self.filterForDataAttribute = function(widget) {
       return self.apos.utils.clonePermanent(widget);
+    };
+
+    self.pushAssets = function() {
+      self.pushAsset('script', 'always', { when: 'always' });
+      self.pushAsset('script', 'user', { when: 'user' });
+      self.pushAsset('script', 'editor', { when: 'user' });
+    };
+
+    self.pushCreateSingleton = function() {
+      self.apos.push.browserMirrorCall('always', self);
+
+      self.apos.push.browserCall('always', 'apos.define(?, ?)',
+        self.__meta.name,
+        {
+          name: self.name,
+          label: self.label,
+          action: self.action,
+          schema: self.schema,
+          contextualOnly: self.options.contextualOnly
+        }
+      );
+
+      self.apos.push.browserCall('always', 'apos.create(?, {})', self.__meta.name);
     };
 
     self.route('post', 'modal', function(req, res) {

--- a/lib/modules/apostrophe-widgets/public/js/user.js
+++ b/lib/modules/apostrophe-widgets/public/js/user.js
@@ -1,10 +1,10 @@
 apos.define('apostrophe-widgets', {
+  // Implicitly extends the definition in always.js
 
   afterConstruct: function(self) {
 
     // Define our editor subclass if it hasn't been
     // done explicitly. Also pass it options
-
     apos.define(self.editorName,
       {
         extendIfFirst: 'apostrophe-widget-editor',
@@ -19,19 +19,20 @@ apos.define('apostrophe-widgets', {
   construct: function(self, options) {
 
     self.options = options;
-
     self.editorName = self.name + '-widget-editor';
 
+    // Opens the editor modal of a widget, unless the widget is contextualOnly,
+    // in which case we simply save the widget and call the save method
     self.edit = function(data, options, save) {
-      //Only create a modal editor if the schema is not contextual only - Sam & Tom
+      // Only create a modal editor if the schema is not contextual only
       if(self.options.contextualOnly){
-        //check for id or create one
+        // Check for an id or assign a generated one
         data = data || {};
         if (!data._id) {
           data._id = apos.utils.generateId();
         }
-        //invoke save on the object
-        return save(data, function(){});
+        // Save the new widget
+        return save(data, function() {});
       } else {
         apos.create(self.editorName, {
           action: self.options.action,


### PR DESCRIPTION
Several sizable chunks here:

- Refactor the rest of the rich text widget out of `apostrophe-areas`. `apostrophe-rich-text-widgets` now subclasses and fully obeys the contract specified by `apostrophe-widgets`.
- Add in contextual 'Add Content' insertion menus, so now you can add content between two existing widgets instead of perpetually at the top of an area. Some work around styling this appropriately as well.
- Attempt at namespacing all `data-area`, `data-widgets`, and `data-widget` to `data-apos-area`, `data-apos-widgets`, and `data-apos-widget` respectively.
- Remove all lockup logic. Eventually, we'll reimplement lockups as a nested area within rich text widgets, which is a much more elegant solution than in 0.5.

@boutell cc @mcoppola @colpanik 