### PR TITLE
Corrected link to tutorial page

### DIFF
--- a/lib/modules/apostrophe-images-widgets/index.js
+++ b/lib/modules/apostrophe-images-widgets/index.js
@@ -1,6 +1,6 @@
 // Implements widgets that display single images and slideshows.
 //
-// See [adding editable content to pages](../../tutorials/getting-started/adding-editable-content-to-pages#apostrophe-images) for a thorough discussion of the options that can be passed to the widget.
+// See [adding editable content to pages](../../tutorials/getting-started/adding-editable-content-to-pages.html#code-apostrophe-images-code) for a thorough discussion of the options that can be passed to the widget.
 
 var _ = require('lodash');
 


### PR DESCRIPTION
Was missing a ".html" extension, and the hash wasn't quite right either