### PR TITLE
Introduced data.home and data.tabs properties

### DIFF
--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -107,7 +107,7 @@ module.exports = {
           return res.redirect('/')
         }
         req.scene = 'user';
-        return res.send(self.renderPage(req, 'login', { message: req.flash('error')}));
+        return self.sendPage(req, 'login', { message: req.flash('error')});
       });
       self.apos.app.post('/login',
         self.passport.authenticate('local', {

--- a/lib/modules/apostrophe-module/index.js
+++ b/lib/modules/apostrophe-module/index.js
@@ -223,7 +223,7 @@ module.exports = {
     };
 
     // TIP: you probably want self.sendPage, which loads
-    // data.tabs and data.home for you.
+    // data.home for you.
     //
     // This method generates a complete HTML page for transmission to the
     // browser. Returns HTML markup ready to send (but self.sendPage is
@@ -312,8 +312,7 @@ module.exports = {
     // `data.permissions` (req.user._permissions)
     // `data.calls` (javascript markup to insert all global and
     //   request-specific calls pushed by server-side code)
-    // `data.home` (basic information about the home page)
-    // `data.tabs` (array of basic information about child pages of the home page)
+    // `data.home` (basic information about the home page, usually with ._children)
     //
     // First, `beforeSendPage` is invoked on every module that
     // has such a method. It receives `req` and an optional callback, and

--- a/lib/modules/apostrophe-module/index.js
+++ b/lib/modules/apostrophe-module/index.js
@@ -222,8 +222,12 @@ module.exports = {
       };
     };
 
-    // Generate a complete HTML page for transmission to the
-    // browser.
+    // TIP: you probably want self.sendPage, which loads
+    // data.tabs and data.home for you.
+    //
+    // This method generates a complete HTML page for transmission to the
+    // browser. Returns HTML markup ready to send (but self.sendPage is
+    // more convenient).
     //
     // If `template` is a function it is passed a data object,
     // otherwise it is rendered as a nunjucks template relative
@@ -232,41 +236,98 @@ module.exports = {
     // `data` is provided to the template, with additional
     // default properties as described below.
     //
-    // "outerLayout" is set to:
+    // `outerLayout` is set to:
     //
-    // "apostrophe-templates:outerLayout.html"
+    // `apostrophe-templates:outerLayout.html`
     //
     // Or:
     //
-    // "apostrophe-templates:refreshLayout.html"
+    // `apostrophe-templates:refreshLayout.html`
     //
     // This allows the template to handle either a content area
     // refresh or a full page render just by doing this:
     //
-    // {% extend outerLayout %}
+    // `{% extend outerLayout %}`
     //
     // Note the lack of quotes.
     //
-    // Under the following conditions, "refreshLayout.html"
-    // is used in place of "outerLayout.html":
+    // Under the following conditions, `refreshLayout.html`
+    // is used in place of `outerLayout.html`:
     //
-    // req.xhr is true (always set on AJAX requests by jQuery)
-    // req.query.xhr is set to simulate an AJAX request
-    // req.decorate is false
-    // req.query.apos_refresh is true
+    // `req.xhr` is true (always set on AJAX requests by jQuery)
+    // `req.query.xhr` is set to simulate an AJAX request
+    // `req.decorate` is false
+    // `req.query.apos_refresh` is true
     //
-    // These default properties are also provided:
+    // These default properties are provided on
+    // the `data` object in nunjucks:
     //
-    // user (req.user)
-    // query (req.query)
-    // permissions (req.user._permissions)
-    // calls (javascript markup to insert all global and
+    // `data.user` (req.user)
+    // `data.query` (req.query)
+    // `data.permissions` (req.user._permissions)
+    // `data.calls` (javascript markup to insert all global and
     //   request-specific calls pushed by server-side code)
-    // data (javascript markup to insert all global and
-    //   request-specific data pushed by server-side code)
     //
     self.renderPage = function(req, template, data) {
       return self.apos.templates.renderPageForModule(req, template, data, self);
+    };
+
+    // This method generates and sends a complete HTML page to the browser.
+    //
+    // If `template` is a function it is passed a data object,
+    // otherwise it is rendered as a nunjucks template relative
+    // to this module via self.render.
+    //
+    // `data` is provided to the template, with additional
+    // default properties as described below.
+    //
+    // `outerLayout` is set to:
+    //
+    // `apostrophe-templates:outerLayout.html`
+    //
+    // Or:
+    //
+    // `apostrophe-templates:refreshLayout.html`
+    //
+    // This allows the template to handle either a content area
+    // refresh or a full page render just by doing this:
+    //
+    // `{% extend outerLayout %}`
+    //
+    // Note the lack of quotes.
+    //
+    // Under the following conditions, `refreshLayout.html`
+    // is used in place of `outerLayout.html`:
+    //
+    // `req.xhr` is true (always set on AJAX requests by jQuery)
+    // `req.query.xhr` is set to simulate an AJAX request
+    // `req.decorate` is false
+    // `req.query.apos_refresh` is true
+    //
+    // These default properties are provided on
+    // the `data` object in nunjucks:
+    //
+    // `data.user` (req.user)
+    // `data.query` (req.query)
+    // `data.permissions` (req.user._permissions)
+    // `data.calls` (javascript markup to insert all global and
+    //   request-specific calls pushed by server-side code)
+    // `data.home` (basic information about the home page)
+    // `data.tabs` (array of basic information about child pages of the home page)
+    //
+    // First, `beforeSendPage` is invoked on every module that
+    // has such a method. It receives `req` and an optional callback, and
+    // can modify `req.data`.
+
+    self.sendPage = function(req, template, data) {
+      return self.apos.callAll('beforeSendPage', req, function(err) {
+        if (err) {
+          req.error = err;
+        }
+        return req.res.send(
+          self.apos.templates.renderPageForModule(req, template, data, self)
+        );
+      });
     };
 
   }

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -733,7 +733,7 @@ module.exports = function(self, options) {
       // These properties are defaults, they shouldn't clobber
       // existing values if someone is keen to use those
       // property names
-      req.data.home = req.data.home || home;
+      req.data.home = home;
       return callback(null);
     });
 

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -412,6 +412,8 @@ module.exports = function(self, options) {
   // self.pageAfterMove = function(req, moved, info, callback) {
   //   // eventually invoke callback
   // };
+
+
   // Route that serves pages. See afterInit in
   // index.js for the wildcard argument and the app.get call
 
@@ -456,13 +458,7 @@ module.exports = function(self, options) {
       return req.res.redirect(req.slug);
     }
 
-    var filters = self.options.filters || {
-      // Get the kids of the ancestors too so we can do tabs and accordion nav
-      ancestors: { children: true },
-      // Get our own kids
-      children: true
-      // peers: true
-    };
+    var filters = self.getServePageFilters();
 
     var cursor = self.find(req);
 
@@ -662,7 +658,7 @@ module.exports = function(self, options) {
       return res.send(args.page);
     }
 
-    result = self.renderPage(req, req.template, args);
+    return self.sendPage(req, req.template, args);
 
     // TODO: this is part of the code that should
     // migrate to an apostrophe-second-chance-login module
@@ -684,8 +680,60 @@ module.exports = function(self, options) {
     //     res.cookie('aposAfterLogin', req.url);
     //   }
     // }
+  };
 
-    return req.res.send(result);
+  // This method sets `req.data.home` and `req.data.tabs`.
+  //
+  // This allows non-CMS pages like `/login` to "see" `data.tabs` and `data.home`
+  // in their templates.
+  //
+  // For performance, if req.data.page is already set and it contains a
+  // `req.data._ancestors[0].children` property, that information
+  // is leveraged to avoid redundant queries. If not, a query is made.
+  //
+  // For consistency, the home page is always retrieved using the same filters that
+  // are configured for `ancestors`, except when this would prevent the
+  // tabs from being fetched.
+  //
+  // This method is automatically invoked across all modules that contain one
+  // by the self.sendPage method of any module.
+
+  self.beforeSendPage = function(req, callback) {
+
+    // Avoid redundant work on CMS pages
+    if (req.data.page && req.data.page._ancestors && req.data.page._ancestors[0] && req.data.page._ancestors[0]._children) {
+      req.data.home = req.data.page._ancestors[0];
+      req.data.tabs = req.data.page._ancestors[0]._children;
+      return setImmediate(callback);
+    }
+
+    // Use the same filters that are configured for ancestors so behavior is
+    // consistent with that on CMS pages, however take steps to guarantee that
+    // the children of the home page are fetched at a minimum
+    var filters = self.getServePageFilters().ancestors || {
+      children: true
+    };
+
+    if (!filters.children) {
+      filters = _.clone(filters);
+      filters.children = true;
+    }
+
+    var cursor = self.find(req, { slug: '/' });
+
+    _.each(filters, function(val, key) {
+      cursor[key](val);
+    });
+
+    return cursor.toObject(function(err, home) {
+      if (err) {
+        return callback(err);
+      }
+      req.data.home = home;
+      req.data.tabs = home._children;
+      return callback(null);
+    });
+
   };
 
   // A request is "found" if it should not be
@@ -694,6 +742,15 @@ module.exports = function(self, options) {
   self.isFound = function(req) {
     var found = req.loginRequired || req.insufficient || req.redirect || (req.data.page && (!req.notFound));
     return found;
+  };
+
+  self.getServePageFilters = function() {
+    return self.options.filters || {
+      // Get the kids of the ancestors too so we can do tabs and accordion nav
+      ancestors: { children: true },
+      // Get our own kids
+      children: true
+    };
   };
 
   self.matchPageAndPrefixes = function(cursor, slug) {

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -682,47 +682,43 @@ module.exports = function(self, options) {
     // }
   };
 
-  // This method sets `req.data.home` and `req.data.tabs`.
+  // This method sets `req.data.home`. It is called automatically every
+  // time `self.sendPage` is called in any module, which includes normal CMS pages,
+  // 404 pages, the login page, etc.
   //
-  // This allows non-CMS pages like `/login` to "see" `data.tabs` and `data.home`
+  // This allows non-CMS pages like `/login` to "see" `data.home` and `data.home._children`
   // in their templates.
   //
   // For performance, if req.data.page is already set and it contains a
-  // `req.data._ancestors[0].children` property, that information
+  // `req.data._ancestors[0]._children` property, that information
   // is leveraged to avoid redundant queries. If not, a query is made.
   //
   // For consistency, the home page is always retrieved using the same filters that
-  // are configured for `ancestors`, except when this would prevent the
-  // tabs from being fetched.
-  //
-  // This method is automatically invoked across all modules that contain one
-  // by the self.sendPage method of any module.
+  // are configured for `ancestors`. Normally that includes children of each
+  // ancestor. If that is explicitly reconfigured without the `children` option,
+  // you will not get `data.home._children`.
 
   self.beforeSendPage = function(req, callback) {
 
-    // Did something else already set both?
-    if (req.data.home && req.data.tabs) {
+    // Did something else already set it?
+    if (req.data.home) {
       return setImmediate(callback);
     }
 
     // Avoid redundant work on CMS pages
-    if (req.data.page && req.data.page._ancestors && req.data.page._ancestors[0] && req.data.page._ancestors[0]._children) {
+    if (req.data.page && req.data.page._ancestors && req.data.page._ancestors[0]) {
       req.data.home = req.data.page._ancestors[0];
-      req.data.tabs = req.data.page._ancestors[0]._children;
       return setImmediate(callback);
     }
 
     // Use the same filters that are configured for ancestors so behavior is
-    // consistent with that on CMS pages, however take steps to guarantee that
-    // the children of the home page are fetched at a minimum
+    // consistent with that on CMS pages, however if ancestors were not
+    // configured, take steps to guarantee that the children of the home page
+    // are fetched
+
     var filters = self.getServePageFilters().ancestors || {
       children: true
     };
-
-    if (!filters.children) {
-      filters = _.clone(filters);
-      filters.children = true;
-    }
 
     var cursor = self.find(req, { slug: '/' });
 
@@ -738,7 +734,6 @@ module.exports = function(self, options) {
       // existing values if someone is keen to use those
       // property names
       req.data.home = req.data.home || home;
-      req.data.tabs = req.data.tabs || home._children;
       return callback(null);
     });
 

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -700,6 +700,11 @@ module.exports = function(self, options) {
 
   self.beforeSendPage = function(req, callback) {
 
+    // Did something else already set both?
+    if (req.data.home && req.data.tabs) {
+      return setImmediate(callback);
+    }
+
     // Avoid redundant work on CMS pages
     if (req.data.page && req.data.page._ancestors && req.data.page._ancestors[0] && req.data.page._ancestors[0]._children) {
       req.data.home = req.data.page._ancestors[0];
@@ -729,8 +734,11 @@ module.exports = function(self, options) {
       if (err) {
         return callback(err);
       }
-      req.data.home = home;
-      req.data.tabs = home._children;
+      // These properties are defaults, they shouldn't clobber
+      // existing values if someone is keen to use those
+      // property names
+      req.data.home = req.data.home || home;
+      req.data.tabs = req.data.tabs || home._children;
       return callback(null);
     });
 

--- a/lib/modules/apostrophe-pages/lib/pagesCursor.js
+++ b/lib/modules/apostrophe-pages/lib/pagesCursor.js
@@ -28,6 +28,9 @@ module.exports = {
 
     self.addFilter('ancestors', {
       def: false,
+      set: function(c) {
+        self.set('ancestors', c);
+      },
       after: function(results, callback) {
         var options = self.get('ancestors');
 

--- a/lib/modules/apostrophe-pages/lib/pagesCursor.js
+++ b/lib/modules/apostrophe-pages/lib/pagesCursor.js
@@ -28,9 +28,6 @@ module.exports = {
 
     self.addFilter('ancestors', {
       def: false,
-      set: function(c) {
-        self.set('ancestors', c);
-      },
       after: function(results, callback) {
         var options = self.get('ancestors');
 

--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -498,9 +498,193 @@ module.exports = {
 
     // Typically you will call the `renderPage` method of
     // your own module, provided by the `apostrophe-module`
-    // base class, which is a wrapper for this method.
+    // base class, which is a wrapper for this method. Also
+    // consider calling `sendPage` which is even more convenient
+    // and adds tabs to the data object, etc.
     //
     // Generate a complete HTML page for transmission to the
+    // browser.
+    //
+    // If `req.error` is truthy, it is logged similarly to a
+    // template error and the `error.html` template is displayed.
+    //
+    // If `template` is a function it is passed a data object,
+    // otherwise it is rendered as a nunjucks template relative
+    // to this module via self.render.
+    //
+    // `data` is provided to the template, with additional
+    // default properties as described below.
+    //
+    // `module` is the module from which the template should
+    // be rendered, if an explicit module name is not part
+    // of the template name.
+    //
+    // Additional properties merged with the `data object:
+    //
+    // "outerLayout" is set to...
+    //
+    // "apostrophe-templates:outerLayout.html"
+    //
+    // Or:
+    //
+    // "apostrophe-templates:refreshLayout.html"
+    //
+    // This allows the template to handle either a content area
+    // refresh or a full page render just by doing this:
+    //
+    // {% extend outerLayout %}
+    //
+    // Note the lack of quotes.
+    //
+    // Under the following conditions, "refreshLayout.html"
+    // is used in place of "outerLayout.html":
+    //
+    // req.xhr is true (always set on AJAX requests by jQuery)
+    // req.query.xhr is set to simulate an AJAX request
+    // req.decorate is false
+    // req.query.apos_refresh is true
+    //
+    // These default properties are also provided on the `data` object
+    // visible in Nunjucks:
+    //
+    // user (req.user)
+    // query (req.query)
+    // permissions (req.user._permissions)
+    // calls (javascript markup to insert all global and
+    //   request-specific calls pushed by server-side code)
+    // data (javascript markup to insert all global and
+    //   request-specific data pushed by server-side code)
+
+    self.renderPageForModule = function(req, template, data, module) {
+      // TODO bring this back as soon as we refactor the
+      // permissions module so an object is there to receive
+      // this property
+
+      // req.browserCall('apos.permissions.current = ?',
+      //   (req.user && req.user._permissions) || {}
+      // );
+
+      var scene = req.user ? 'user' : 'anon';
+      if (req.scene) {
+        scene = req.scene;
+      }
+      var globalCalls = self.apos.push.getBrowserCalls('always');
+      if (scene === 'user') {
+        globalCalls += self.apos.push.getBrowserCalls('user');
+      }
+
+      // Always the last call; signifies we're done initializing the
+      // page as far as the core is concerned; a lovely time for other
+      // modules and project-level javascript to do their own
+      // enhancements.
+      //
+      // This method emits a 'ready' event, and also
+      // emits an 'enhance' event with the entire $body
+      // as its argument.
+      //
+      // Waits for DOMready to give other
+      // things maximum opportunity to happen.
+
+      var decorate = !(req.query.apos_refresh || req.query.xhr || req.xhr || (req.decorate === false));
+
+      if (req.query.apos_refresh) {
+        // Trigger the apos.ready and apos.enhance events after the
+        // DOM settles and pushed javascript has had a chance to run;
+        // do it just in the context of the refreshed main content div
+        req.browserCall('apos.pageReadyWhenCalm($("[data-apos-refreshable]"))');
+      } else if (decorate) {
+        // Trigger the apos.ready and apos.enhance events after the
+        // DOM settles and pushed javascript has had a chance to run
+        req.browserCall('apos.pageReadyWhenCalm($("body"));');
+      } else {
+        // If we're ajaxing something other than data-apos-refreshable,
+        // responsibility for progressive enhancement falls on the developer
+      }
+
+      // JavaScript may want to know who the user is. Provide
+      // just a conservative set of basics for security. Devs
+      // who want to know more about the user in browserland
+      // can push more data and it'll merge
+      if (req.user) {
+        req.browserCall('apos.user = ?;', _.pick('title', '_id', 'username'));
+      }
+
+      req.browserCall('apos.scene = ?', scene);
+
+      var reqCalls = req.getBrowserCalls();
+
+      var decorate = !(req.query.apos_refresh || req.query.xhr || req.xhr || (req.decorate === false));
+
+      var urls = require('url');
+
+      // data.url will be the original requested page URL, for use in building
+      // relative links, adding or removing query parameters, etc. If this is a
+      // refresh request, we remove that so that frontend templates don't build
+      // URLs that also refresh
+
+      var dataUrl = req.url;
+
+      var parsed = urls.parse(req.url, true);
+      if (parsed.query && parsed.query.apos_refresh) {
+        delete parsed.query.apos_refresh;
+        delete parsed.search;
+        dataUrl = urls.format(parsed);
+      }
+
+      var args = {
+        outerLayout: decorate ? 'apostrophe-templates:outerLayout.html' : 'apostrophe-templates:refreshLayout.html',
+        permissions: (req.user && req.user._permissions) || {},
+        when: scene,
+        js: {
+          globalCalls: self.safe(globalCalls),
+          reqCalls: self.safe(reqCalls)
+        },
+        refreshing: req.query && (!!req.query.apos_refresh),
+        // Make the query available to templates for easy access to
+        // filter settings etc.
+        query: req.query,
+        url: dataUrl
+      };
+
+      _.extend(args, data);
+
+      // Report errors from beforeSendPage methods similarly
+      // to template errors
+      if (req.error) {
+        return error(req.error, template);
+      }
+
+      try {
+        if (typeof(template) === 'string') {
+          content = module.render(req, template, args);
+        } else {
+          content = template(req, args);
+        }
+      } catch (e) {
+        // The page template
+        // threw an exception. Log where it
+        // occurred for easier debugging
+        return error(e, 'template');
+      }
+
+      return content;
+
+      function error(e, type) {
+        var now = Date.now();
+        now = moment(now).format("YYYY-MM-DDTHH:mm:ssZZ");
+        console.error(':: ' + now + ': ' + type + ' error at ' + req.url);
+        console.error('Current user: ' + (req.user ? req.user.username : 'none'));
+        console.error(e);
+        req.statusCode = 500;
+        return self.render(req, 'templateError');
+      }
+    };
+
+    // Typically you will call the `sendPage` method of
+    // your own module, provided by the `apostrophe-module`
+    // base class, which is a wrapper for this method.
+    //
+    // Send a complete HTML page for to the
     // browser.
     //
     // If `template` is a function it is passed a data object,
@@ -539,7 +723,8 @@ module.exports = {
     // req.decorate is false
     // req.query.apos_refresh is true
     //
-    // These default properties are also provided:
+    // These default properties are also provided on the `data` object
+    // visible in Nunjucks:
     //
     // user (req.user)
     // query (req.query)
@@ -667,6 +852,5 @@ module.exports = {
         return self.render(req, 'templateError');
       }
     };
-
   }
 };

--- a/test/lib/modules/apostrophe-pages/views/notFound.html
+++ b/test/lib/modules/apostrophe-pages/views/notFound.html
@@ -5,7 +5,7 @@
 {% block main %}
 <a href="{{ data.home._url }}">Home: {{ data.home.slug }}</a>
 
-{% for tab in data.tabs %}
+{% for tab in data.home._children %}
   <a href="{{ tab._url }}">Tab: {{ tab.slug }}</a>
 {% endfor %}
 

--- a/test/lib/modules/apostrophe-pages/views/notFound.html
+++ b/test/lib/modules/apostrophe-pages/views/notFound.html
@@ -3,4 +3,10 @@
 {% block title %}Not Found{% endblock %}
 
 {% block main %}
+<a href="{{ data.home._url }}">Home: {{ data.home.slug }}</a>
+
+{% for tab in data.tabs %}
+  <a href="{{ tab._url }}">Tab: {{ tab.slug }}</a>
+{% endfor %}
+
 {% endblock %}

--- a/test/lib/modules/apostrophe-pages/views/pages/default.html
+++ b/test/lib/modules/apostrophe-pages/views/pages/default.html
@@ -2,7 +2,7 @@
 
 <a href="{{ data.home._url }}">Home: {{ data.home.slug }}</a>
 
-{% for tab in data.tabs %}
+{% for tab in data.home._children %}
   <a href="{{ tab._url }}">Tab: {{ tab.slug }}</a>
 {% endfor %}
 

--- a/test/lib/modules/apostrophe-pages/views/pages/default.html
+++ b/test/lib/modules/apostrophe-pages/views/pages/default.html
@@ -1,4 +1,11 @@
 <h4>Default Page Template</h4>
+
+<a href="{{ data.home._url }}">Home: {{ data.home.slug }}</a>
+
+{% for tab in data.tabs %}
+  <a href="{{ tab._url }}">Tab: {{ tab.slug }}</a>
+{% endfor %}
+
 {# events widget is needed for pieces-widgets test #}
 {{
   apos.area(data.page, 'body', {

--- a/test/lib/modules/apostrophe-pages/views/pages/testPage.html
+++ b/test/lib/modules/apostrophe-pages/views/pages/testPage.html
@@ -1,1 +1,9 @@
 <h3>Sing to me, Oh Muse.</h3>
+
+
+<a href="{{ data.home._url }}">Home: {{ data.home.slug }}</a>
+
+{% for tab in data.tabs %}
+  <a href="{{ tab._url }}">Tab: {{ tab.slug }}</a>
+{% endfor %}
+

--- a/test/lib/modules/apostrophe-pages/views/pages/testPage.html
+++ b/test/lib/modules/apostrophe-pages/views/pages/testPage.html
@@ -3,7 +3,7 @@
 
 <a href="{{ data.home._url }}">Home: {{ data.home.slug }}</a>
 
-{% for tab in data.tabs %}
+{% for tab in data.home._children %}
   <a href="{{ tab._url }}">Tab: {{ tab.slug }}</a>
 {% endfor %}
 

--- a/test/oembed.js
+++ b/test/oembed.js
@@ -62,8 +62,6 @@ describe('Login', function() {
       url: youtube
     }), function(err, response, body) {
       assert(!err);
-      console.log(body);
-      console.log(response.statusCode);
       assert(response.statusCode === 200);
       var data = JSON.parse(body);
       assert(data.type === 'video');

--- a/test/pages.js
+++ b/test/pages.js
@@ -10,9 +10,9 @@ describe('Pages', function() {
 
   this.timeout(5000);
 
-  // after(function() {
-  //   apos.db.dropDatabase();
-  // });
+  after(function() {
+    apos.db.dropDatabase();
+  });
 
   //////
   // EXISTENCE

--- a/test/pages.js
+++ b/test/pages.js
@@ -394,7 +394,7 @@ describe('Pages', function() {
       assert(body.match(/Sing to me, Oh Muse./));
       // Does the response prove that data.home was available?
       assert(body.match(/Home: \//));
-      // Does the response prove that data.tabs was available?
+      // Does the response prove that data.home._children was available?
       assert(body.match(/Tab: \/another-parent/));
       //console.log(body);
       return done();
@@ -408,7 +408,7 @@ describe('Pages', function() {
       assert.equal(response.statusCode, 404);
       // Does the response prove that data.home was available?
       assert(body.match(/Home: \//));
-      // Does the response prove that data.tabs was available?
+      // Does the response prove that data.home._children was available?
       assert(body.match(/Tab: \/another-parent/));
       //console.log(body);
       return done();

--- a/test/pages.js
+++ b/test/pages.js
@@ -10,9 +10,9 @@ describe('Pages', function() {
 
   this.timeout(5000);
 
-  after(function() {
-    apos.db.dropDatabase();
-  });
+  // after(function() {
+  //   apos.db.dropDatabase();
+  // });
 
   //////
   // EXISTENCE
@@ -156,7 +156,7 @@ describe('Pages', function() {
         slug: '/another-parent',
         published: true,
         path: '/another-parent',
-        level: 3,
+        level: 1,
         rank: 0
       }
     ];
@@ -392,15 +392,24 @@ describe('Pages', function() {
       assert.equal(response.statusCode, 200);
       //Did we get our page back?
       assert(body.match(/Sing to me, Oh Muse./));
+      // Does the response prove that data.home was available?
+      assert(body.match(/Home: \//));
+      // Does the response prove that data.tabs was available?
+      assert(body.match(/Tab: \/another-parent/));
       //console.log(body);
       return done();
     })
   });
+
   it('should not be able to serve a nonexistent page', function(done){
     return request('http://localhost:7940/nobodyschild', function(err, response, body){
       assert(!err);
-      //Is our status code good?
+      // Is our status code good?
       assert.equal(response.statusCode, 404);
+      // Does the response prove that data.home was available?
+      assert(body.match(/Home: \//));
+      // Does the response prove that data.tabs was available?
+      assert(body.match(/Tab: \/another-parent/));
       //console.log(body);
       return done();
     })


### PR DESCRIPTION
Introduced data.home and data.tabs properties, which are available by default anywhere the new self.sendPage method is called to render an HTML page, and in regular CMS pages as well. The login module now calls self.sendPage, so you can access data.home and data.tabs in login.html. You can also access them in notFound.html and everywhere else. here is a new beforeSendPage metamethod which is invoked on all modules, creating an opportunity to implement things like this. Also improved some inline documentation. Stop calling self.renderPage, self.sendPage is less work and gives you these features.