### PR TITLE
set width and height to `auto` after dropping a dragged widget

### DIFF
--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -435,6 +435,8 @@ apos.define('apostrophe-area-editor', {
         // element move when we try to drag it again later
         $item.css('top', '0');
         $item.css('left', '0');
+        $item.css('width', 'auto');
+        $item.css('height', 'auto');
         $(event.target).after($item);
         self.disableDroppables();
         self.reRenderWidget($item);


### PR DESCRIPTION
this lets the widget take the shape of the new area you've dropped into without refresh