### PR TITLE
Explicilty set language attribute

### DIFF
--- a/lib/modules/apostrophe-templates/views/outerLayoutBase.html
+++ b/lib/modules/apostrophe-templates/views/outerLayoutBase.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
   <head>
     <title>{% block title %}{% endblock %}</title>
     {{ apos.assets.stylesheets(data.when) }}


### PR DESCRIPTION
Declaring the lanaguage attribute on the html element helps screen readers with pronunciation