### PR TITLE
showFields fixes: function properly if a field is shown by two choice…

### DIFF
--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -133,6 +133,15 @@ apos.define('apostrophe-schemas', {
         if (!$field.length) {
           $field = self.findField($el, field.legacy);
         }
+        var $fieldset = self.findFieldset($el, field.name);
+
+        if ($fieldset.hasClass('apos-hidden')) {
+          // If this field is hidden by toggleHiddenFields, the user is not expected to
+          // populate it, even if it would otherwise be required. This allows showFields to
+          // function as intended, and as seen in A2 0.5
+          return setImmediate(callback);
+        }
+
         return self.fieldTypes[field.type].convert(data, field.name, $field, $el, field, function(err) {
           if (err) {
             // error can be an object, with field and type properties
@@ -401,7 +410,6 @@ apos.define('apostrophe-schemas', {
 
       $field.on('change', afterChange);
       $fieldset.on('aposShowFields', afterChange);
-
       function afterChange() {
         // Implement showFields
 
@@ -418,6 +426,11 @@ apos.define('apostrophe-schemas', {
         } else {
           val = $field.val();
         }
+
+        // Recall if another choice currently active already chose to show each field.
+        // That way, if two choices show the same field, the fact that the second one
+        // is not currently selected does not hide the field the first one just showed
+        var shown = {};
 
         _.each(field.choices || [], function(choice) {
 
@@ -437,6 +450,7 @@ apos.define('apostrophe-schemas', {
             } else if (!choice.value) {
               if ((!val) || (val === '0')) {
                 show = true;
+              } else {
               }
             } else {
               if (val && (val !== '0')) {
@@ -451,11 +465,15 @@ apos.define('apostrophe-schemas', {
           }
 
           _.each(choice.showFields || [], function(fieldName) {
+            if (show || shown[fieldName]) {
+              shown[fieldName] = true;
+            } else {
+              shown[fieldName] = false;
+            }
             var $fieldset = self.findFieldset($el, fieldName);
-            $fieldset.toggleClass('apos-hidden', !show);
+
+            $fieldset.toggleClass('apos-hidden', !shown[fieldName]);
             $fieldset.trigger('aposShowFields');
-            var $helpText = $fieldset.next('p.apos-help');
-            $helpText.toggleClass('apos-hidden', !show);
           });
 
         });


### PR DESCRIPTION
…s. Function properly when `choices` with `showFields` have been set for boolean fields. Ignore `required` for fields that are hidden by `showFields`, so that it can be used as intended to say that these things are required only in the presence of a particular select or boolean choice.