### PR TITLE
Minify is fixed. The jqtree.css code was crashing when treated as LES…

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,12 +152,21 @@ module.exports = function(options) {
     afterInit
   ], function(err) {
     if (err) {
-      throw err;
+      if (options.initFailed) {
+        // Report error in an extensible way
+        return options.initFailed(err);
+      } else {
+        // In the absence of a callback to handle initialization failure,
+        // we have to assume there's just one instance of Apostrophe and
+        // we can print the error and end the app
+        console.error(err);
+        process.exit(1);
+      }
     }
     if (self.argv._.length) {
       self.emit('runTask');
     } else {
-      // The apostrophe-express-init module adds this method
+      // The apostrophe-express module adds this method
       self.listen();
     }
   });
@@ -283,14 +292,6 @@ module.exports = function(options) {
     return self.options.afterInit(callback);
   }
 
-  function afterListen(callback) {
-    // Give project-level code a chance to run after we
-    // start listening. Not called at all for tasks
-    if (!self.options.afterListen) {
-      return setImmediate(callback);
-    }
-    return self.options.afterListen(callback);
-  }
 };
 
 var abstractClasses = [ 'apostrophe-module', 'apostrophe-widgets', 'apostrophe-custom-pages', 'apostrophe-pieces', 'apostrophe-pieces-pages', 'apostrophe-pieces-widgets' ];

--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -25,6 +25,7 @@ module.exports = {
     });
 
     self.pushDefaults();
+
   },
 
   construct: function(self, options) {
@@ -305,6 +306,8 @@ module.exports = {
 
       self.tooLateToPushAssets = true;
 
+      self.ensureFolder();
+
       // Create symbolic links in /modules so that our web paths can be
       // served by a static server like nginx
 
@@ -319,6 +322,22 @@ module.exports = {
         }
         return callback(null);
       });
+    };
+
+    self.ensureFolder = function() {
+      var staticDir = self.apos.rootDir + '/public';
+
+      ensure(staticDir);
+      ensure(staticDir + '/modules');
+      ensure(staticDir + '/css');
+      ensure(staticDir + '/js');
+
+      function ensure(dir) {
+        if (!fs.existsSync(dir)) {
+          fs.mkdirSync(dir);
+        }
+      }
+
     };
 
     self.symlinkModules = function(callback) {
@@ -540,7 +559,9 @@ module.exports = {
             return cache.set(key, code, callback);
           });
         }
-      }, callback);
+      }, function(err) {
+        return callback(err);
+      });
     };
 
     self.minifyStylesheet = function(stylesheet, callback) {
@@ -618,11 +639,8 @@ module.exports = {
           console.error(err);
         }
         css = css.css;
-        if (self.prefix) {
-          // Call a method provided by appy to be
-          // compatible with what the frontend
-          // middleware does
-          css = self.options.prefixCssUrls(css);
+        if (self.apos.prefix) {
+          css = self.prefixCssUrls(css);
         }
         return callback(err, css);
       });
@@ -804,7 +822,7 @@ module.exports = {
           if (!self.apos.prefix) {
             return css;
           }
-          css = prefixCssUrls(css);
+          css = self.prefixCssUrls(css);
           return css;
         }
       },
@@ -827,12 +845,28 @@ module.exports = {
       compress: false
     }));
 
-    var staticDir = self.apos.rootDir + '/public';
-
-    ensure(staticDir);
-    ensure(staticDir + '/modules');
-    ensure(staticDir + '/css');
-    ensure(staticDir + '/js');
+    // Prefix all URLs in CSS with the global site prefix
+    self.prefixCssUrls = function(css) {
+      css = css.replace(/url\(([^'"].*?)\)/g, function(s, url) {
+        if (url.match(/^\//)) {
+          url = self.apos.prefix + url;
+        }
+        return 'url(' + url + ')';
+      });
+      css = css.replace(/url\(\"(.+?)\"\)/g, function(s, url) {
+        if (url.match(/^\//)) {
+          url = self.apos.prefix + url;
+        }
+        return 'url("' + url + '")';
+      });
+      css = css.replace(/url\(\'(.+?)\'\)/g, function(s, url) {
+        if (url.match(/^\//)) {
+          url = self.apos.prefix + url;
+        }
+        return 'url(\'' + url + '\')';
+      });
+      return css;
+    };
 
     self.apos.app.use(self.apos.express.static(self.apos.rootDir + '/public'));
 
@@ -895,7 +929,7 @@ module.exports = {
         if (self.options.minify) {
           var unminifiable = self.filterAssets(self.pushed['scripts'], when, false);
           result += scriptTags(unminifiable);
-          result += '<script src="' + self.prefix + '/apos-minified/' + when + '-' + self.generation + '.js"></script>\n';
+          result += '<script src="' + self.apos.prefix + '/apos-minified/' + when + '-' + self.generation + '.js"></script>\n';
           return self.apos.templates.safe(result);
         } else {
           var scriptsWhen = self.filterAssets(self.pushed['scripts'], when);
@@ -934,11 +968,5 @@ module.exports = {
         }).join(''));
       }
     });
-
-    function ensure(dir) {
-      if (!fs.existsSync(dir)) {
-        fs.mkdirSync(dir);
-      }
-    }
   }
 };

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -49,7 +49,7 @@ module.exports = function(self, options) {
     }
 
     function md5(callback) {
-      return self.md5(file.path, function(err, md5) {
+      return self.apos.utils.md5File(file.path, function(err, md5) {
         if (err) {
           return callback(err);
         }
@@ -100,25 +100,6 @@ module.exports = function(self, options) {
       if (_.contains(group.extensions, candidate)) {
         return true;
       }
-    });
-  };
-
-  self.md5 = function(filename, callback) {
-    var md5 = crypto.createHash('md5');
-
-    var s = fs.ReadStream(filename);
-
-    s.on('data', function(d) {
-      md5.update(d);
-    });
-
-    s.on('error', function(err) {
-      return callback(err);
-    });
-
-    s.on('end', function() {
-      var d = md5.digest('hex');
-      return callback(null, d);
     });
   };
 

--- a/lib/modules/apostrophe-pages/public/css/jqtree.less
+++ b/lib/modules/apostrophe-pages/public/css/jqtree.less
@@ -122,8 +122,11 @@ span.jqtree-dragging {
   cursor: pointer;
   padding: 2px 8px; }
 
-/* IE 6, 7, 8 */
-@media \0screen\,screen\9 {
-  ul.jqtree-tree li.jqtree-ghost span.jqtree-circle {
-    background: url(jqtree-circle.png) no-repeat;
-    border: 0 none; } }
+// Generates a LESS compiler error, and we don't do IE 6/7/8
+// workarounds for jqtree. -Tom
+//
+// /* IE 6, 7, 8 */
+// @media \0screen\,screen\9 {
+//   ul.jqtree-tree li.jqtree-ghost span.jqtree-circle {
+//     background: url(jqtree-circle.png) no-repeat;
+//     border: 0 none; } }

--- a/lib/modules/apostrophe-utils/lib/api.js
+++ b/lib/modules/apostrophe-utils/lib/api.js
@@ -4,6 +4,7 @@ _.str = require('underscore.string');
 var XRegExp = require('xregexp').XRegExp;
 var crypto = require('crypto');
 var cuid = require('cuid');
+var fs = require('fs');
 
 module.exports = function(self, options) {
 
@@ -209,6 +210,26 @@ module.exports = function(self, options) {
     var md5 = crypto.createHash('md5');
     md5.update(s);
     return md5.digest('hex');
+  };
+
+  // perform an md5 checksum on a file. Delivers `null`, `hexString` to callback.
+  self.md5File = function(filename, callback) {
+    var md5 = crypto.createHash('md5');
+
+    var s = fs.ReadStream(filename);
+
+    s.on('data', function(d) {
+      md5.update(d);
+    });
+
+    s.on('error', function(err) {
+      return callback(err);
+    });
+
+    s.on('end', function() {
+      var d = md5.digest('hex');
+      return callback(null, d);
+    });
   };
 
   // Turn the provided string into a string suitable for use as a slug.


### PR DESCRIPTION
…S, I removed an IE6/7/8 workaround we don't need and now it's fine. There were other bugs that prevented minify from completing and are now fixed. Also Apostrophe was failing to print initialization errors and gracefully exit. md5File is now in utils because it is not really specific to attachments.