### PR TITLE
Find for editing

### DIFF
--- a/lib/modules/apostrophe-pieces-pages/index.js
+++ b/lib/modules/apostrophe-pieces-pages/index.js
@@ -123,13 +123,18 @@ module.exports = {
     };
 
     self.showPage = function(req, callback) {
-      var cursor = self.pieces.find(req, { slug: req.params.slug });
 
-      if (self.pieces.contextual) {
-        cursor.published(null);
-      }
+      // We'll try to find the piece as an ordinary reader and, if the piece type
+      // is contextual, we'll also try it as an editor if needed
 
-      return cursor.toObject(function(err, doc) {
+      var doc;
+      return async.series([
+        findAsReader,
+        findAsEditor
+      ], function(err) {
+        if (err) {
+          return callback(err);
+        }
         if (!doc) {
           req.notFound = true;
           return callback(null);
@@ -152,7 +157,35 @@ module.exports = {
         req.data.piece = doc;
         return self.beforeShow(req, callback);
       });
-    }
+
+      function findAsReader(callback) {
+        var cursor = self.pieces.find(req, { slug: req.params.slug });
+        return cursor.toObject(function(err, _doc) {
+          if (err) {
+            return callback(err);
+          }
+          doc = _doc;
+          return callback(null);
+        });
+      }
+
+      function findAsEditor(callback) {
+        if (doc || (!req.user) || (!self.pieces.contextual)) {
+          return callback(null);
+        }
+        // Use findForEditing to allow subclasses to extend the set of filters that
+        // don't apply by default in an editing context. -Tom
+        var cursor = self.pieces.findForEditing(req, { slug: req.params.slug });
+        return cursor.toObject(function(err, _doc) {
+          if (err) {
+            return callback(err);
+          }
+          doc = _doc;
+          return callback(null);
+        });
+      }
+
+    };
 
     self.beforeShow = function(req, callback) {
       return setImmediate(callback);

--- a/lib/modules/apostrophe-pieces/lib/api.js
+++ b/lib/modules/apostrophe-pieces/lib/api.js
@@ -4,20 +4,31 @@ var _ = require('lodash');
 
 module.exports = function(self, options) {
 
+  // Returns a cursor for use in finding docs. See cursor.js for chainable
+  // filters, and also yielders that actually deliver the docs to you
+
   self.find = function(req, criteria, projection) {
     var cursor = self.apos.docs.find(req, criteria, projection);
     require('./cursor.js')(self, cursor);
     return cursor;
   };
 
+  // Returns a cursor that finds docs the current user can edit. Unlike
+  // find(), this cursor defaults to including unpublished docs. Subclasses
+  // of apostrophe-pieces often extend this to remove more default filters
+
+  self.findForEditing = function(req, criteria, projection) {
+    return self.find(req, criteria, projection)
+      .permission('edit')
+      .published(null);
+  };
+
   // middleware for JSON API routes that expect the ID of
-  // an existing piece at req.body._id
+  // an existing piece at req.body._id, with editing privileges
   self.requirePiece = function(req, res, next) {
     var id = self.apos.launder.id(req.body._id);
 
-    return self.find(req, { _id: id })
-      .permission('edit')
-      .published(null)
+    return self.findForEditing(req, { _id: id })
       .toObject(function(err, _piece) {
         if (err) {
           return self.apiResponse(res, err);
@@ -43,10 +54,13 @@ module.exports = function(self, options) {
   };
 
   self.list = function(req, filters, callback) {
-    var cursor = self.find(req)
-      .published(null)
-      .perPage(self.options.perPage || 10)
-      .queryToFilters(filters);
+    var cursor;
+    if (filters.chooser) {
+      cursor = self.find(req);
+    } else {
+      cursor = self.findForEditing(req);
+    }
+    cursor.queryToFilters(filters);
     var results = {};
     return async.series({
       toCount: function(callback) {
@@ -115,9 +129,7 @@ module.exports = function(self, options) {
     if (!self.contextual) {
       return setImmediate(callback);
     }
-    return self.find(req, { _id: piece._id })
-      .permission('edit')
-      .published(null)
+    return self.findForEditing(req, { _id: piece._id })
       .toObject(function(err, _piece) {
         if (err) {
           return callback(err);


### PR DESCRIPTION
findForEditing method provides a logical extension point for changing the filters used when fetching things for editing purposes, fixes #574