### PR TITLE
Resolves "info" tab appearing in editors without fields (#515)

### DIFF
--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -200,7 +200,7 @@ module.exports = {
         if (!field.group) {
           field.group = { name: 'default', label: 'info' };
         }
-        if (groups.length == 0 || groups[currentGroup].name !== field.group.name) {
+        if (groups.length == 0 || (groups[currentGroup].name !== field.group.name && !field.contextual)) {
           groups.push({
             type: 'group',
             name: field.group.name,


### PR DESCRIPTION
fixes bug where contextual fields such as trash were causing info schema tab to display without any fields