### PR TITLE
Align richtext contextual hover controls above text

### DIFF
--- a/lib/modules/apostrophe-rich-text-widgets/public/css/components/rich-text-widget.less
+++ b/lib/modules/apostrophe-rich-text-widgets/public/css/components/rich-text-widget.less
@@ -5,8 +5,9 @@
   {
     >.apos-area-widget-controls--context
     {
-      top: 0;
-      transform: translateY(-50%);
+      top: auto;
+      left: 0;
+      bottom: 100%;
     }
     >.apos-area-widget-controls--data
     {


### PR DESCRIPTION
Sample area:
![screenshot from 2016-10-08 21 15 04](https://cloud.githubusercontent.com/assets/3639540/19217259/644d841e-8da4-11e6-8f81-9e14a27f30d4.png)

The problem (hovering over the text covers it when it's only a single line):
![screenshot from 2016-10-08 21 15 18](https://cloud.githubusercontent.com/assets/3639540/19217262/6e8cd592-8da4-11e6-8ce8-e21ee3528c42.png)

Fixed:
![screenshot from 2016-10-08 22 12 04](https://cloud.githubusercontent.com/assets/3639540/19217264/7587282a-8da4-11e6-82c0-93de8f6b0d7c.png)

EDIT: This still needs work, actually. I just discovered that this will interrupt the hover states of adjacent objects.