### PR TITLE
Push project-level configured assets to push at modulesReady instead …

### DIFF
--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -25,8 +25,6 @@ module.exports = {
     });
 
     self.pushDefaults();
-
-    self.pushConfigured();
   },
 
   construct: function(self, options) {
@@ -698,6 +696,12 @@ module.exports = {
       _.each(self.templates || [], function(item) {
         self.pushAsset('template', item.name, item);
       });
+    };
+
+    self.modulesReady = function() {
+      // Push project-level configured assets last, to make it easier to
+      // override Apostrophe-level styles
+      self.pushConfigured();
     };
 
     self.pushConfigured = function() {


### PR DESCRIPTION
…of apostrophe-assets afterConstruct.

@boutell @mcoppola 

This should make it much easier to override admin styles at project level, since a lot of the admin styles are defined in `apostrophe-ui`, which inits after `apostrophe-assets.