### PR TITLE
Added filters and search to chooser modal view, which needed to be in…

### DIFF
--- a/lib/modules/apostrophe-docs/public/js/chooser.js
+++ b/lib/modules/apostrophe-docs/public/js/chooser.js
@@ -357,7 +357,7 @@ apos.define('apostrophe-docs-chooser', {
       manager.beforeList = function(listOptions) {
         // The `limit` hint would break normal pagination in the manage view; the
         // chooser handles that one on its own. -Tom
-        _.extend(listOptions, _.omit(self.field.hints, 'limit'));
+        _.extend(listOptions, _.omit(self.field.hints, 'limit'), { chooser: true });
       };
 
       manager.afterRefresh = function() {

--- a/lib/modules/apostrophe-modal/public/css/components/modal-filters.less
+++ b/lib/modules/apostrophe-modal/public/css/components/modal-filters.less
@@ -1,5 +1,5 @@
-.apos-ui.apos-modal
-.apos-modal-header .apos-modal-filters
+.apos-ui.apos-modal .apos-modal-header .apos-modal-filters,
+.apos-ui.apos-modal .apos-modal-body .apos-modal-filters
 {
 	margin-top: @apos-margin-2;
 
@@ -16,7 +16,9 @@
 		.apos-pill
 		{
 			margin-right: @apos-margin-2;
+			margin-bottom: @apos-margin-1;
 		}
+		margin-bottom: -@apos-margin-1;
 	}
 
 	.apos-modal-filters-search
@@ -36,5 +38,14 @@
 			font-size: 14px;
 			line-height: 14px;
 		}
+	}
+}
+
+.apos-ui.apos-modal .apos-modal-body .apos-modal-filters .apos-modal-filters-toggles
+{
+	.apos-pill
+	{
+		margin-right: 0;
+		margin-left: @apos-margin-2;
 	}
 }

--- a/lib/modules/apostrophe-modal/public/css/components/modal-result-label.less
+++ b/lib/modules/apostrophe-modal/public/css/components/modal-result-label.less
@@ -5,12 +5,13 @@
 //
 // ===============================================================
 
-.apos-ui.apos-modal
-.apos-manage-result-label
+.apos-ui.apos-modal .apos-manage-result-label
 {
-	padding: 20px 0;
-	font-family: 'Karla', 'Helvetica', sans-serif;
-  font-size: 28px;
-  line-height: 38px;
+	padding: @apos-padding-1 0;
+	font-family: "Roboto", "Helvetica", sans-serif;
+  font-weight: 500;
+  font-size: 18px;
+  line-height: 28px;
+  letter-spacing: 1px;
   color: @apos-dark;
 }

--- a/lib/modules/apostrophe-pieces/index.js
+++ b/lib/modules/apostrophe-pieces/index.js
@@ -85,6 +85,7 @@ module.exports = {
             label: 'Both'
           }
         ],
+        allowedInChooser: false,
         def: true
       },
       {
@@ -99,6 +100,7 @@ module.exports = {
             label: 'Trash'
           }
         ],
+        allowedInChooser: false,
         def: false
       }
     ].concat(options.addFilters || []);

--- a/lib/modules/apostrophe-pieces/lib/routes.js
+++ b/lib/modules/apostrophe-pieces/lib/routes.js
@@ -96,7 +96,13 @@ module.exports = function(self, options) {
         results.options.pluralLabel = self.pluralLabel;
         results.options.manageViews = self.options.manageViews;
         results.schema = self.schema;
-        results.filters = { options: self.filters, choices: filters || {}, q: filters.search };
+        results.filters = {
+          options: filters.chooser ? _.filter(self.filters, function(item) {
+            return item.allowedInChooser !== false;
+          }) : self.filters,
+          choices: filters,
+          q: filters.search
+        };
         results.columns = self.columns;
         results.sorts = self.sorts;
         var actualSort = results.cursor.get('sort');

--- a/lib/modules/apostrophe-pieces/public/css/chooser.less
+++ b/lib/modules/apostrophe-pieces/public/css/chooser.less
@@ -1,7 +1,7 @@
 .apos-ui
 {
 
-  .apos-manage-view--chooser
+  .apos-chooser-manage-view-wrapper
   {
     .apos-inline-block;
     float: left;

--- a/lib/modules/apostrophe-pieces/views/chooserModalBase.html
+++ b/lib/modules/apostrophe-pieces/views/chooserModalBase.html
@@ -21,7 +21,10 @@
 
 {%- block body -%}
   <div class="apos-chooser" data-chooser></div>
-  <div class="apos-manage-view apos-manage-view--chooser" data-apos-manage-view>
-    {# ajax populates me with either the grid view or the table view #}
+  <div class="apos-chooser-manage-view-wrapper">
+    <div class="apos-manage-view-filters apos-modal-filters" data-filters></div>
+    <div class="apos-manage-view apos-manage-view--chooser" data-apos-manage-view>
+      {# ajax populates me with either the grid view or the table view #}
+    </div>
   </div>
 {%- endblock -%}

--- a/lib/modules/apostrophe-pieces/views/manageFilters.html
+++ b/lib/modules/apostrophe-pieces/views/manageFilters.html
@@ -1,3 +1,2 @@
 {%- import "piecesMacros.html" as pieces with context -%}
-
-{{ pieces.filters(data.filters, cursor) }}
+{{ pieces.filters(data.filters) }}


### PR DESCRIPTION
… the manage-view body because of it being a slideable modal. Made style tweaks accordingly. Also added a `allowedInChooser` option to filters, which, if explicitly set to false, doesn't display that filter in choosers (for filters like trashed and published, which shouldn't be used when joining)

Ref #500 

@boutell 