### PR TITLE
Add more robust logic to composeFilters and composeColumns methods in…

### DIFF
--- a/lib/modules/apostrophe-docs/index.js
+++ b/lib/modules/apostrophe-docs/index.js
@@ -9,8 +9,7 @@ module.exports = {
     return async.series([ self.enableCollection, self.ensureIndexes ], callback);
   },
 
-  construct: function(self, options) {
-
+  beforeConstruct: function(self, options) {
     options.addFields = [
       {
         type: 'string',
@@ -48,6 +47,9 @@ module.exports = {
         def: false
       }
     ].concat(options.addFields || []);
+  },
+
+  construct: function(self, options) {
 
     self.schema = self.apos.schemas.compose(options);
 

--- a/lib/modules/apostrophe-groups/index.js
+++ b/lib/modules/apostrophe-groups/index.js
@@ -5,7 +5,6 @@ module.exports = {
   name: 'apostrophe-group',
   label: 'Group',
   pluralLabel: 'Groups',
-  removeFields: [ 'published' ],
   addFields: [
     {
       type: 'joinByArrayReverse',
@@ -18,6 +17,12 @@ module.exports = {
   ],
 
   construct: function(self, options) {
+
+    options.removeFields = (self.options.minimumRemoved || [ 'published' ])
+      .concat(options.removeFields || []);
+
+    options.removeFilters = [ 'published' ]
+      .concat(options.removeFilters || []);
 
     // Since groups are never piublished,
     // if you are deliberately fetching groups,

--- a/lib/modules/apostrophe-groups/index.js
+++ b/lib/modules/apostrophe-groups/index.js
@@ -16,18 +16,18 @@ module.exports = {
     }
   ],
 
-  construct: function(self, options) {
-
-    options.removeFields = (self.options.minimumRemoved || [ 'published' ])
+  beforeConstruct: function(self, options) {
+    options.removeFields = (options.minimumRemoved || [ 'published' ])
       .concat(options.removeFields || []);
 
     options.removeFilters = [ 'published' ]
       .concat(options.removeFilters || []);
+  },
 
-    // Since groups are never piublished,
+  construct: function(self, options) {
+    // Since groups are never published,
     // if you are deliberately fetching groups,
     // we assume you don't care if they are published.
-
     var superFind = self.find;
     self.find = function(req, criteria, projection){
       return superFind(req, criteria, projection).published(null);

--- a/lib/modules/apostrophe-pieces/index.js
+++ b/lib/modules/apostrophe-pieces/index.js
@@ -9,7 +9,6 @@ module.exports = {
     self.composeSchema();
     self.composeFilters();
     self.composeColumns();
-    self.composeSorts();
     // inherit some useful methods from the default manager for our doc type,
     // if we never bothered to override them
     self.manager = self.apos.docs.getManager(self.options.name);
@@ -48,7 +47,7 @@ module.exports = {
       ].concat(options.addFields || []);
     }
 
-    self.defaultColumns = [
+    options.defaultColumns = options.defaultColumns || [
       {
         name: 'title',
         label: 'Title'
@@ -70,7 +69,7 @@ module.exports = {
     ];
 
     if (self.contextual) {
-      self.defaultColumns.push({
+      options.defaultColumns.push({
         name: '_url',
         label: 'Link',
         partial: function(value) {
@@ -79,25 +78,7 @@ module.exports = {
       })
     }
 
-    options.addColumns = self.defaultColumns.concat(options.addColumns || []);
-
-    options.addSorts = [
-      {
-        name: 'updatedAt',
-        label: 'By Last Change (Newest to Oldest)',
-        sort: { updatedAt: -1 }
-      },
-      {
-        name: 'title',
-        label: 'By Title (A-Z)',
-        sort: { title: 1 }
-      },
-      {
-        name: 'updatedAtReverse',
-        label: 'By Last Change (Oldest to Newest)',
-        sort: { updatedAt: 1 }
-      }
-    ].concat(options.addSorts || []);
+    options.addColumns = options.defaultColumns.concat(options.addColumns || []);
 
     options.addFilters = [
       {

--- a/lib/modules/apostrophe-pieces/index.js
+++ b/lib/modules/apostrophe-pieces/index.js
@@ -20,19 +20,7 @@ module.exports = {
     self.createRoutes();
   },
 
-  construct: function(self, options) {
-    if (!options.name) {
-      throw new Error('apostrophe-pieces require name option');
-    }
-    if (!options.label) {
-      throw new Error('apostrophe-pieces require label option');
-    }
-    options.pluralLabel = options.pluralLabel || options.label + 's';
-
-    self.name = options.name;
-    self.label = options.label;
-    self.pluralLabel = options.pluralLabel;
-    self.manageViews = options.manageViews;
+  beforeConstruct: function(self, options) {
     self.contextual = options.contextual;
 
     if (self.contextual) {
@@ -114,6 +102,21 @@ module.exports = {
         def: false
       }
     ].concat(options.addFilters || []);
+  },
+
+  construct: function(self, options) {
+    if (!options.name) {
+      throw new Error('apostrophe-pieces require name option');
+    }
+    if (!options.label) {
+      throw new Error('apostrophe-pieces require label option');
+    }
+    options.pluralLabel = options.pluralLabel || options.label + 's';
+
+    self.name = options.name;
+    self.label = options.label;
+    self.pluralLabel = options.pluralLabel;
+    self.manageViews = options.manageViews;
 
     require('./lib/routes.js')(self, options);
     require('./lib/api.js')(self, options);

--- a/lib/modules/apostrophe-pieces/lib/api.js
+++ b/lib/modules/apostrophe-pieces/lib/api.js
@@ -225,18 +225,49 @@ module.exports = function(self, options) {
   };
 
   self.composeFilters = function() {
-    // in the future we can add the entire add/remove/order/alter stack
-    self.filters = self.options.filters || self.options.addFilters;
+    self.filters = options.filters || [];
+    if (options.addFilters) {
+      _.each(options.addFilters, function(filter) {
+        var i;
+        // remove it from the filters if we've already added it, last one wins
+        for (i = 0; (i < self.filters.length); i++) {
+          if (self.filters[i].name === filter.name) {
+            self.filters.splice(i, 1);
+            break;
+          }
+        }
+        // add the new field to the filters
+        self.filters.push(filter);
+      });
+    }
+    if (options.removeFilters) {
+      self.filters = _.filter(self.filters, function(filter) {
+        return !_.contains(options.removeFilters, filter.name);
+      });
+    }
   };
 
   self.composeColumns = function() {
-    // in the future we can add the entire add/remove/order/alter stack
-    self.columns = self.options.columns || self.options.addColumns;
-  };
-
-  self.composeSorts = function() {
-    // in the future we can add the entire add/remove/order/alter stack
-    self.sorts = self.options.sorts || self.options.addSorts;
+    self.columns = options.columns || [];
+    if (options.addColumns) {
+      _.each(options.addColumns, function(column) {
+        var i;
+        // remove it from the columns if we've already added it, last one wins
+        for (i = 0; (i < self.columns.length); i++) {
+          if (self.columns[i].name === column.name) {
+            self.columns.splice(i, 1);
+            break;
+          }
+        }
+        // add the new field to the columns
+        self.columns.push(column);
+      });
+    }
+    if (options.removeColumns) {
+      self.columns = _.filter(self.columns, function(column) {
+        return !_.contains(options.removeColumns, column.name);
+      });
+    }
   };
 
 };

--- a/lib/modules/apostrophe-pieces/lib/api.js
+++ b/lib/modules/apostrophe-pieces/lib/api.js
@@ -225,19 +225,15 @@ module.exports = function(self, options) {
   };
 
   self.composeFilters = function() {
-    self.filters = options.filters || [];
+    self.filters = _.cloneDeep(options.filters) || [];
     if (options.addFilters) {
-      _.each(options.addFilters, function(filter) {
-        var i;
+      _.each(options.addFilters, function(newFilter) {
         // remove it from the filters if we've already added it, last one wins
-        for (i = 0; (i < self.filters.length); i++) {
-          if (self.filters[i].name === filter.name) {
-            self.filters.splice(i, 1);
-            break;
-          }
-        }
+        self.filters = _.filter(self.filters, function(filter) {
+          return filter.name !== newFilter.name;
+        });
         // add the new field to the filters
-        self.filters.push(filter);
+        self.filters.push(newFilter);
       });
     }
     if (options.removeFilters) {
@@ -248,19 +244,15 @@ module.exports = function(self, options) {
   };
 
   self.composeColumns = function() {
-    self.columns = options.columns || [];
+    self.columns = _.cloneDeep(options.columns) || [];
     if (options.addColumns) {
-      _.each(options.addColumns, function(column) {
-        var i;
+      _.each(options.addColumns, function(newColumn) {
         // remove it from the columns if we've already added it, last one wins
-        for (i = 0; (i < self.columns.length); i++) {
-          if (self.columns[i].name === column.name) {
-            self.columns.splice(i, 1);
-            break;
-          }
-        }
+        self.columns = _.filter(self.columns, function(column) {
+          return column.name !== newColumn.name;
+        });
         // add the new field to the columns
-        self.columns.push(column);
+        self.columns.push(newColumn);
       });
     }
     if (options.removeColumns) {

--- a/lib/modules/apostrophe-pieces/lib/api.js
+++ b/lib/modules/apostrophe-pieces/lib/api.js
@@ -225,7 +225,7 @@ module.exports = function(self, options) {
   };
 
   self.composeFilters = function() {
-    self.filters = _.cloneDeep(options.filters) || [];
+    self.filters = options.filters || [];
     if (options.addFilters) {
       _.each(options.addFilters, function(newFilter) {
         // remove it from the filters if we've already added it, last one wins
@@ -244,7 +244,7 @@ module.exports = function(self, options) {
   };
 
   self.composeColumns = function() {
-    self.columns = _.cloneDeep(options.columns) || [];
+    self.columns = options.columns || [];
     if (options.addColumns) {
       _.each(options.addColumns, function(newColumn) {
         // remove it from the columns if we've already added it, last one wins

--- a/lib/modules/apostrophe-pieces/lib/browser.js
+++ b/lib/modules/apostrophe-pieces/lib/browser.js
@@ -29,7 +29,6 @@ module.exports = function(self, options) {
     options.browser.schema = self.schema;
     options.browser.filters = self.filters;
     options.browser.columns = self.columns;
-    options.browser.sorts = self.sorts;
     options.browser.contextual = self.contextual;
     self.apos.push.browserCall('user', 'apos.create(?, ?)', self.__meta.name, self.options.browser);
   };

--- a/lib/modules/apostrophe-pieces/views/manageFilters.html
+++ b/lib/modules/apostrophe-pieces/views/manageFilters.html
@@ -1,13 +1,3 @@
 {%- import "piecesMacros.html" as pieces with context -%}
 
 {{ pieces.filters(data.filters, cursor) }}
-
-{# Tabel headers will become the sort buttons. -matt c #}
-
-{#<div class="apos-select-wrapper apos-inline-input apos-manage-sorts">
-  <select name="sort" data-selectize>
-    {% for sort in data.sorts %}
-      <option value="{{ sort.sort | jsonAttribute }}" label="{{ __(sort.label) }}"{%- if sort.name == data.sort -%} selected{%- endif -%}>{{ __(sort.label) }}</option>
-    {% endfor %}
-  </select>
-</div>#}

--- a/lib/modules/apostrophe-users/index.js
+++ b/lib/modules/apostrophe-users/index.js
@@ -20,8 +20,11 @@ module.exports = {
 
   construct: function(self, options) {
 
-    options.removeFields = (self.options.minimumRemoved || [ 'published' ])
+    options.removeFields = (options.defaultRemoveFields || [ 'published' ])
       .concat(options.removeFields || []);
+
+    options.removeFilters = (options.defaultRemoveFilters || [ 'published' ])
+      .concat(options.removeFilters || []);
 
     options.addFields = [
       {

--- a/lib/modules/apostrophe-users/index.js
+++ b/lib/modules/apostrophe-users/index.js
@@ -18,13 +18,7 @@ module.exports = {
     ], callback);
   },
 
-  construct: function(self, options) {
-
-    options.removeFields = (options.defaultRemoveFields || [ 'published' ])
-      .concat(options.removeFields || []);
-
-    options.removeFilters = (options.defaultRemoveFilters || [ 'published' ])
-      .concat(options.removeFilters || []);
+  beforeConstruct: function(self, options) {
 
     options.addFields = [
       {
@@ -129,6 +123,16 @@ module.exports = {
         }
       ]);
     }
+
+    options.removeFields = (options.defaultRemoveFields || [ 'published' ])
+      .concat(options.removeFields || []);
+
+    options.removeFilters = (options.defaultRemoveFilters || [ 'published' ])
+      .concat(options.removeFilters || []);
+
+  },
+
+  construct: function(self, options) {
 
     self.ensureSafe = function(callback) {
       return async.series([


### PR DESCRIPTION
… pieces. Use this logic to remove the published filter from users and groups by default, since we remove that field.