### PR TITLE
If there is a defaultElement set in the options of apostrophe-rich-te…

### DIFF
--- a/lib/modules/apostrophe-rich-text-widgets/public/js/editor.js
+++ b/lib/modules/apostrophe-rich-text-widgets/public/js/editor.js
@@ -36,6 +36,12 @@ apos.define('apostrophe-rich-text-widgets-editor', {
 
       self.toolbar = self.options.toolbar || [];
 
+      if (self.options.defaultElement) {
+        self.defaultElement = self.options.defaultElement;
+      } else if (self.styles.length) {
+        self.defaultElement = self.styles[0].element;
+      }
+
       // This will allow loading of extra plugins for each editor
       var extraPlugins = [ 'split' ];
       // Additional standard plugins can be configured
@@ -103,7 +109,8 @@ apos.define('apostrophe-rich-text-widgets-editor', {
         // And without the call to focus() people have to double click for no
         // apparent reason
         if (self.$richText.html() === "" || self.$richText.html() === ' ') {
-          self.$richText.html('<div>&nbsp;</div>');
+          var emptyState = '<' + self.defaultElement || 'div' + '>&nbsp;</' + self.defaultElement || 'div' + '>';
+          self.$richText.html(emptyState);
         }
         self.ckeditorInstance.focus();
         self.$richText.data('aposRichTextState', 'started');


### PR DESCRIPTION
…xt-widgets, use that instead of an empty div. If that's not set, use the first of the styles array instead of an empty div. If that's also not set, then go ahead and use the empty div. Trying to resolve #251 

@stuartromanek Assigning this to you since it is originally your issue. The `font_style` option in ckeditor didn't appear to work for this, but changing the markup we inject appears to make ckeditor automatically select a style.