### PR TITLE
Fix issue where a 'group' select field in the user editor would always reset …

### DIFF
--- a/lib/modules/apostrophe-users/index.js
+++ b/lib/modules/apostrophe-users/index.js
@@ -326,6 +326,16 @@ module.exports = {
       });
     };
 
+    var superRequirePiece = self.requirePiece;
+    self.requirePiece = function(req, res, next) {
+      return superRequirePiece(req, res, function() {
+        if (req.piece && req.piece.groupIds && req.piece.groupIds.length) {
+          req.piece.group = req.piece.groupIds[0];
+        }
+        return next();
+      });
+    };
+
     self.addHelpers({
       accountMenu: function() {
         return self.partial('accountMenu', { options: options });


### PR DESCRIPTION
…to 'guest' (or whatever the first group option was), regardless of the actual value. This was happening because that 'group' field doesn't actually correspond to a real field, but rather is just an easier to work with frontend for a `joinByArray`. The conversion (saving) pipeline took this into account, but when retrieving the record from the database we never set the value of the field in order for it to properly populate on the frontend.