### PR TITLE
fixed bug in cropper. for scaleUp/scaleDown we need original attachme…

### DIFF
--- a/lib/modules/apostrophe-attachments/public/js/cropEditor.js
+++ b/lib/modules/apostrophe-attachments/public/js/cropEditor.js
@@ -8,7 +8,7 @@ apos.define('apostrophe-attachments-crop-editor', {
     self.afterShow = function() {
 
       self.$cropImage = self.$el.find('[data-crop-image]');
-      self.cropWidth = self.$cropImage.width();
+      self.cropWidth = self.attachment.width;
       self.$saveButton = self.$el.find('[data-apos-save]');
       self.busy(true);
       self.$cropImage.attr('src', apos.attachments.url(self.attachment, {size: 'original'} ));
@@ -79,6 +79,7 @@ apos.define('apostrophe-attachments-crop-editor', {
     };
 
     self.serializeCrop = function(data) {
+
       return {
         top: self.scaleUp(data.y),
         left: self.scaleUp(data.x),


### PR DESCRIPTION
…nt width since cropper.js has zoomable feature.  reference to <img>.width() replaced by attchment.width