### PR TITLE
Allow for slugs to have an optional prefix in their schema, which aut…

### DIFF
--- a/lib/modules/apostrophe-images/index.js
+++ b/lib/modules/apostrophe-images/index.js
@@ -7,6 +7,13 @@ module.exports = {
   manageViews: ['grid', 'list'],
   addFields: [
     {
+      type: 'slug',
+      name: 'slug',
+      label: 'Slug',
+      prefix: 'image',
+      required: true
+    },
+    {
       type: 'attachment',
       name: 'attachment',
       label: 'Image File',

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -57,7 +57,9 @@ apos.define('apostrophe-schemas', {
           var $title = self.findField($el, 'title');
           var $slug = self.findField($el, 'slug');
 
-
+          if (slug.prefix) {
+            $slug.data('prefix', slug.prefix);
+          }
 
           self.enableSlug($title, $slug);
         }
@@ -410,13 +412,13 @@ apos.define('apostrophe-schemas', {
       var currentSlug = $slug.val();
       var components = currentSlug.split('/');
       var currentSlugTitle = components.pop();
-
-      if ((originalTitle === '') || (currentSlugTitle === apos.utils.slugify(originalTitle))) {
-        $title.on('keyup', function(e) {
-          var title = $title.val();
-          if (title !== originalTitle) {
-            $slug.val($slug.val().replace(/[^\/]*$/, apos.utils.slugify(title)));
-          }
+      var prefix = '';
+      if ($slug.data('prefix')) {
+        prefix = $slug.data('prefix') + '-';
+      }
+      if ((originalTitle === '') || (currentSlugTitle === apos.utils.slugify(prefix + originalTitle))) {
+        $title.on('change keyup paste', function(e) {
+          $slug.val($slug.val().replace(/[^\/]*$/, apos.utils.slugify(prefix + $title.val())));
         });
       }
     };

--- a/lib/modules/apostrophe-users/index.js
+++ b/lib/modules/apostrophe-users/index.js
@@ -37,6 +37,13 @@ module.exports = {
         label: 'Title'
       },
       {
+        type: 'slug',
+        name: 'slug',
+        label: 'Slug',
+        prefix: 'user',
+        required: true
+      },
+      {
         type: 'boolean',
         name: 'disabled',
         label: 'Login Disabled',


### PR DESCRIPTION
…opopulates the slug with the specified prefix on the frontend but can ultimately be overidden by the user. Resolves #499 