### PR TITLE
100% height for login takeover page

### DIFF
--- a/lib/modules/apostrophe-login/public/css/always.less
+++ b/lib/modules/apostrophe-login/public/css/always.less
@@ -7,6 +7,7 @@
 }
 .apos-login-content
 {
+  background-color: @apos-primary;
   position: relative;
   top: @apos-margin-5;
   left: 50%;

--- a/lib/modules/apostrophe-login/public/css/always.less
+++ b/lib/modules/apostrophe-login/public/css/always.less
@@ -1,3 +1,12 @@
+html, body
+{
+  height: 100%;
+}
+
+.apos-refreshable
+{
+  height: 100%;
+}
 
 .apos-login-wrapper
 {

--- a/lib/modules/apostrophe-login/public/css/always.less
+++ b/lib/modules/apostrophe-login/public/css/always.less
@@ -1,21 +1,13 @@
-html, body
-{
-  height: 100%;
-}
-
-.apos-refreshable
-{
-  height: 100%;
-}
-
 .apos-login-wrapper
 {
+  position: absolute;
+  width: 100%;
   height: 100%;
   background-color: @apos-primary;
 }
 .apos-login-content
 {
-  position: absolute;
+  position: relative;
   top: @apos-margin-5;
   left: 50%;
   -webkit-transform: translateX(-50%);
@@ -29,6 +21,7 @@ html, body
 }
 .apos-login.apos-ui
 {
+  margin: 0 auto;
   max-width: 300px;
   background-color: @apos-light;
   padding: @apos-padding-2;

--- a/lib/modules/apostrophe-ui/public/css/components/admin-bar.less
+++ b/lib/modules/apostrophe-ui/public/css/components/admin-bar.less
@@ -22,7 +22,7 @@
   position: relative;
   padding: @apos-padding-2;
   .apos-inline-block();
-  background-color: @apos-base;
+  // background-color: @apos-base;
   cursor: pointer;
   z-index: 1; // todo bobo
   svg { max-height: 36px; }


### PR DESCRIPTION
fix for boilerplate `login.html` styles. feels a little strange pushing styles for `html` and `body` just within this module. 