### PR TITLE
autoload cursor definitions

### DIFF
--- a/lib/modules/apostrophe-custom-pages/index.js
+++ b/lib/modules/apostrophe-custom-pages/index.js
@@ -61,16 +61,17 @@ module.exports = {
 
     // Return a cursor for finding pages of this type only. The cursor is an
     // `apostrophe-pages-cursor`, so it has access to filters like
-    // `ancestors` and `children`. Subclasses will often override this
-    // to create a cursor of a more specific type that adds more filters
+    // `ancestors` and `children`.
+    //
+    // Because pages are normally displayed by Apostrophe's page loading mechanism,
+    // which uses an `apostrophe-pages-cursor`, it doesn't really make sense to return
+    // a custom cursor subclass here. It would not be used when actually viewing the
+    // page anyway. If you must have extra filters for specific page types, implicitly
+    // subclass apostrophe-pages-cursor and add filters that are mindful of the
+    // type of each page.
 
     self.find = function(req, criteria, projection) {
-      return self.apos.create('apostrophe-pages-cursor', {
-        apos: self.apos,
-        req: req,
-        criteria: criteria,
-        projection: projection
-      }).type(self.name);
+      return self.apos.pages.find(req, criteria, projection).type(self.name);
     };
 
   }

--- a/lib/modules/apostrophe-doc-type-manager/index.js
+++ b/lib/modules/apostrophe-doc-type-manager/index.js
@@ -17,6 +17,7 @@ var _ = require('lodash');
 module.exports = {
 
   afterConstruct: function(self) {
+    self.defineCursor();
     self.composeSchema();
     self.apos.docs.setManager(self.name, self);
     self.pushAssets();

--- a/lib/modules/apostrophe-doc-type-manager/lib/api.js
+++ b/lib/modules/apostrophe-doc-type-manager/lib/api.js
@@ -2,21 +2,38 @@ var _ = require('lodash');
 
 module.exports = function(self, options) {
 
+  // Define the related type "cursor", so that all of our subclasses
+  // automatically have a cursor type too, and it is autoloaded from
+  // ./lib/cursor.js if that exists, otherwise given an empty
+  // definition.
+
+  self.defineCursor = function() {
+    self.defineRelatedType('cursor', {
+      stop: 'apostrophe-doc-type-manager'
+    });
+  };
+
   // Returns a cursor that will only yield docs of the appropriate type
-  // as determined by the `name` option of the module. Subclasses often
-  // extend this method to return a cursor of a subclass that adds
-  // additional filters.
+  // as determined by the `name` option of the module. Returns a cursor of
+  // the appropriate type for the current module, even if it is a subclass.
+
+  // Returns a cursor for use in finding docs. See cursor.js for chainable
+  // filters, and also yielders that actually deliver the docs to you.
 
   self.find = function(req, criteria, projection) {
-    return self.apos.docs.find(req, criteria, projection).type(self.name);
+    return self.createRelatedType('cursor', {
+      apos: self.apos,
+      module: self,
+      req: req,
+      criteria: criteria,
+      projection: projection
+    });
   };
 
   // Returns a new instance of the doc type, with the appropriate default
   // values for each schema field.
 
   self.newInstance = function() {
-    // Careful, we can't refer to `manager` as self because of the way our
-    // methods get merged into other objects; so get the actual manager
     var doc = self.apos.schemas.newInstance(self.schema);
     doc.type = self.name;
     return doc;

--- a/lib/modules/apostrophe-doc-type-manager/lib/cursor.js
+++ b/lib/modules/apostrophe-doc-type-manager/lib/cursor.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extend: 'apostrophe-cursor',
+  afterConstruct: function(self) {
+    self.type(self.options.module.name);
+  }
+};

--- a/lib/modules/apostrophe-groups/index.js
+++ b/lib/modules/apostrophe-groups/index.js
@@ -55,7 +55,6 @@ module.exports = {
   },
 
   construct: function(self, options) {
-    self.apos.define('apostrophe-groups-cursor', require('./lib/cursor.js'));
 
     self.modulesReady = function() {
       self.setPermissionsChoices();

--- a/lib/modules/apostrophe-images/index.js
+++ b/lib/modules/apostrophe-images/index.js
@@ -56,7 +56,6 @@ module.exports = {
     self.pushAsset('script', 'editor-modal', { when: 'user' });
     self.pushAsset('stylesheet', 'user', { when: 'user' });
     require('./lib/api.js')(self, options);
-    self.apos.define('apostrophe-images-cursor', require('./lib/cursor.js'));
     self.enableHelpers();
   }
 };

--- a/lib/modules/apostrophe-module/index.js
+++ b/lib/modules/apostrophe-module/index.js
@@ -17,6 +17,7 @@
 var _ = require('lodash');
 var async = require('async');
 var moment = require('moment');
+var fs = require('fs');
 
 module.exports = {
   beforeConstruct: function(self, options) {
@@ -418,5 +419,120 @@ module.exports = {
         action: self.action
       };
     };
+
+    // Define a new moog type related to this module, autoloading its
+    // definition from the appropriate file. This is very helpful when you
+    // want to define another type of object, other than the module itself.
+    // Apostrophe uses this method to define database cursor types related to modules.
+
+    // The name of the related type will be the name of the module, followed by a
+    // hyphen, followed by the value of `tool`. The definition of the type will be
+    // automatically loaded from the `lib/tool.js` file of the module
+    // (substitute the actual tool parameter for `tool`, i.e. `cursor.js`).
+
+    // This is done recursively for all modules that this module
+    // extends, whether or not they actually have a `lib/tool.js` file.
+    // If the file is missing, an empty definition is synthesized that
+    // extends the next "parent class" in the chain.
+
+    // If any of the types are already defined, execution stops at that
+    // point. For instance, if `apostrophe-images` has already called this
+    // as a subclass of `apostrophe-pieces`, then `apostrophe-files` will
+    // just define its own cursor, extending `apostrophe-pieces-cursor`, and stop.
+    // This prevents duplicate definitions when many types extend `apostrophe-pieces`.
+
+    // If `options.stop` is set to the name of an ancestor module,
+    // the chain stops **after** defining the related type for that module.
+
+    // For instance, the module `apostrophe-files` extends
+    // `apostrophe-pieces`, which extends `apostrophe-doc-type-manager`.
+
+    // So when that module calls:
+
+    // ```
+    // self.defineRelatedType('cursor', {
+    //   stop: 'apostrophe-doc-type-manager'
+    // });
+    // ```
+
+    // We get:
+
+    // apostrophe-files-cursor extends...
+    // apostrophe-pieces-cursor which extends...
+    // apostrophe-doc-type-manager-cursor which extends...
+    // apostrophe-cursor (because `cursor.js` for doc-type-manager says so)
+
+    self.defineRelatedType = function(tool, options) {
+      var chain = self.__meta.chain;
+      defineRelatedTypeBody(chain.length - 1, tool, options);
+
+      // if (self.__meta.name === 'apostrophe-tags') {
+      //   process.exit(1);
+      // }
+      function defineRelatedTypeBody(i, tool, options) {
+        var definition;
+        var extend;
+        var synthesized;
+        var name = chain[i].name + '-' + tool;
+        if (_.has(self.apos.synth.definitions, name.replace(/^my-/, ''))) {
+          // Already defined
+          return;
+        }
+        var path = chain[i].dirname + '/lib/' + tool + '.js';
+        if (!fs.existsSync(path)) {
+          // Synthesize
+          definition = {};
+          synthesized = true;
+        } else {
+          // Load the definition; supply `extend` if it is not set
+          definition = require(path);
+        }
+        extend = definition.extend;
+        if (extend === undefined) {
+          extend = inferParentName();
+          if (extend !== undefined) {
+            definition.extend = extend;
+          }
+        }
+        var inferred = inferParentName();
+        if (inferred && ((extend === inferred) || (('my-' + extend) === inferred))) {
+          defineRelatedTypeBody(i - 1, tool, options);
+        }
+        if (name.match(/^my-/)) {
+          // Restore the implicit subclassing
+          name = name.replace(/^my-/, '');
+          definition.extend = undefined;
+        }
+        // console.log('DEFINING ' + name + (synthesized ? ' (synthetic)' : ''));
+        self.apos.synth.define(name, definition);
+
+        function inferParentName() {
+          if ((i > 0) && (chain[i].name !== options.stop)) {
+            return (chain[i - 1].name + '-' + tool).replace(/^my-/, '');
+          } else {
+            // A hard stop, so we don't implicitly extend
+            // `apostrophe-module`. Related types are not modules
+            return false;
+          }
+        }
+
+      }
+    };
+
+    // Create an object of a related type defined by this module.
+    // See `defineRelatedType`. A convenient wrapper for calling `apos.create`.
+    
+    // For instance, if this module is `apostrophe-images`, then
+    // `self.createRelatedType('cursor', { options... })` will
+    // create an instance of `apostrophe-images-cursor`.
+    
+    // As usual with moog, the callback is required only if
+    // at least one `construct`, `beforeConstruct` or `afterConstruct`
+    // function takes a callback.
+
+    self.createRelatedType = function(tool, options, callback) {
+      return self.apos.synth.create(self.__meta.name + '-' + tool, options, callback);
+    };
+
   }
 };

--- a/lib/modules/apostrophe-pieces/index.js
+++ b/lib/modules/apostrophe-pieces/index.js
@@ -138,13 +138,6 @@ module.exports = {
     self.choiceTemplate = self.__meta.name + ':chooserChoice.html';
     self.choicesTemplate = self.__meta.name + ':chooserChoices.html';
     self.relationshipTemplate = self.__meta.name + ':relationshipEditor.html';
-
-    // Define the corresponding cursor type
-    self.apos.define('apostrophe-pieces-cursor', require('./lib/cursor.js'));
-    // Ensure that any subclasses that don't explicitly define their own
-    // cursor type still have one by the appropriate name
-    self.apos.synth.mirror(self.__meta, '-cursor');
-
   }
 
 };

--- a/lib/modules/apostrophe-pieces/lib/api.js
+++ b/lib/modules/apostrophe-pieces/lib/api.js
@@ -10,19 +10,6 @@ module.exports = function(self, options) {
     self.trashPrefixFields = self.trashPrefixFields.concat(fields);
   };
 
-  // Returns a cursor for use in finding docs. See cursor.js for chainable
-  // filters, and also yielders that actually deliver the docs to you
-
-  self.find = function(req, criteria, projection) {
-    return cursor = self.apos.create(self.__meta.name + '-cursor', {
-      apos: self.apos,
-      module: self,
-      req: req,
-      criteria: criteria,
-      projection: projection
-    });
-  };
-
   // Returns a cursor that finds docs the current user can edit. Unlike
   // find(), this cursor defaults to including unpublished docs. Subclasses
   // of apostrophe-pieces often extend this to remove more default filters

--- a/lib/modules/apostrophe-pieces/lib/cursor.js
+++ b/lib/modules/apostrophe-pieces/lib/cursor.js
@@ -1,9 +1,7 @@
 module.exports = {
-  extend: 'apostrophe-cursor',
+  extend: 'apostrophe-doc-type-manager-cursor',
   afterConstruct: function(self) {
-    // Customize defaults. If we don't do this late in afterConstruct, we
-    // get blown out by the criteria argument to find()
-    self.type(self.options.module.name).sort(self.options.module.options.sort || { updatedAt: -1 });
+    self.sort(self.options.module.options.sort || { updatedAt: -1 });
   }
 };
 

--- a/lib/modules/apostrophe-tags/lib/browser.js
+++ b/lib/modules/apostrophe-tags/lib/browser.js
@@ -10,7 +10,7 @@ module.exports = function(self, options) {
   self.pushDefinitions = function() {
     var tools =[ 'manager-modal' ];
     _.each(tools, function(tool) {
-      self.apos.push.browserMirrorCall('user', self, { 'tool': tool, 'substitute': { 'apostrophe-doc-type-manager': 'apostrophe-docs' } });
+      self.apos.push.browserMirrorCall('user', self, { 'tool': tool, 'stop': 'apostrophe-tags-manager-modal' });
     });
   };
 };

--- a/lib/modules/apostrophe-users/index.js
+++ b/lib/modules/apostrophe-users/index.js
@@ -541,7 +541,5 @@ module.exports = {
       });
     });
 
-    self.apos.define('apostrophe-users-cursor', require('./lib/cursor.js'));
-
   }
 };


### PR DESCRIPTION
## TL;DR SUMMARY

With this change, any subclass of pieces with a "lib/cursor.js" will automatically load it. This includes project level.

It must export a moog definition (an object with `construct` or perhaps `afterConstruct` functions). The cursor is "self" in these functions. In other words it looks just like a module "index.js" file. 

No "extend" property is required, unless you're actually looking to avoid extending the usual thing.

Boom!

No overriding "self.find", no calling "apos.define". Nuttin. It just works. 

This addresses the pain point of remembering how to `apos.define` and require cursors, the one thing we frequently have to manually define on the server side, every time we want to add filters. I think this has been one of the reasons why folks have been slow to stop adding filters in `find`, which is wrong (it breaks pagination).

## BC BREAK

This impacts all the projects that are defining cursors the hard way, or requiring a cursor.js file from find() calls. But the former is unnecessary work and the latter is wrong (it breaks pagination). So let's just fix them. I have fixes standing by for the blog, events, and places modules, plus sci center and urban engineering. I will walk everybody through anything that comes up with this; I really want to land it for 2.x.

## IMPORTANT TO KNOW

*"So what is cool to do in an override of a `find` method?*

It is OK to CALL filters there, but you should NEVER ADD filters there. Do that in cursor.js.

You know what's better though? Call those filters in `afterConstruct` in your `cursor.js`. Don't bother overriding `find`.

"What if I need access to my module in my filters?"

You can get at the module from the cursor:

`self.options.module`

## HOW MUCH DO YOU TRUST THE CODE?

I tested the code pretty thoroughly. I'm more interested in buy-in for making this change. I feel strongly enough about it that I think we should do it before publishing 2.0. It would definitely be a "3.0" BC break if we didn't.

## MORE ANTICIPATED QUESTIONS

*"What about other doc type managers?"* Oh cool, you've been paying attention. Correct, this is actually for all doc type managers, but most folks are generally familiar only with pieces.

*"What if your parent class also has a cursor.js?"* They both work, they extend like you hope they do.

*"So if I put cursor.js in pieces..."* Yes, you can have a lib/modules/apostrophe-pieces/lib/cursor.js and that affects *all* pieces.

*"Do I have to have an index.js for the module?"* No, you don't have to have an index.js for the module *at all*, it still just works.

*"Is this a special snowflake one-off pattern to clutter up our world?"* Nope! If you want to create a cool new "related type" like cursors for your module, check out the new "defineRelatedType" and "createRelatedType" methods, now available on all modules. These kill the weirdness of defining and creating cursors and other things that are objects, but are not modules. You get snazzy autoloading of definitions, just like for cursors.

*"What about pages?"* Pages break out of this pattern, for reasons (they are loaded by apostrophe-pages-cursor, they are of many different types, it's a bad assumption to think their own cursor will get used).

*"What about adding methods to ALL cursors? Even the generic `apostrophe-cursor` that doesn't care about types at all?"* Wow, you really have been paying attention. Yes, we do that sometimes, but it's a big deal and I think explicitly calling `apos.define('apostrophe-cursor', require(...))` makes sense for such a momentous occasion.

