### PR TITLE
fast related pages (ancestors and children should not have joins by d…

### DIFF
--- a/lib/modules/apostrophe-pages/lib/pagesCursor.js
+++ b/lib/modules/apostrophe-pages/lib/pagesCursor.js
@@ -54,7 +54,7 @@ module.exports = {
         return async.eachSeries(results, function(page, callback) {
           var req = self.get('req');
 
-          var aCursor = self.apos.pages.find(req).areas(false);
+          var aCursor = self.apos.pages.find(req).areas(false).joins(false);
 
           var parameters = applySubcursorOptions(aCursor, options, [ 'depth' ]);
 
@@ -133,7 +133,7 @@ module.exports = {
           return setImmediate(callback);
         }
 
-        var cCursor = self.apos.pages.find(self.get('req')).areas(false).orphan(false);
+        var cCursor = self.apos.pages.find(self.get('req')).areas(false).joins(false).orphan(false);
 
         var parameters = applySubcursorOptions(cCursor, value, [ 'depth' ]);
 

--- a/lib/modules/apostrophe-templates/views/outerLayoutBase.html
+++ b/lib/modules/apostrophe-templates/views/outerLayoutBase.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>{% block title %}{% endblock %}</title>


### PR DESCRIPTION
…efault), also HTML5 doctype in outerLayoutBase so jQuery accepts it is HTML5