### PR TITLE
added slugs to autocomplete titles for all page types and for the "an…

### DIFF
--- a/lib/modules/apostrophe-any-page-manager/index.js
+++ b/lib/modules/apostrophe-any-page-manager/index.js
@@ -28,12 +28,11 @@ module.exports = {
     // for this type if all that is needed is a title for display
     // in an autocomplete menu. Since this is a page, we are including
     // the slug as well.
+    var superGetAutocompleteProjection = self.getAutocompleteProjection;
     self.getAutocompleteProjection = function(query) {
-      return {
-        title: 1,
-        slug: 1,
-        _id: 1
-      };
+      var projection = superGetAutocompleteProjection(query);
+      projection.slug = 1;
+      return projection;
     };
 
     // Returns a string to represent the given `doc` in an

--- a/lib/modules/apostrophe-custom-pages/index.js
+++ b/lib/modules/apostrophe-custom-pages/index.js
@@ -81,5 +81,6 @@ module.exports = {
 
   construct: function(self, options) {
     require('./lib/dispatch.js')(self, options);
+    require('./lib/api.js')(self, options);
   }
 };

--- a/lib/modules/apostrophe-custom-pages/lib/api.js
+++ b/lib/modules/apostrophe-custom-pages/lib/api.js
@@ -1,0 +1,23 @@
+module.exports = function(self, options) {
+  // Returns a MongoDB projection object to be used when querying
+  // for this type if all that is needed is a title for display
+  // in an autocomplete menu. Since this is a page, we are including
+  // the slug as well.
+  var superGetAutocompleteProjection = self.getAutocompleteProjection;
+  self.getAutocompleteProjection = function(query) {
+    var projection = superGetAutocompleteProjection(query);
+    projection.slug = 1;
+    return projection;
+  };
+
+  // Returns a string to represent the given `doc` in an
+  // autocomplete menu. `doc` will contain only the fields returned
+  // by `getAutocompleteProjection`. `query.field` will contain
+  // the schema field definition for the join the user is attempting
+  // to match titles from. The default behavior is to return
+  // the `title` property, but since this is a page we are including
+  // the slug as well.
+  self.getAutocompleteTitle = function(doc, query) {
+    return doc.title + ' (' + doc.slug + ')';
+  };
+};

--- a/lib/modules/apostrophe-global/index.js
+++ b/lib/modules/apostrophe-global/index.js
@@ -62,7 +62,10 @@ module.exports = {
           }, callback);
         },
         fetch: function(callback) {
-          return self.findGlobal(req, function(err, result) {
+          // Existence test must not load widgets etc. as this can lead
+          // to chicken and egg problems if widgets join with page types
+          // not yet registered
+          return self.apos.docs.db.findOne({ slug: self.slug }, function(err, result) {
             if (err) {
               return callback(err);
             }
@@ -74,7 +77,7 @@ module.exports = {
           if (existing) {
             return setImmediate(callback);
           }
-          return self.apos.docs.insert(req, { slug: 'global', published: true, type: self.name }, callback);
+          return self.apos.docs.insert(req, { slug: self.slug, published: true, type: self.name }, callback);
         }
       }, callback)
     };


### PR DESCRIPTION
…y page" case, in a way that extends whatever projection is being returned for all doctypes. In addition, fixed a bug in the apostrophe-global module: it would crash on startup if an existing "global" doc contained widgets referencing doc types not yet initialized, such as "plain old page types" which get initialized at the last minute. Also, this module now correctly respects its "slug" option.