### PR TITLE
Fix issue where creating a new contextually edited piece would cause …

### DIFF
--- a/lib/modules/apostrophe-pieces/public/js/editor-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/editor-modal.js
@@ -109,6 +109,7 @@ apos.define('apostrophe-pieces-editor-modal', {
             alert('An error occurred. Please try again.');
             return callback('error');
           }
+          self.unsavedChanges = false;
           return self.displayResponse(result, callback);
         }, function() {
           alert('An error occurred. Please try again');


### PR DESCRIPTION
…the beforeunload confirmation of discarding changes to open.

Once we know that we've successfully saved the piece, set unsavedChanges to false before redirecting to the newly created piece.