### PR TITLE
implemented attachment helpers such as apos.images.first, apos.attach…

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -6,6 +6,7 @@ module.exports = {
     'apostrophe-i18n': {},
     'apostrophe-db': {},
     'apostrophe-caches': {},
+    'apostrophe-migrations': {},
     'apostrophe-express': {},
     'apostrophe-push': {},
     'apostrophe-urls': {},

--- a/lib/modules/apostrophe-attachments/index.js
+++ b/lib/modules/apostrophe-attachments/index.js
@@ -23,6 +23,7 @@ module.exports = {
       self.pushAssets();
       self.pushCreateSingleton();
       self.enableHelpers();
+      self.addTypeMigration();
       return callback(null);
     });
   },
@@ -110,10 +111,8 @@ module.exports = {
     };
 
     self.enableHelpers = function() {
-      self.addHelpers({
-        url: self.url
-      });
-    }
+      self.addHelpers(_.pick(self, 'url', 'findImage', 'findImages', 'findOne', 'find'));
+    };
 
     require('./lib/schemaField')(self, options);
     require('./lib/api')(self, options);

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -230,6 +230,8 @@ module.exports = function(self, options) {
     })
   };
 
+  // This method is available as a template helper: apos.attachments.url
+  //
   // Given a file object (as found in a slideshow widget for instance),
   // return the file URL. If options.size is set, return the URL for
   // that size (one-third, one-half, two-thirds, full). full is
@@ -257,6 +259,121 @@ module.exports = function(self, options) {
     return path + '.' + file.extension;
   };
 
+  // This method is available as a template helper: apos.attachments.first
+  //
+  // Find the first attachment referenced within any object with
+  // attachments as possible properties or sub-properties.
+  //
+  // For best performance be reasonably specific; don't pass an entire page or piece
+  // object if you can pass page.thumbnail to avoid an exhaustive search, especially
+  // if the page has many joins.
+  //
+  // Returns the first attachment matching the criteria.
+  //
+  // For ease of use, a null or undefined `within` argument is accepted.
+  //
+  // Examples:
+  //
+  // 1. In the body please
+  //
+  // apos.attachments.first(page.body)
+  //
+  // 2. Must be a PDF
+  //
+  // apos.attachments.first(page.body, { extension: 'pdf' })
+  //
+  // 3. May be any office-oriented file type
+  //
+  // apos.attachments.first(page.body, { group: 'office' })
+  //
+  // apos.images.first is a convenience wrapper for fetching only images.
+  //
+  // OPTIONS:
+  //
+  // You may specify `extension`, `extensions` (an array of extensions)
+  // or `group` to filter the results.
+
+  self.first = function(within, options) {
+    options = options ? _.clone(options) : {};
+    options.limit = 1;
+    return self.all(within, options)[0];
+  };
+
+  // This method is available as a template helper: apos.attachments.all
+  //
+  // Find all attachments referenced within an object, whether they are
+  // properties or sub-properties (via joins, etc).
+  //
+  // For best performance be reasonably specific; don't pass an entire page or piece
+  // object if you can pass piece.thumbnail to avoid an exhaustive search, especially
+  // if the piece has many joins.
+  //
+  // Returns an array of attachments, or an empty array if none are found.
+  //
+  // For ease of use, a null or undefined `within` argument is accepted.
+  //
+  // Examples:
+  //
+  // 1. In the body please
+  //
+  // apos.attachments.all(page.body)
+  //
+  // 2. Must be a PDF
+  //
+  // apos.attachments.all(page.body, { extension: 'pdf' })
+  //
+  // 3. May be any office-oriented file type
+  //
+  // apos.attachments.all(page.body, { group: 'office' })
+  //
+  // apos.images.all is a convenience wrapper for fetching only images.
+  //
+  // OPTIONS:
+  //
+  // You may specify `extension`, `extensions` (an array of extensions)
+  // or `group` to filter the results.
+
+  self.all = function(within, options) {
+    options = options || {};
+
+    function test(attachment) {
+      if ((!attachment) || (typeof(attachment) !== 'object')) {
+        return false;
+      }
+      if (attachment.type !== 'attachment') {
+        return false;
+      }
+      if (options.extension) {
+        if (attachment.extension !== options.extension) {
+          return false;
+        }
+      }
+      if (options.group) {
+        if (attachment.group !== options.group) {
+          return false;
+        }
+      }
+      if (options.extensions) {
+        if (!_.contains(options.extensions, attachment.extension)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    var winners = [];
+    if (!within) {
+      return [];
+    }
+    var i, j;
+    self.apos.docs.walk(within, function(o, key, value) {
+      if (test(value)) {
+        winners.push(value);
+      }
+    });
+    return winners;
+  };
+
   self.middleware = {
     canUpload: function(req, res, next) {
       if (!self.apos.permissions.can(req, 'upload-attachment')) {
@@ -266,4 +383,56 @@ module.exports = function(self, options) {
       next();
     }
   };
+
+  self.addTypeMigration = function() {
+
+    self.apos.migrations.add(self.__meta.name + '.addType', function(callback) {
+
+      var needed;
+
+      return async.series([ needed, attachments, docs ], callback);
+
+      function needed(callback) {
+        return self.db.findOne({ type: { $exists: 0 } }, function(err, found) {
+          if (err) {
+            return callback(err);
+          }
+          needed = !!found;
+          return callback(null);
+        });
+      }
+
+      function attachments(callback) {
+        if (!needed) {
+          return setImmediate(callback);
+        }
+        return self.db.update({}, { $set: { type: 'attachment' } }, { multi: true }, callback);
+      }
+
+      function docs(callback) {
+        if (!needed) {
+          return setImmediate(callback);
+        }
+        return self.apos.migrations.eachDoc({}, function(doc, callback) {
+          var changed = false;
+          self.apos.docs.walk(doc, function(o, key, value) {
+            // Sniff out attachments in a database that predates the
+            // type property for them
+            if (value && (typeof(value) === 'object') && value.extension && value.md5 && value.group && value._id && value.group) {
+              value.type = 'attachment';
+              changed = true;
+            }
+          });
+          if (!changed) {
+            return setImmediate(callback);
+          }
+          self.apos.docs.db.update({ _id: doc._id }, doc, callback);
+        }, callback);
+      }
+    }, {
+      safe: true
+    });
+
+  };
+
 }

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -365,7 +365,6 @@ module.exports = function(self, options) {
     if (!within) {
       return [];
     }
-    var i, j;
     self.apos.docs.walk(within, function(o, key, value) {
       if (test(value)) {
         winners.push(value);

--- a/lib/modules/apostrophe-docs/lib/api.js
+++ b/lib/modules/apostrophe-docs/lib/api.js
@@ -309,8 +309,9 @@ module.exports = function(self, options) {
   // deletes properties.
   //
   // The second argument must be a function that takes
-  // an object, a key, a value and a "dot path" an
-  // returns true if that property should be discarded.
+  // an object, a key, a value and a "dot path" and
+  // returns `false` if that property should be discarded.
+  // If any other value is returned the property remains.
   //
   // Remember, keys can be numbers; toString() is
   // your friend.
@@ -319,9 +320,10 @@ module.exports = function(self, options) {
   //
   // { a: { b: 5 } }
   //
-  // Then when the callback is invoked for b, the key
-  // will be `b` and the dotPath will be the string
-  // `a.b`.
+  // Then when the callback is invoked for b, the
+  // object will be { b: 5 }, the key
+  // will be `b`, the value will be `5` and the dotPath
+  // will be the string `a.b`.
   //
   // You do not need to pass the `_dotPath` argument.
   // That argument is used for recursive invocation.

--- a/lib/modules/apostrophe-images/index.js
+++ b/lib/modules/apostrophe-images/index.js
@@ -44,5 +44,6 @@ module.exports = {
     self.pushAsset('script', 'editor-modal', { when: 'user' });
     self.pushAsset('stylesheet', 'user', { when: 'user' });
     require('./lib/api.js')(self, options);
+    self.enableHelpers();
   }
 };

--- a/lib/modules/apostrophe-images/lib/api.js
+++ b/lib/modules/apostrophe-images/lib/api.js
@@ -10,4 +10,85 @@ module.exports = function(self, options) {
     return cursor;
   };
 
+  // This method is available as a template helper: apos.images.first
+  //
+  // Find the first image attachment referenced within an object that may have attachments
+  // as properties or sub-properties.
+  //
+  // For best performance be reasonably specific; don't pass an entire page or piece
+  // object if you can pass page.thumbnail to avoid an exhaustive search, especially
+  // if the page has many joins.
+  //
+  // For ease of use, a null or undefined `within` argument is accepted.
+  //
+  // Note that this method doesn't actually care if the attachment is part of
+  // an `apostrophe-images` piece or not. It simply checks whether the `group`
+  // property is set to `images`.
+  //
+  // Examples:
+  //
+  // 1. First image in the body area please
+  //
+  // apos.images.first(page.body)
+  //
+  // 2. Must be a GIF
+  //
+  // apos.images.first(page.body, { extension: 'gif' })
+  //
+  // (Note Apostrophe always uses .jpg for JPEGs.)
+  //
+  // OPTIONS:
+  //
+  // You may specify `extension` or `extensions` (an array of extensions)
+  // to filter the results.
+
+  self.first = function(within, options) {
+    options = options ? _.clone(options) : {};
+    options.group = 'images';
+    var result = self.apos.attachments.first(within, options);
+    return result;
+  };
+
+  // This method is available as a template helper: apos.images.all
+  //
+  // Find all image attachments referenced within an object that may have attachments
+  // as properties or sub-properties.
+  //
+  // For best performance be reasonably specific; don't pass an entire page or piece
+  // object if you can pass page.thumbnail to avoid an exhaustive search, especially
+  // if the page has many joins.
+  //
+  // For ease of use, a null or undefined `within` argument is accepted.
+  //
+  // Note that this method doesn't actually care if the attachment is part of
+  // an `apostrophe-images` piece or not. It simply checks whether the `group`
+  // property is set to `images`.
+  //
+  // Examples:
+  //
+  // 1. All images in the body area please
+  //
+  // apos.images.all(page.body)
+  //
+  // 2. Must be GIFs
+  //
+  // apos.images.all(page.body, { extension: 'gif' })
+  //
+  // (Note Apostrophe always uses .jpg for JPEGs.)
+  //
+  // OPTIONS:
+  //
+  // You may specify `extension` or `extensions` (an array of extensions)
+  // to filter the results.
+
+  self.all = function(within, options) {
+    options = options ? _.clone(options) : {};
+    options.group = 'images';
+    return self.apos.attachments.all(within, options);
+  };
+
+  self.enableHelpers = function() {
+    self.addHelpers(_.pick(self, 'first', 'all'));
+  };
+
 };

--- a/lib/modules/apostrophe-migrations/index.js
+++ b/lib/modules/apostrophe-migrations/index.js
@@ -1,0 +1,14 @@
+module.exports = {
+
+  alias: 'migrations',
+
+  afterConstruct: function(self) {
+    self.enableCache();
+    self.addMigrationTask();
+  },
+
+  construct: function(self, options) {
+    require('./lib/api.js')(self, options);
+    require('./lib/implementation.js')(self, options);
+  }
+};

--- a/lib/modules/apostrophe-migrations/lib/api.js
+++ b/lib/modules/apostrophe-migrations/lib/api.js
@@ -27,7 +27,6 @@ module.exports = function(self, options) {
   // THIS API IS FOR MIGRATION AND TASK USE ONLY AND HAS NO SECURITY.
 
   self.eachDoc = function(criteria, limit, iterator, callback) {
-    console.log(arguments);
     if (arguments.length === 3) {
       callback = iterator;
       iterator = limit;
@@ -62,7 +61,6 @@ module.exports = function(self, options) {
     //
     // https://groups.google.com/forum/#!topic/mongodb-user/AFC1ia7MHzk
 
-    console.log(criteria);
     var cursor = collection.find(criteria);
     cursor.sort({ _id: 1 });
     return broadband(cursor, limit, iterator, callback);

--- a/lib/modules/apostrophe-migrations/lib/api.js
+++ b/lib/modules/apostrophe-migrations/lib/api.js
@@ -1,0 +1,70 @@
+var broadband = require('broadband');
+
+module.exports = function(self, options) {
+
+  // Add a migration callback to be invoked when the apostrophe-migrations:migrate task is invoked. As an optimization,
+  // the callback MIGHT not be invoked if it has been invoked before, but your callback MUST be idempotent (it must not
+  // behave badly if the migration has been run before).
+  //
+  // The options argument may be omitted. If options.safe is true, this migration will still be run when the
+  // --safe option is passed to the task. ONLY SET THIS OPTION IF THE CALLBACK HAS NO NEGATIVE IMPACT ON A RUNNING,
+  // LIVE SITE. But if you can mark a migration safe, do it, because it minimizes downtime when deploying.
+
+  self.add = function(name, callback, options) {
+    if (!options) {
+      options = {};
+    }
+    self.migrations.push({ name: name, options: options, callback: callback });
+  };
+
+  // Invoke the iterator function once for each doc in the aposDocs collection.
+  // If only three arguments are given, `limit` is assumed to be 1 (only one
+  // doc may be processed at a time).
+  //
+  // This method will never visit the same doc twice in a single call, even if
+  // modifications are made.
+  //
+  // THIS API IS FOR MIGRATION AND TASK USE ONLY AND HAS NO SECURITY.
+
+  self.eachDoc = function(criteria, limit, iterator, callback) {
+    console.log(arguments);
+    if (arguments.length === 3) {
+      callback = iterator;
+      iterator = limit;
+      limit = 1;
+    }
+    return self.each(self.apos.docs.db, criteria, limit, iterator, callback);
+  };
+
+  // Invoke the iterator function once for each document in the given collection.
+  // If only three arguments are given, `limit` is assumed to be 1 (only one
+  // doc may be processed at a time).
+  //
+  // This method will never visit the same document twice in a single call, even if
+  // modifications are made.
+  //
+  // THIS API IS FOR MIGRATION AND TASK USE ONLY AND HAS NO SECURITY.
+
+  self.each = function(collection, criteria, limit, iterator, callback) {
+    if (arguments.length === 4) {
+      callback = iterator;
+      iterator = limit;
+      limit = 1;
+    }
+
+    // Sort by _id. This ensures that no document is
+    // ever visited twice, even if we modify documents as
+    // we go along.
+    //
+    // Otherwise there can be unexpected results from find()
+    // in typical migrations as the changes we make can
+    // affect the remainder of the query.
+    //
+    // https://groups.google.com/forum/#!topic/mongodb-user/AFC1ia7MHzk
+
+    console.log(criteria);
+    var cursor = collection.find(criteria);
+    cursor.sort({ _id: 1 });
+    return broadband(cursor, limit, iterator, callback);
+  };
+};

--- a/lib/modules/apostrophe-migrations/lib/implementation.js
+++ b/lib/modules/apostrophe-migrations/lib/implementation.js
@@ -1,0 +1,45 @@
+var async = require('async');
+
+module.exports = function(self, options) {
+
+  self.migrations = [];
+
+  self.enableCache = function() {
+    self.cache = self.apos.caches.get(self.__meta.name);
+  };
+
+  self.addMigrationTask = function() {
+    self.apos.tasks.add(self.__meta.name, 'migrate', 'Apply any necessary migrations to the database.', self.migrationTask);
+  };
+
+  self.migrationTask = function(apos, argv, callback) {
+    return async.eachSeries(self.migrations, function(migration, callback) {
+      if (self.apos.argv.safe && (!migration.options.safe)) {
+        return setImmediate(callback);
+      }
+      return self.runOne(migration, function(err) {
+        return callback(err);
+      });
+    }, callback);
+  };
+
+  self.runOne = function(migration, callback) {
+    return self.cache.get(migration.name, function(err, info) {
+      if (err) {
+        return callback(err);
+      }
+      if (info) {
+        // We don't need to run it again
+        return callback(null);
+      }
+      console.log('Running database migration: ' + migration.name);
+      return migration.callback(function(err) {
+        if (err) {
+          console.error(err);
+          return callback(err);
+        }
+        return self.cache.set(migration.name, true, callback);
+      });
+    });
+  };
+};

--- a/lib/modules/apostrophe-versions/lib/api.js
+++ b/lib/modules/apostrophe-versions/lib/api.js
@@ -236,9 +236,6 @@ module.exports = function(self, options) {
   // schema arrays. version2 is assumed to be the
   // newer version. The doc is examined to determine what
   // schema to use.
-  //
-  // This method is asynchronous and will likely take better
-  // advantage of that fact later.
 
   self.compare = function(req, doc, version1, version2, callback) {
     var manager = self.apos.docs.getManager(doc.type);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "async": "^1.0.0",
     "bless": "^3.0.3",
     "body-parser": "^1.12.0",
+    "broadband": "^0.1.1",
     "clean-css": "^3.0.9",
     "connect-flash": "^0.1.1",
     "connect-mongo": "0.8.x",


### PR DESCRIPTION
…ments.all. Also implemented migrations as we needed a type: "attachment" property on attachments to do this efficiently. All existing projects need to add apostrophe-migrations:migrate back into deployment/dependencies and deployment/migrate (in dependencies it needs the --safe flag).