### PR TITLE
Fix singleton limits

### DIFF
--- a/lib/modules/apostrophe-areas/lib/helpers.js
+++ b/lib/modules/apostrophe-areas/lib/helpers.js
@@ -8,8 +8,6 @@ module.exports = function(self, options) {
       var options;
 
       if (arguments.length === 1) {
-        // TODO fix this api, now that singletons are a special case of area
-        options = _.defaults(doc, options);
         options = doc;
         area = options.area;
       } else {
@@ -27,10 +25,12 @@ module.exports = function(self, options) {
         }
       }
 
-      // Need to make the widget definition options configured the same
-      // way as in areas to support drag n drop.
-      options.widgets = {};
-      options.widgets[options.type] = _options || {};
+      if (!options.widgets) {
+        // Need to make the widget definition options configured the same
+        // way as in areas to support drag n drop.
+        options.widgets = {};
+        options.widgets[options.type] = _options || {};
+      }
 
       // var widget = self.findSingletonWidget(options.area, options.type);
 

--- a/lib/modules/apostrophe-docs/public/js/chooser.js
+++ b/lib/modules/apostrophe-docs/public/js/chooser.js
@@ -230,10 +230,13 @@ apos.define('apostrophe-docs-chooser', {
       });
     };
     self.onChange = function() {
+      console.log('onChange');
       if (self.limit && self.choices.length >= self.limit) {
+        console.log('FULL');
         self.$el.addClass('apos-chooser-full');
         self.$autocomplete.prop('disabled', true);
       } else {
+        console.log('NOT FULL');
         self.$el.removeClass('apos-chooser-full');
         self.$autocomplete.prop('disabled', false);
       }

--- a/lib/modules/apostrophe-docs/public/js/chooser.js
+++ b/lib/modules/apostrophe-docs/public/js/chooser.js
@@ -73,14 +73,19 @@ apos.define('apostrophe-docs-chooser', {
       return setImmediate(callback);
     };
     self.add = function(_id) {
+      if (self.choices.length >= self.limit) {
+        return false;
+      }
       self.choices.push({ value: _id });
       self.refresh();
+      return true;
     };
     self.remove = function(_id) {
       self.choices = _.filter(self.choices, function(choice) {
         return choice.value !== _id;
       });
-      return self.refresh();
+      self.refresh();
+      return true;
     }
     self.refreshing = 0;
     self.last = [];
@@ -230,13 +235,10 @@ apos.define('apostrophe-docs-chooser', {
       });
     };
     self.onChange = function() {
-      console.log('onChange');
       if (self.limit && self.choices.length >= self.limit) {
-        console.log('FULL');
         self.$el.addClass('apos-chooser-full');
         self.$autocomplete.prop('disabled', true);
       } else {
-        console.log('NOT FULL');
         self.$el.removeClass('apos-chooser-full');
         self.$autocomplete.prop('disabled', false);
       }
@@ -289,13 +291,20 @@ apos.define('apostrophe-docs-chooser', {
       };
 
       manager.enableCheckboxEventsForChooser = function() {
-        manager.$el.on('change', '[data-piece] input[type="checkbox"]', function() {
+        manager.$el.on('change', '[data-piece] input[type="checkbox"]', function(e) {
           // in rare circumstances, might not be ready yet, don't crash
           if (!manager.chooser) {
             return;
           }
-          var method = $(this).prop('checked') ? manager.chooser.add : manager.chooser.remove;
-          method($(this).closest('[data-piece]').attr('data-piece'));
+          var $box = $(this);
+          var method = $box.prop('checked') ? manager.chooser.add : manager.chooser.remove;
+          if (!method($box.closest('[data-piece]').attr('data-piece'))) {
+            // If the operation could not be completed, change back the state
+            // of the checkbox.
+            $box.prop('checked', function(index, value) {
+              return !value;
+            });
+          }
         });
       };
 

--- a/lib/modules/apostrophe-images-widgets/public/js/editor.js
+++ b/lib/modules/apostrophe-images-widgets/public/js/editor.js
@@ -10,6 +10,7 @@ apos.define('apostrophe-images-widgets-editor', {
         hints: {}
       });
       _.defaults(join.hints, {
+        limit: options.templateOptions.limit,
         minSize: options.templateOptions.minSize,
         aspectRatio: options.templateOptions.aspectRatio
       });

--- a/lib/modules/apostrophe-images/public/css/grid-item.less
+++ b/lib/modules/apostrophe-images/public/css/grid-item.less
@@ -1,6 +1,7 @@
 // grid item
 .apos-ui .apos-manage-grid-view
-.apos-manage-grid-piece {
+.apos-manage-grid-piece
+{
   position: relative;
   .apos-inline-block(top);
 
@@ -10,12 +11,14 @@
   width: 100%;
   box-shadow: 0 2px 8px 0 rgba(21,22,22,0.0);
 
-  .apos-manage-grid-select{
+  .apos-manage-grid-select
+  {
     .apos-inline-block(top);
   }
 
   // thumbnail
-  .apos-manage-grid-image{
+  .apos-manage-grid-image
+  {
     position: relative;
     width: 100%;
     height: auto;
@@ -37,7 +40,8 @@
     }
   }
   // label
-  .apos-manage-grid-piece-label{
+  .apos-manage-grid-piece-label
+  {
     display: block;
     padding: @apos-padding-2 @apos-padding-2;
     padding-left: 28px;  // room for checkbox

--- a/lib/modules/apostrophe-images/public/css/grid-view.less
+++ b/lib/modules/apostrophe-images/public/css/grid-view.less
@@ -1,7 +1,10 @@
 // grid view
-.apos-ui .apos-manage-grid-view {
+.apos-ui .apos-manage-grid-view
+{
   position: relative;
 
+  height: 100%;
+  overflow-y: scroll;
   width: 82.5%;
   left: 17.5%; // account for sidebar
   padding-left: 1em;

--- a/lib/modules/apostrophe-images/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-images/public/js/manager-modal.js
@@ -11,9 +11,13 @@ apos.define('apostrophe-images-manager-modal', {
     var superEnableButtonEvents = self.enableButtonEvents;
     self.enableButtonEvents = function() {
       // focus on single click
-      self.$el.on('click', '[data-focus-' + options.name + '], input[type="checkbox"]', function(e) {
+      self.$el.on('click', '[data-focus-' + options.name + ']', function(e) {
         e.preventDefault();
         self.focusElement( $(this) );
+      });
+
+      self.$el.on('afterChange', 'input[type="checkbox"]', function(e) {
+        $(this).parent('label').toggleClass('apos-focus', $(this).prop('checked'))
       });
 
       // edit on dobule click
@@ -26,13 +30,15 @@ apos.define('apostrophe-images-manager-modal', {
       superEnableButtonEvents();
     };
 
-    self.focusElement = function($focusedElm) {
-      $focusedElm.toggleClass('apos-focus');
+    self.focusElement = function($el) {
+      $el.toggleClass('apos-focus');
 
       // set checkbox to :checked, and trigger change event
-      var checkbox = $focusedElm.find('input[type="checkbox"]');
-      checkbox.prop('checked', function(i, currentState) { return !currentState; });
-      checkbox.trigger('change');
+      var $checkbox = $el.find('input[type="checkbox"]');
+      $checkbox.prop('checked', function(i, currentState) { return !currentState; });
+      $checkbox.trigger('change');
+      $el.toggleClass('apos-focus', $checkbox.prop('checked'))
+      // $checkbox.trigger('afterChange');
     };
 
 

--- a/lib/modules/apostrophe-pieces/public/css/chooser.less
+++ b/lib/modules/apostrophe-pieces/public/css/chooser.less
@@ -13,7 +13,8 @@
   {
     .apos-inline-block;
     float: left;
-    min-height: 100%;
+    height: 100%;
+    overflow-y: scroll;
     width: 25%;
     background-color: @apos-light;
   }

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -238,6 +238,7 @@ apos.define('apostrophe-schemas', {
       }
       // Singletons are essentially areas with a limit of 1 and only one type
       // of widget permitted.
+      var options = {};
       options.type = type;
       options.widgets = {};
       options.widgets[options.type] = _options;


### PR DESCRIPTION
This should resolve #518 , along with an issue where the manager/chooser modal wasn't really enforcing limits properly. There is still an issue where the chosen selection isn't reflected in checkboxes on populate, this is due to a bug between the actual checkbox element (which is hidden) and the green box that user's actually interact with, and the fact that one doesn't always reflect the state of the other. One of those cases where two-way data-binding would be handy.