### PR TITLE
Fix an issue where schemas were not correctly blessing widgets within…

### DIFF
--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -658,9 +658,11 @@ module.exports = {
         return self.apos.areas.isEmpty({ area: area });
       },
       bless: function(req, field) {
-        _.each(field.widgets || {}, function(options, type) {
-          self.apos.utils.bless(req, options, 'widget', type);
-        });
+        if (field.options && field.options.widgets) {
+          _.each(field.options.widgets || {}, function(options, type) {
+            self.apos.utils.bless(req, options, 'widget', type);
+          });
+        }
       }
     });
 


### PR DESCRIPTION
… an area. Instead of looking for the list of available widgets in field.options.widgets, it was looking in field.widgets,

which isn't where that configuration lives. This would cause modals with areas present in them to throw unblessed errors (though seemingly not consistently, which is strange. Perhaps those widgets did eventually get blessed properly after trying to load the modal?). This might resolve #511

@mcoppola Could you check this out and make sure it works in Science Center? I'm not sure if you had any existing cases that were still giving you unblessed errors.

cc @boutell 