### PR TITLE
cursors are now fully moog-powered. Rather than overriding find() you…

### DIFF
--- a/lib/modules/apostrophe-docs/lib/api.js
+++ b/lib/modules/apostrophe-docs/lib/api.js
@@ -77,11 +77,7 @@ module.exports = function(self, options) {
     if ((!req) || (!req.res)) {
       throw new Error("I think you forgot to pass req as the first argument to find()!");
     }
-    var cursor = self.apos.create('apostrophe-cursor', { docs: self });
-    cursor.set('req', req);
-    cursor.set('criteria', criteria);
-    cursor.set('projection', projection);
-    return cursor;
+    return self.apos.create('apostrophe-cursor', { apos: self.apos, req: req, criteria: criteria, projection: projection });
   };
 
   // Insert the given document. If the slug is not

--- a/lib/modules/apostrophe-docs/lib/cursor.js
+++ b/lib/modules/apostrophe-docs/lib/cursor.js
@@ -20,9 +20,12 @@ module.exports = {
 
   beforeConstruct: function(self, options) {
     self.options = options;
-    self.apos = options.docs.apos;
-    self.docs = options.docs;
-    self.db = options.docs.db;
+    self.apos = options.apos;
+    self.db = self.apos.docs.db;
+  },
+
+  afterConstruct: function(self) {
+    self.handleFindArguments();
   },
 
   construct: function(self, options) {
@@ -680,6 +683,20 @@ module.exports = {
     };
 
     // Protected API of cursors (for extending cursors).
+
+    // Invoked by afterConstruct to handle the arguments that came
+    // from the find() call responsible for creating this cursor
+    self.handleFindArguments = function() {
+      if (self.options.req) {
+        self.set('req', self.options.req);
+      }
+      if (self.options.criteria) {
+        self.set('criteria', self.options.criteria);
+      }
+      if (self.options.projection) {
+        self.set('projection', self.options.projection);
+      }
+    };
 
     // Filters and any other methods you add should
     // store their state with this method rather than

--- a/lib/modules/apostrophe-groups/index.js
+++ b/lib/modules/apostrophe-groups/index.js
@@ -25,16 +25,7 @@ module.exports = {
   },
 
   construct: function(self, options) {
-    // Since groups are never published,
-    // if you are deliberately fetching groups,
-    // we assume you don't care if they are published.
-    var superFind = self.find;
-    self.find = function(req, criteria, projection){
-      return superFind(req, criteria, projection).published(null);
-    };
-
-
-
+    self.apos.define('apostrophe-groups-cursor', require('./lib/cursor.js'));
   }
 
 }

--- a/lib/modules/apostrophe-groups/lib/cursor.js
+++ b/lib/modules/apostrophe-groups/lib/cursor.js
@@ -1,0 +1,9 @@
+module.exports = {
+  extend: 'apostrophe-pieces-cursor',
+  construct: function(self, options) {
+    // It is normal for groups to be unpublished (a backend feature only), so cursors
+    // for groups shouldn't be picky by default
+    self.published(null);
+  }
+};
+

--- a/lib/modules/apostrophe-groups/lib/cursor.js
+++ b/lib/modules/apostrophe-groups/lib/cursor.js
@@ -1,6 +1,6 @@
 module.exports = {
   extend: 'apostrophe-pieces-cursor',
-  construct: function(self, options) {
+  afterConstruct: function(self) {
     // It is normal for groups to be unpublished (a backend feature only), so cursors
     // for groups shouldn't be picky by default
     self.published(null);

--- a/lib/modules/apostrophe-images/index.js
+++ b/lib/modules/apostrophe-images/index.js
@@ -44,6 +44,7 @@ module.exports = {
     self.pushAsset('script', 'editor-modal', { when: 'user' });
     self.pushAsset('stylesheet', 'user', { when: 'user' });
     require('./lib/api.js')(self, options);
+    self.apos.define('apostrophe-images-cursor', require('./lib/cursor.js'));
     self.enableHelpers();
   }
 };

--- a/lib/modules/apostrophe-images/lib/api.js
+++ b/lib/modules/apostrophe-images/lib/api.js
@@ -3,13 +3,6 @@ var _ = require('lodash');
 
 module.exports = function(self, options) {
 
-  var superFind = self.find;
-  self.find = function(req, criteria, projection) {
-    var cursor = superFind(req, criteria, projection);
-    require('./cursor.js')(self, cursor);
-    return cursor;
-  };
-
   // This method is available as a template helper: apos.images.first
   //
   // Find the first image attachment referenced within an object that may have attachments

--- a/lib/modules/apostrophe-images/lib/cursor.js
+++ b/lib/modules/apostrophe-images/lib/cursor.js
@@ -1,60 +1,32 @@
-module.exports = function(self, cursor) {
+module.exports = {
 
-  cursor.addFilter('minSize', {
-    finalize: function() {
-      var minSize = cursor.get('minSize');
-      if (!minSize) {
-        return;
-      }
-      var criteria = {};
-      criteria['attachment.width'] = { $gte: minSize[0] };
-      criteria['attachment.height'] = { $gte: minSize[1] };
-      cursor.and(criteria);
-    },
-    safeFor: 'public',
-    launder: function(a) {
-      if (!Array.isArray(a)) {
-        return undefined;
-      }
-      if (a.length !== 2) {
-        return undefined;
-      }
-      return [ self.apos.launder.integer(a[0]), self.apos.launder.integer(a[1]) ];
-    }
-  });
+  extend: 'apostrophe-pieces-cursor',
 
-  // This is more hint than filter. It shouldn't affect the db query. -Tom
-  // cursor.addFilter('aspectRatio', {
-  //   finalize: function() {
-  //     var aspectRatio = cursor.get('aspectRatio');
-  //     try {
-  //       aspectRatio = aspectRatio[0] / aspectRatio[1];
-  //     } catch (e) {
-  //       // Bad denominator, ignore
-  //       return;
-  //     }
-  //     var criteria = {};
-  //     criteria['attachment.aspectRatio'] = aspectRatio;
-  //     self.and(criteria);
-  //   },
-  //   safeFor: 'public',
-  //   launder: function(a) {
-  //     if (!Array.isArray(a)) {
-  //       return undefined;
-  //     }
-  //     if (a.length !== 2) {
-  //       return undefined;
-  //     }
-  //     var numerator = self.apos.launder.integer(a[0]);
-  //     var denominator = self.apos.launder.integer(a[1]);
-  //     if (numerator <= 0) {
-  //       return undefined;
-  //     }
-  //     if (denominator <= 0) {
-  //       return undefined;
-  //     }
-  //     return [ numerator, denominator ];
-  //   }
-  // });
+  construct: function(self, options) {
+
+    self.addFilter('minSize', {
+      finalize: function() {
+        var minSize = self.get('minSize');
+        if (!minSize) {
+          return;
+        }
+        var criteria = {};
+        criteria['attachment.width'] = { $gte: minSize[0] };
+        criteria['attachment.height'] = { $gte: minSize[1] };
+        self.and(criteria);
+      },
+      safeFor: 'public',
+      launder: function(a) {
+        if (!Array.isArray(a)) {
+          return undefined;
+        }
+        if (a.length !== 2) {
+          return undefined;
+        }
+        return [ self.apos.launder.integer(a[0]), self.apos.launder.integer(a[1]) ];
+      }
+    });
+
+  }
 
 };

--- a/lib/modules/apostrophe-pages/index.js
+++ b/lib/modules/apostrophe-pages/index.js
@@ -90,6 +90,9 @@ module.exports = {
     // merge new methods with all apostrophe-cursors
     self.apos.define('apostrophe-cursor', require('./lib/anyCursor.js'));
 
+    // Add methods to cursors used specifically to fetch pages only
+    self.apos.define('apostrophe-pages-cursor', require('./lib/pagesCursor.js'));
+
     // Wait until the last possible moment to add
     // the wildcard route for serving pages, so that
     // other routes are not blocked

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -8,10 +8,12 @@ module.exports = function(self, options) {
   // including ancestors, descendants, etc.
 
   self.find = function(req, criteria, projection) {
-    var cursor = self.apos.docs.find(req, criteria, projection);
-    // Add filters meant for fetching pages only
-    require('./pagesCursor.js')(self, cursor);
-    return cursor;
+    return self.apos.create(self.__meta.name + '-cursor', {
+      apos: self.apos,
+      req: req,
+      criteria: criteria,
+      projection: projection
+    });
   };
 
   // Insert a page as a child of the specified page or page ID.

--- a/lib/modules/apostrophe-pages/lib/pagesCursor.js
+++ b/lib/modules/apostrophe-pages/lib/pagesCursor.js
@@ -1,188 +1,192 @@
 var async = require('async');
 var _ = require('lodash');
 
-module.exports = function(self, cursor) {
+module.exports = {
 
-  // With docs in general it doesn't make sense to show unpublished docs most
-  // of the time, however with pages it makes sense to show them as long as the
-  // user has permission, which is checked for separately
-  cursor.filters.published.def = null;
+  extend: 'apostrophe-cursor',
 
-  // When calling self.pages.find our expectation is that we will only get pages,
-  // not docs that are not a part of the page tree
-  cursor.addFilter('isPage', {
-    def: true,
-    finalize: function() {
-      var state = cursor.get('isPage');
-      if (state) {
-        cursor.and({
-          slug: /^\//
-        });
+  construct: function(self, options) {
+
+    // With docs in general it doesn't make sense to show unpublished docs most
+    // of the time, however with pages it makes sense to show them as long as the
+    // user has permission, which is checked for separately
+    self.filters.published.def = null;
+
+    // When calling self.pages.find our expectation is that we will only get pages,
+    // not docs that are not a part of the page tree
+    self.addFilter('isPage', {
+      def: true,
+      finalize: function() {
+        var state = self.get('isPage');
+        if (state) {
+          self.and({
+            slug: /^\//
+          });
+        }
       }
-    }
-  });
+    });
 
-  cursor.addFilter('ancestors', {
-    def: false,
-    after: function(results, callback) {
-      var options = cursor.get('ancestors');
+    self.addFilter('ancestors', {
+      def: false,
+      after: function(results, callback) {
+        var options = self.get('ancestors');
 
-      if (!options) {
-        return setImmediate(callback);
-      }
-
-      return async.eachSeries(results, function(page, callback) {
-        var req = cursor.get('req');
-
-        var aCursor = self.find(req).areas(false);
-
-        var parameters = applySubcursorOptions(aCursor, options, [ 'depth' ]);
-
-        var components = page.path.split('/');
-        var paths = [];
-        var path = '';
-        _.each(components, function(component) {
-          path += component;
-          // Special case: the path of the homepage
-          // is /, not an empty string
-          var queryPath = path;
-          if (queryPath === '') {
-            queryPath = '/';
-          }
-          // Don't redundantly load ourselves
-          if (queryPath === page.path) {
-            return;
-          }
-          paths.push(queryPath);
-          path += '/';
-        });
-
-        if (parameters.depth !== undefined) {
-          paths = paths.slice(- parameters.depth);
+        if (!options) {
+          return setImmediate(callback);
         }
 
-        aCursor.and({
-          path: { $in: paths }
+        return async.eachSeries(results, function(page, callback) {
+          var req = self.get('req');
+
+          var aCursor = self.apos.pages.find(req).areas(false);
+
+          var parameters = applySubcursorOptions(aCursor, options, [ 'depth' ]);
+
+          var components = page.path.split('/');
+          var paths = [];
+          var path = '';
+          _.each(components, function(component) {
+            path += component;
+            // Special case: the path of the homepage
+            // is /, not an empty string
+            var queryPath = path;
+            if (queryPath === '') {
+              queryPath = '/';
+            }
+            // Don't redundantly load ourselves
+            if (queryPath === page.path) {
+              return;
+            }
+            paths.push(queryPath);
+            path += '/';
+          });
+
+          if (parameters.depth !== undefined) {
+            paths = paths.slice(- parameters.depth);
+          }
+
+          aCursor.and({
+            path: { $in: paths }
+          });
+
+          aCursor.sort({ path: 1 });
+
+          return aCursor.toArray(function(err, _ancestors) {
+            if (err) {
+              return callback(err);
+            }
+            page._ancestors = _ancestors;
+            return callback(null);
+          });
+        }, callback);
+      }
+    });
+
+    self.addFilter('children', {
+      def: false,
+      after: function(results, callback) {
+        var value = self.get('children');
+        if (!value) {
+          return setImmediate(callback);
+        }
+
+        var cCursor = self.apos.pages.find(self.get('req')).areas(false);
+
+        var parameters = applySubcursorOptions(cCursor, value, [ 'depth' ]);
+
+        var depth = parameters.depth;
+        // Careful, let them specify a depth of 0 but still have a good default
+        if (depth === undefined) {
+          depth = 1;
+        }
+        if (!depth) {
+          return setImmediate(callback);
+        }
+
+        var clauses = [];
+
+        _.each(results, function(page) {
+          clauses.push({
+            $and: [
+              {
+                path: new RegExp('^' + self.apos.utils.regExpQuote(self.apos.utils.addSlashIfNeeded(page.path))),
+                level: { $gt: page.level, $lte: page.level + depth }
+              }
+            ]
+          });
         });
 
-        aCursor.sort({ path: 1 });
+        // Because mongo is incredibly stubborn in
+        // that awful mysql way now
+        if (clauses.length) {
+          cCursor.and({ $or: clauses });
+        } else {
+          cCursor.and({ ___neverEverDefined: true });
+        }
 
-        return aCursor.toArray(function(err, _ancestors) {
+        cCursor.sort({ level: 1, rank: 1 });
+
+        var pagesByPath = {};
+        _.each(results, function(page) {
+          pagesByPath[page.path] = page;
+          page._children = [];
+        });
+
+        return cCursor.toArray(function(err, descendants) {
           if (err) {
             return callback(err);
           }
-          page._ancestors = _ancestors;
+
+          try {
+            _.each(descendants, function(page) {
+              if (!_.has(pagesByPath, page.path)) {
+                page._children = [];
+                pagesByPath[page.path] = page;
+              }
+              var last = page.path.lastIndexOf('/');
+              var parentPath = page.path.substr(0, last);
+              if (parentPath === '') {
+                parentPath = '/';
+              }
+              if (pagesByPath[parentPath]) {
+                pagesByPath[parentPath]._children.push(page);
+              } else {
+                throw new Error('internal inconsistency in children()');
+              }
+            });
+          } catch (e) {
+            return callback(e);
+          }
           return callback(null);
         });
-      }, callback);
-    }
-  });
-
-  cursor.addFilter('children', {
-    def: false,
-    after: function(results, callback) {
-      var value = cursor.get('children');
-      if (!value) {
-        return setImmediate(callback);
       }
+    });
 
-      var cCursor = self.find(cursor.get('req')).areas(false);
+    // Use .reorganize(true) to return only pages that
+    // are suitable for display in the reorganize view.
+    // For instance, if you have thousands of subpages
+    // of a "blog" page, you might want to hide them from
+    // the global reorganize interface by setting their
+    // reorganize property to false. —Tom and Sam
 
-      var parameters = applySubcursorOptions(cCursor, value, [ 'depth' ]);
-
-      var depth = parameters.depth;
-      // Careful, let them specify a depth of 0 but still have a good default
-      if (depth === undefined) {
-        depth = 1;
-      }
-      if (!depth) {
-        return setImmediate(callback);
-      }
-
-      var clauses = [];
-
-      _.each(results, function(page) {
-        clauses.push({
-          $and: [
-            {
-              path: new RegExp('^' + self.apos.utils.regExpQuote(self.apos.utils.addSlashIfNeeded(page.path))),
-              level: { $gt: page.level, $lte: page.level + depth }
-            }
-          ]
-        });
-      });
-
-      // Because mongo is incredibly stubborn in
-      // that awful mysql way now
-      if (clauses.length) {
-        cCursor.and({ $or: clauses });
-      } else {
-        cCursor.and({ ___neverEverDefined: true });
-      }
-
-      cCursor.sort({ level: 1, rank: 1 });
-
-      var pagesByPath = {};
-      _.each(results, function(page) {
-        pagesByPath[page.path] = page;
-        page._children = [];
-      });
-
-      return cCursor.toArray(function(err, descendants) {
-        if (err) {
-          return callback(err);
-        }
-
-        try {
-          _.each(descendants, function(page) {
-            if (!_.has(pagesByPath, page.path)) {
-              page._children = [];
-              pagesByPath[page.path] = page;
-            }
-            var last = page.path.lastIndexOf('/');
-            var parentPath = page.path.substr(0, last);
-            if (parentPath === '') {
-              parentPath = '/';
-            }
-            if (pagesByPath[parentPath]) {
-              pagesByPath[parentPath]._children.push(page);
-            } else {
-              throw new Error('internal inconsistency in children()');
-            }
+    self.addFilter('reorganize', {
+      def: null,
+      finalize: function() {
+        var state = self.get('reorganize');
+        if (state === null) {
+          return;
+        } else if (state === true) {
+          self.and({
+            reorganize: { $ne: false }
           });
-        } catch (e) {
-          return callback(e);
+        } else if (state === false) {
+          self.and({
+            reorganize: false
+          });
         }
-        return callback(null);
-      });
-    }
-  });
-
-  // Use .reorganize(true) to return only pages that
-  // are suitable for display in the reorganize view.
-  // For instance, if you have thousands of subpages
-  // of a "blog" page, you might want to hide them from
-  // the global reorganize interface by setting their
-  // reorganize property to false. —Tom and Sam
-
-  cursor.addFilter('reorganize', {
-    def: null,
-    finalize: function() {
-      var state = cursor.get('reorganize');
-      if (state === null) {
-        return;
-      } else if (state === true) {
-        cursor.and({
-          reorganize: { $ne: false }
-        });
-      } else if (state === false) {
-        cursor.and({
-          reorganize: false
-        });
       }
-    }
-  });
-
+    });
+  }
 };
 
 function applySubcursorOptions(aCursor, options, ours) {

--- a/lib/modules/apostrophe-pieces/index.js
+++ b/lib/modules/apostrophe-pieces/index.js
@@ -133,6 +133,13 @@ module.exports = {
     self.choiceTemplate = self.__meta.name + ':chooserChoice.html';
     self.choicesTemplate = self.__meta.name + ':chooserChoices.html';
     self.relationshipTemplate = self.__meta.name + ':relationshipEditor.html';
+
+    // Define the corresponding cursor type
+    self.apos.define('apostrophe-pieces-cursor', require('./lib/cursor.js'));
+    // Ensure that any subclasses that don't explicitly define their own
+    // cursor type still have one by the appropriate name
+    self.apos.synth.mirror(self.__meta, '-cursor');
+
   }
 
 };

--- a/lib/modules/apostrophe-pieces/lib/api.js
+++ b/lib/modules/apostrophe-pieces/lib/api.js
@@ -5,9 +5,13 @@ var _ = require('lodash');
 module.exports = function(self, options) {
 
   self.find = function(req, criteria, projection) {
-    var cursor = self.apos.docs.find(req, criteria, projection);
-    require('./cursor.js')(self, cursor);
-    return cursor;
+    return cursor = self.apos.create(self.__meta.name + '-cursor', {
+      apos: self.apos,
+      module: self,
+      req: req,
+      criteria: criteria,
+      projection: projection
+    });
   };
 
   // middleware for JSON API routes that expect the ID of

--- a/lib/modules/apostrophe-pieces/lib/cursor.js
+++ b/lib/modules/apostrophe-pieces/lib/cursor.js
@@ -1,7 +1,8 @@
 module.exports = {
   extend: 'apostrophe-cursor',
-  construct: function(self, options) {
-    // Customize defaults
+  afterConstruct: function(self) {
+    // Customize defaults. If we don't do this late in afterConstruct, we
+    // get blown out by the criteria argument to find()
     self.type(self.options.module.name).sort(self.options.module.options.sort || { updatedAt: -1 });
   }
 };

--- a/lib/modules/apostrophe-pieces/lib/cursor.js
+++ b/lib/modules/apostrophe-pieces/lib/cursor.js
@@ -1,3 +1,8 @@
-module.exports = function(self, cursor) {
-  return cursor.type(self.name).sort(self.options.sort || { updatedAt: -1 });
+module.exports = {
+  extend: 'apostrophe-cursor',
+  construct: function(self, options) {
+    // Customize defaults
+    self.type(self.options.module.name).sort(self.options.module.options.sort || { updatedAt: -1 });
+  }
 };
+

--- a/lib/modules/apostrophe-users/index.js
+++ b/lib/modules/apostrophe-users/index.js
@@ -276,15 +276,6 @@ module.exports = {
     // if you are deliberately fetching users,
     // we assume you don't care if they are published.
 
-    var superFind = self.find;
-    self.find = function(req, criteria, projection){
-      var cursor = superFind(req, criteria, projection).published(null);
-      // Add filters meant specifically for users
-      require('./lib/cursor.js')(self, cursor);
-      return cursor;
-
-    };
-
     self.ensureGroups = function(callback){
       if (!options.groups){
         return setImmediate(callback);
@@ -340,54 +331,54 @@ module.exports = {
     });
 
     self.apos.tasks.add('apostrophe-users', 'add',
-     'Usage: node app apostrophe-users:add username groupname\n\n' +
-     'This adds a new user and assigns them to a group.\n' +
-     'You will be prompted for a password.',
-     function(apos, argv, callback) {
-       return self.addFromTask(callback);
-     }
-   );
+      'Usage: node app apostrophe-users:add username groupname\n\n' +
+      'This adds a new user and assigns them to a group.\n' +
+      'You will be prompted for a password.',
+      function(apos, argv, callback) {
+        return self.addFromTask(callback);
+      }
+    );
 
-   self.addFromTask = function(callback){
-     var argv = self.apos.argv;
-     if(argv._.length !== 3 ){
-       return callback('Incorrect number of arguments.');
-     }
-     var username = argv._[1];
-     var groupname = argv._[2];
-     var req = self.apos.tasks.getReq();
-     // find the group
-     self.apos.groups.find(req, {title: groupname}).toObject(function(err, group){
-       if(err){
-         return callback(err);
-       }
-       if(!group){
-         return callback('That group does not exist.');
-       }
-       prompt.start();
-       prompt.get({
-         properties: {
-           password: {
-             required: true,
-             hidden: true
-           }
-         }
-       }, function(err, result){
-         if(err){
-           return callback(err);
-         }
-         self.apos.users.insert(req, {
-           username: username,
-           password: result.password,
-           title: username,
-           firstName: username,
-           groupIds: [ group._id ]
-         }, callback);
-       });
-     });
-   };
+    self.addFromTask = function(callback) {
+      var argv = self.apos.argv;
+      if(argv._.length !== 3 ){
+        return callback('Incorrect number of arguments.');
+      }
+      var username = argv._[1];
+      var groupname = argv._[2];
+      var req = self.apos.tasks.getReq();
+      // find the group
+      self.apos.groups.find(req, {title: groupname}).toObject(function(err, group){
+        if(err){
+          return callback(err);
+        }
+        if(!group){
+          return callback('That group does not exist.');
+        }
+        prompt.start();
+        prompt.get({
+          properties: {
+            password: {
+              required: true,
+              hidden: true
+            }
+          }
+        }, function(err, result){
+          if(err){
+            return callback(err);
+          }
+          self.apos.users.insert(req, {
+            username: username,
+            password: result.password,
+            title: username,
+            firstName: username,
+            groupIds: [ group._id ]
+          }, callback);
+        });
+      });
+    };
 
-
+    self.apos.define('apostrophe-users-cursor', require('./lib/cursor.js'));
 
   }
 };

--- a/lib/modules/apostrophe-users/lib/cursor.js
+++ b/lib/modules/apostrophe-users/lib/cursor.js
@@ -1,19 +1,27 @@
 var _ = require('lodash');
 
-module.exports = function(self, cursor) {
+module.exports = {
 
-  cursor.addFilter('singleGroup', {
-    def: self.options.groups,
-    after: function(results) {
-      var options = cursor.get('singleGroup');
-      if(!options){
-        return;
-      }
-      _.each(results, function(result){
-        if(result.groupIds){
-          result.group = result.groupIds[0];
+  extend: 'apostrophe-pieces-cursor',
+
+  construct: function(self, options) {
+
+    // Users are a backend concept, we usually don't care if they are published
+    self.published(null);
+
+    self.addFilter('singleGroup', {
+      def: self.options.groups,
+      after: function(results) {
+        var options = self.get('singleGroup');
+        if(!options){
+          return;
         }
-      });
-    }
-  });
+        _.each(results, function(result){
+          if(result.groupIds){
+            result.group = result.groupIds[0];
+          }
+        });
+      }
+    });
+  }
 };

--- a/lib/modules/apostrophe-users/lib/cursor.js
+++ b/lib/modules/apostrophe-users/lib/cursor.js
@@ -4,11 +4,12 @@ module.exports = {
 
   extend: 'apostrophe-pieces-cursor',
 
-  construct: function(self, options) {
-
+  afterConstruct: function(self) {
     // Users are a backend concept, we usually don't care if they are published
     self.published(null);
+  },
 
+  construct: function(self, options) {
     self.addFilter('singleGroup', {
       def: self.options.groups,
       after: function(results) {

--- a/test/images.js
+++ b/test/images.js
@@ -1,0 +1,128 @@
+
+var assert = require('assert');
+var _ = require('lodash');
+var async = require('async');
+var apos;
+
+var mockImages = [
+  {
+    type: 'apostrophe-image',
+    slug: 'image-1',
+    published: true,
+    attachment: {
+      width: 500,
+      height: 400
+    }
+  },
+  {
+    type: 'apostrophe-image',
+    slug: 'image-2',
+    published: true,
+    attachment: {
+      width: 500,
+      height: 400
+    }
+  },
+  {
+    type: 'apostrophe-image',
+    slug: 'image-3',
+    published: true,
+    attachment: {
+      width: 150,
+      height: 150
+    }
+  },
+];
+
+describe('Images', function() {
+
+  this.timeout(5000);
+
+  it('should be a property of the apos object', function(done) {
+    this.timeout(5000);
+    this.slow(2000);
+
+    apos = require('../index.js')({
+      root: module,
+      shortName: 'test',
+      hostName: 'test.com',
+      modules: {
+        'apostrophe-express': {
+          port: 7951
+        }
+      },
+      afterInit: function(callback) {
+        assert(apos.images);
+        // In tests this will be the name of the test file,
+        // so override that in order to get apostrophe to
+        // listen normally and not try to run a task. -Tom
+        apos.argv._ = [];
+        return callback(null);
+      },
+      afterListen: function(err) {
+        // assert(!err);
+        done();
+      }
+    });
+  });
+
+  // Test pieces.list()
+  it('should clean up any existing images for testing', function(done) {
+    return apos.docs.db.remove({ type: 'apostrophe-image' }, function(err) {
+      assert(!err);
+      return done();
+    });
+  });
+
+  it('should add images for testing', function(done) {
+    assert(apos.images.insert);
+    return async.each(mockImages, function(image, callback) {
+      return apos.images.insert(adminReq(), image, callback);
+    }, function(err) {
+      assert(!err);
+      done();
+    });
+  });
+
+  it('should respect minSize filter', function(done) {
+    var req = anonReq();
+    return apos.images.find(req).minSize([ 200, 200 ]).toArray(function(err, images) {
+      assert(!err);
+      assert(images.length === 2);
+      return done();
+    });
+  });
+
+  it('should respect minSize filter in toCount, which uses a cloned cursor', function(done) {
+    var req = anonReq();
+    return apos.images.find(req).minSize([ 200, 200 ]).toCount(function(err, count) {
+      assert(!err);
+      assert(count === 2);
+      return done();
+    });
+  });
+
+// mock up a request
+  function anonReq() {
+    return {
+      res: {
+        __: function(x) { return x; }
+      },
+      browserCall: apos.app.request.browserCall,
+      getBrowserCalls: apos.app.request.getBrowserCalls,
+      query: {}
+    };
+  }
+
+  function adminReq() {
+    return _.merge(anonReq(), {
+      user: {
+        _id: 'testfileuser',
+        _permissions: {
+          admin: true
+        }
+      }
+    });
+  }
+
+})

--- a/test/test.js
+++ b/test/test.js
@@ -17,45 +17,48 @@ describe('Modules', function(){
   // Removes some non-determinism of tasks timing out when running on travis
   this.timeout(5000);
 
-  require('./base-module.js');
+  // require('./base-module.js');
 
-  require('./utils.js');
+  // require('./utils.js');
 
-  require('./db.js');
+  // require('./db.js');
 
-  require('./caches.js');
+  // require('./caches.js');
 
-  require('./express.js');
+  // require('./express.js');
 
-  require('./templates.js');
+  // require('./templates.js');
 
-  require('./launder.js');
+  // require('./launder.js');
 
-  require('./permissions.js');
+  // require('./permissions.js');
 
-  require('./attachments.js');
+  // require('./attachments.js');
 
-  require('./schemas.js');
+  // require('./schemas.js');
 
-  require('./docs.js');
+  // require('./docs.js');
 
-  require('./pages.js');
+  // require('./pages.js');
 
-  require('./custom-pages.js');
+  // require('./custom-pages.js');
 
-  require('./pieces.js');
+  // require('./pieces.js');
 
-  require('./pieces-pages.js');
+  // require('./pieces-pages.js');
 
-  require('./pieces-widgets.js');
+  // require('./pieces-widgets.js');
 
-  require('./search.js');
+  // require('./search.js');
 
-  require('./tags.js');
+  // require('./tags.js');
 
-  require('./users.js');
+  // require('./users.js');
 
-  require('./login.js');
+  // require('./login.js');
 
-  require('./versions.js');
+  // require('./versions.js');
+
+  require('./images.js');
+
 });

--- a/test/test.js
+++ b/test/test.js
@@ -17,47 +17,47 @@ describe('Modules', function(){
   // Removes some non-determinism of tasks timing out when running on travis
   this.timeout(5000);
 
-  // require('./base-module.js');
+  require('./base-module.js');
 
-  // require('./utils.js');
+  require('./utils.js');
 
-  // require('./db.js');
+  require('./db.js');
 
-  // require('./caches.js');
+  require('./caches.js');
 
-  // require('./express.js');
+  require('./express.js');
 
-  // require('./templates.js');
+  require('./templates.js');
 
-  // require('./launder.js');
+  require('./launder.js');
 
-  // require('./permissions.js');
+  require('./permissions.js');
 
-  // require('./attachments.js');
+  require('./attachments.js');
 
-  // require('./schemas.js');
+  require('./schemas.js');
 
-  // require('./docs.js');
+  require('./docs.js');
 
-  // require('./pages.js');
+  require('./pages.js');
 
-  // require('./custom-pages.js');
+  require('./custom-pages.js');
 
-  // require('./pieces.js');
+  require('./pieces.js');
 
-  // require('./pieces-pages.js');
+  require('./pieces-pages.js');
 
-  // require('./pieces-widgets.js');
+  require('./pieces-widgets.js');
 
-  // require('./search.js');
+  require('./search.js');
 
-  // require('./tags.js');
+  require('./tags.js');
 
-  // require('./users.js');
+  require('./users.js');
 
-  // require('./login.js');
+  require('./login.js');
 
-  // require('./versions.js');
+  require('./versions.js');
 
   require('./images.js');
 


### PR DESCRIPTION
… should provide a "things-cursor" type corresponding to your "things" piece type. You can call filters in construct() to implement different defaults which is the most common use case for find() other than adding filters. You can also call addFilters() in construct of course. Fixes #571