### PR TITLE
Fix an issue where you couldn't choose a piece for a widget after add…

### DIFF
--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -18,6 +18,9 @@ apos.define('apostrophe-area-editor', {
 
     self.resetEl = function($el) {
       self.$el = $el;
+      if (self.$selected && self.$selected.length) {
+        self.$selected = self.$el.find('[data-apos-widget-id="' + self.$selected.data('apos-widget-id') + '"]', '[data-apos-area]');
+      }
       self.init();
     };
 
@@ -107,7 +110,7 @@ apos.define('apostrophe-area-editor', {
       // If this is not empty then we want to append the new item after this item.
       // If it is empty then we want to prepend it to the area (we used the content menu
       // at the top of the area, rather than one nested in an item).
-      self.$insertItemContext = $el.parentsUntil('[data-apos-area]').filter('[data-apos-widget-wrapper]', self.$el);
+      self.$selected = $el.parentsUntil('[data-apos-area]').filter('[data-apos-widget-wrapper]', self.$el).find('[data-apos-widget]').first();
 
       // We may have come from a context content menu associated with a specific item;
       // if so dismiss it, but note we waited until after calling closest() to figure out
@@ -237,9 +240,8 @@ apos.define('apostrophe-area-editor', {
 
     self.replaceWidget = function($old, $wrapper) {
       var $widget = $wrapper.findSafe('[data-apos-widget]', '[data-apos-area]');
-      var data = apos.areas.getWidgetData($old);
       self.enhanceWidgetControls($widget);
-      data = apos.areas.getWidgetData($widget);
+      var data = apos.areas.getWidgetData($widget);
       apos.areas.setWidgetData($widget, data);
       $old.replaceWith($widget);
       apos.emit('enhance', $widget);
@@ -247,8 +249,8 @@ apos.define('apostrophe-area-editor', {
 
     self.insertItem = function($item) {
       $item.data('areaEditor', self);
-      if (self.$insertItemContext && self.$insertItemContext.length) {
-        self.$insertItemContext.after($item);
+      if (self.$selected && self.$selected.length) {
+        self.$selected.parent('[data-apos-widget-wrapper]').after($item);
       } else {
         self.$el.find('[data-apos-widgets]:first').prepend($item);
       }
@@ -323,7 +325,8 @@ apos.define('apostrophe-area-editor', {
 
     self.editWidget = function($widget) {
       self.stopEditingRichText();
-      var type = $widget.attr('data-apos-widget');
+      self.$selected = $widget;
+      var type = self.$selected.attr('data-apos-widget');
       var options = self.options.widgets[type] || {};
 
       apos.areas.getWidgetManager(type).edit(
@@ -343,7 +346,7 @@ apos.define('apostrophe-area-editor', {
             // various situations in which jquery is
             // picky about HTML
             var $newWidget = $($.parseHTML($.trim(html), null, true));
-            self.replaceWidget($widget, $newWidget);
+            self.replaceWidget(self.$selected, $newWidget);
             return callback(null, $newWidget.findSafe('[data-apos-widget]', '[data-apos-area]'));
           });
         }

--- a/lib/modules/apostrophe-areas/views/widget.html
+++ b/lib/modules/apostrophe-areas/views/widget.html
@@ -5,7 +5,7 @@
 <div class="apos-area-widget-wrapper" data-apos-widget-wrapper="{{ data.widget.type }}">
   {# This wrapper exists for editor.js to inject contextual widget insertion controls into,
     since those are area level controls rather than widget level #}
-  <div class="apos-area-widget{% if data.manager.options.contextualOnly %} apos-area-widget--contextual{% endif %}" data-apos-widget="{{ data.widget.type }}" data='{{ data.dataFiltered | jsonAttribute({ single: true }) }}' data-options='{{ data.manager.filterOptionsForDataAttribute(apos.utils.omit(data.options, 'area')) | jsonAttribute({ single: true }) }}'>
+  <div class="apos-area-widget{% if data.manager.options.contextualOnly %} apos-area-widget--contextual{% endif %}" data-apos-widget="{{ data.widget.type }}" data-apos-widget-id="{{ data.widget._id }}" data='{{ data.dataFiltered | jsonAttribute({ single: true }) }}' data-options='{{ data.manager.filterOptionsForDataAttribute(apos.utils.omit(data.options, 'area')) | jsonAttribute({ single: true }) }}'>
     {%- if data.widget._edit and data.options.edit != false -%}
       {%- include 'widgetControls.html' -%}
     {%- endif -%}


### PR DESCRIPTION
…ing a new piece through the chooser.

The issue here was caused by the fact that creating a new piece completely blows away apos-refreshable. While we took this into account by retrieving the old area editor and assigning it a new $el, we didn't also reset the $widget being edited (or, in the case of insertion, the $widget we are inserting after).