### PR TITLE
Schema error css separation

### DIFF
--- a/lib/modules/apostrophe-schemas/public/css/user.less
+++ b/lib/modules/apostrophe-schemas/public/css/user.less
@@ -2,23 +2,37 @@
 @import 'components/array-field.less';
 @import 'components/help.less';
 
-.apos-field {
-  &.apos-required {
-    label::after {
-      content: ' *';
-      color: @apos-base;
-    }
+.apos-required {
+  label::after {
+    content: ' *';
+    color: @apos-base;
   }
-  &.apos-error-required {
-    label {
-      color: @apos-red;
-      
-      &:after {
-        color: @apos-red;
-        content: ' (required)';
-      }
-    }
-    
-    input { .apos-glow(@apos-red); }
+}
+
+/////////////////////////////
+// generic state styles
+/////////////////////////////
+.apos-error
+{
+  input { .apos-glow(@apos-red); }
+  label { color: @apos-red; }
+}
+
+.apos-warning
+{
+  input { .apos-glow(@apos-gold); }
+  label { color: @apos-gold; }
+}
+
+/////////////////////////////
+// specific states
+/////////////////////////////
+
+.apos-error--required
+{
+  label:after
+  {
+    color: @apos-red;
+    content: ' (required)';
   }
 }

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -294,7 +294,7 @@ apos.define('apostrophe-schemas', {
     self.showError = function($el, error) {
       var $fieldset = self.findFieldset($el, error.field.name);
       $fieldset.addClass('apos-error');
-      $fieldset.addClass('apos-error-' + apos.utils.cssName(error.type));
+      $fieldset.addClass('apos-error--' + apos.utils.cssName(error.type));
       // makes it easy to do more with particular types of errors
       apos.emit('schemaError', $fieldset, error);
     };


### PR DESCRIPTION
separate generic error and warning states from the specific instructions/actions the user needs to know in order to submit a happy form.