### PR TITLE
Add onbeforeunload handler added on modal creation, removed on modal …

### DIFF
--- a/lib/modules/apostrophe-modal/public/js/modal.js
+++ b/lib/modules/apostrophe-modal/public/js/modal.js
@@ -192,6 +192,11 @@ apos.define('apostrophe-modal', {
       self.$el.on('aposModalHide', function() {
         self.getLastSlide().hide();
       });
+      window.onbeforeunload = function() {
+        if (self.unsavedChanges) {
+          return self.getBeforeUnloadText();
+        }
+      };
     };
 
     // Return the last slide or the modal itself if it has no nested slides.
@@ -437,6 +442,11 @@ apos.define('apostrophe-modal', {
       return callback();
     };
 
+    self.getBeforeUnloadText = function() {
+      return "You are about to discard unsaved changes to this "
+        + (options.label ? options.label.toLowerCase() : 'item') + '.';
+    };
+
     self.getConfirmCancelText = function() {
       return 'Are you sure you want to discard unsaved changes to this '
         + (options.label ? options.label.toLowerCase() : 'item') + '?';
@@ -477,6 +487,7 @@ apos.define('apostrophe-modal', {
             };
             apos.modalSupport.closeTopModal();
           }
+          window.onbeforeunload = null;
           if (callback) {
             return callback();
           }


### PR DESCRIPTION
…cancel. If there are unsaved changes, proc a confirm cancel on page unload.

We talked about this one, @boutell, let me know if it looks good. I verified that I get rid of the event when the modal is cancelled.