### PR TITLE
Fix an issue where, in certain cases, moving a page ahead of another …

### DIFF
--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -206,7 +206,7 @@ module.exports = function(self, options) {
     function nudgeNewPeers(callback) {
       // Nudge down the pages that should now follow us
       // Always remember multi: true
-      self.apos.docs.db.update({ path: new RegExp('^' + self.apos.utils.regExpQuote(addSlashIfNeeded(parent.path))), level: parent.level + 1, rank: { $gt: rank } }, { $inc: { rank: 1 } }, { multi: true }, function(err, count) {
+      self.apos.docs.db.update({ path: new RegExp('^' + self.apos.utils.regExpQuote(addSlashIfNeeded(parent.path))), level: parent.level + 1, rank: { $gte: rank } }, { $inc: { rank: 1 } }, { multi: true }, function(err, count) {
         return callback(err);
       });
     }


### PR DESCRIPTION
…page in the reorganize menu wouldn't nudge all the pages to a unique rank. Resolves #552

Just changed a `$gt` to a `$gte` here, because otherwise, if you move a page to a new rank that collides with the one immediately succeeding it, it doesn't nudge that page that it is colliding with.

I'm not too familiar with this logic though, so let me know if you see any issue with this @boutell 