### PR TITLE
when returning a cropped image attachment found in an apostrophe-imag…

### DIFF
--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -214,29 +214,32 @@ module.exports = function(self, options) {
 
   // This method is available as a template helper: apos.attachments.url
   //
-  // Given a file object (as found in a slideshow widget for instance),
-  // return the file URL. If options.size is set, return the URL for
+  // Given an attachment object,
+  // return the URL. If options.size is set, return the URL for
   // that size (one-third, one-half, two-thirds, full). full is
   // "full width" (1140px), not the original. For the original, don't pass size.
   // If the "uploadfsPath" option is true, an
   // uploadfs path is returned instead of a URL.
 
-  self.url = function(file, options) {
+  self.url = function(attachment, options) {
     options = options || {};
 
-    var path = '/attachments/' + file._id + '-' + file.name;
+    var path = '/attachments/' + attachment._id + '-' + attachment.name;
     if (!options.uploadfsPath) {
       path = self.uploadfs.getUrl() + path;
     }
     // Attachments can have "one true crop," or a crop can be passed with the options.
     // For convenience, be tolerant if options.crop is passed but doesn't
     // actually have valid cropping properties
-    var c = options.crop || file.crop;
-    if (c && c.width) {
-      path += '.' + c.left + '.' + c.top + '.' + c.width + '.' + c.height;
+    var c;
+    if (options.crop !== false) {
+      c = options.crop || attachment._crop || attachment.crop;
+      if (c && c.width) {
+        path += '.' + c.left + '.' + c.top + '.' + c.width + '.' + c.height;
+      }
     }
     var effectiveSize;
-    if ((file.group !== 'images') || (options.size === 'original')) {
+    if ((attachment.group !== 'images') || (options.size === 'original')) {
       effectiveSize = false;
     } else {
       effectiveSize = options.size || 'full';
@@ -244,7 +247,7 @@ module.exports = function(self, options) {
     if (effectiveSize) {
       path += '.' + effectiveSize;
     }
-    return path + '.' + file.extension;
+    return path + '.' + attachment.extension;
   };
 
   // This method is available as a template helper: apos.attachments.first
@@ -353,8 +356,21 @@ module.exports = function(self, options) {
     if (!within) {
       return [];
     }
-    self.apos.docs.walk(within, function(o, key, value) {
+    self.apos.docs.walk(within, function(o, key, value, dotPath, ancestors) {
       if (test(value)) {
+        // If one of our ancestors has a relationship to the piece that
+        // immediately contains us, provide that as the crop. This ensures
+        // that cropping coordinates stored in an apsotrophe-images widget
+        // are passed through when we make a simple call to
+        // apos.attachments.url with the returned object
+        var i;
+        for (i = ancestors.length - 1; (i >= 0); i--) {
+          var ancestor = ancestors[i];
+          if (ancestor.relationships && ancestor.relationships[o._id]) {
+            value._crop = ancestor.relationships[o._id];
+            break;
+          }
+        }
         winners.push(value);
       }
     });

--- a/lib/modules/apostrophe-docs/lib/api.js
+++ b/lib/modules/apostrophe-docs/lib/api.js
@@ -305,9 +305,12 @@ module.exports = function(self, options) {
   // deletes properties.
   //
   // The second argument must be a function that takes
-  // an object, a key, a value and a "dot path" and
-  // returns `false` if that property should be discarded.
-  // If any other value is returned the property remains.
+  // an object, a key, a value, a "dot path" and an
+  // array containing the ancestors of this property
+  // (beginning with the original `doc` and including
+  // "object") and explicitly returns `false` if that property
+  // should be discarded. If any other value is returned the
+  // property remains.
   //
   // Remember, keys can be numbers; toString() is
   // your friend.
@@ -318,13 +321,14 @@ module.exports = function(self, options) {
   //
   // Then when the callback is invoked for b, the
   // object will be { b: 5 }, the key
-  // will be `b`, the value will be `5` and the dotPath
-  // will be the string `a.b`.
+  // will be `b`, the value will be `5`, the dotPath
+  // will be the string `a.b`, and ancestors will be
+  // [ { a: { b: 5 } } ].
   //
-  // You do not need to pass the `_dotPath` argument.
-  // That argument is used for recursive invocation.
+  // You do not need to pass the `_dotPath` and `_ancestors` arguments.
+  // They are used for recursive invocation.
 
-  self.walk = function(doc, callback, _dotPath) {
+  self.walk = function(doc, callback, _dotPath, _ancestors) {
     // We do not use underscore here because of
     // performance issues.
     //
@@ -338,15 +342,16 @@ module.exports = function(self, options) {
     } else {
       _dotPath = '';
     }
+    _ancestors = (_ancestors || []).concat(doc);
     var remove = [];
     for (key in doc) {
       __dotPath = _dotPath + key.toString();
-      if (callback(doc, key, doc[key], __dotPath) === false) {
+      if (callback(doc, key, doc[key], __dotPath, _ancestors) === false) {
         remove.push(key);
       } else {
         val = doc[key];
         if (typeof(val) === 'object') {
-          self.walk(val, callback, __dotPath);
+          self.walk(val, callback, __dotPath, _ancestors.concat([ doc ]));
         }
       }
     }


### PR DESCRIPTION
…es widget, apos.images.first and apos.images.all now return the attachment with a ._crop property, which apos.attachments.url automatically respects unless the crop option is explicitly false. Closes #600