### PR TITLE
Adding help text to field schema

### DIFF
--- a/lib/modules/apostrophe-schemas/public/css/components/help.less
+++ b/lib/modules/apostrophe-schemas/public/css/components/help.less
@@ -1,0 +1,5 @@
+.apos-field .apos-field-help {
+    color: lighten(@apos-dark, 20%);
+    font-style: italic;
+    margin-bottom: 10px;
+}

--- a/lib/modules/apostrophe-schemas/public/css/user.less
+++ b/lib/modules/apostrophe-schemas/public/css/user.less
@@ -1,15 +1,16 @@
 @import 'components/array-editor.less';
 @import 'components/array-field.less';
+@import 'components/help.less';
 
 .apos-field {
-  &.apos-required {
-    label::after {
-      content: ' * Required';
+    &.apos-required {
+        label::after {
+            content: ' * Required';
+        }
     }
-  }
-  &.apos-error-required {
-    label {
-      color: @apos-red;
+    &.apos-error-required {
+        label {
+            color: @apos-red;
+        }
     }
-  }
 }

--- a/lib/modules/apostrophe-schemas/public/css/user.less
+++ b/lib/modules/apostrophe-schemas/public/css/user.less
@@ -3,14 +3,14 @@
 @import 'components/help.less';
 
 .apos-field {
-    &.apos-required {
-        label::after {
-            content: ' * Required';
-        }
+  &.apos-required {
+    label::after {
+      content: ' * Required';
     }
-    &.apos-error-required {
-        label {
-            color: @apos-red;
-        }
+  }
+  &.apos-error-required {
+    label {
+      color: @apos-red;
     }
+  }
 }

--- a/lib/modules/apostrophe-schemas/views/macros.html
+++ b/lib/modules/apostrophe-schemas/views/macros.html
@@ -39,6 +39,9 @@
 {%- macro fieldset(field, bodyMacro) %}
   <fieldset class="apos-field apos-field-{{ field.type | css }} apos-field-{{ field.name | css }} {{ field.classes }}" data-name="{{ field.name }}" {{ field.attributes }}>
     <label for="{{ name }}" class="apos-field-label">{{ field.label }}</label>
+    {%- if field.help -%}
+      <div class="apos-field-help">{{ __(field.help) }}</div>
+    {%- endif -%}
     {{ bodyMacro(field) }}
   </fieldset>
   {# <fieldset class="apos-fieldset apos-fieldset-{{ field.type | css }} apos-fieldset-{{ field.name | css }} {{ field.classes }}" data-name="{{ field.name }}" {{ field.attributes }}>


### PR DESCRIPTION
Example use:

```
    {
      name: 'title',
      type: 'string',
      label: 'Sample Label',
      help: 'Sample Help Text'
    }
```

Screenshot:

<img width="538" alt="screen shot 2016-06-21 at 4 20 23 pm" src="https://cloud.githubusercontent.com/assets/482527/16244869/25dc4568-37cc-11e6-910c-f49408f2ce9e.png">
