### PR TITLE
[Area UX] Changes to Areas controls

### DIFF
--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -113,22 +113,27 @@
   padding: 0;
 }
 
+// [data-apos-area-controls] .apos-area-controls { opacity: 1 !important;}
 .apos-ui .apos-dropdown.apos-dropdown--area-controls
 {
+  height: 5px;
   display: inherit;
   .apos-drop-shadow(0, 0, 0, 0);
   >.apos-button
   {
+    position: relative;
+    top: -7px;
     border: 2px solid @apos-white;
     .apos-rounded(@apos-padding-3);
     .apos-drop-shadow();
+
   }
   >.apos-dropdown-items
   {
     text-align: left;
     left: 0;
     right: 0;
-    top: 12px;
+    top: 6px;
     margin-left: auto;
     margin-right: auto;
     max-width: 200px;
@@ -172,7 +177,8 @@
 .apos-area-widget-wrapper>.apos-ui>.apos-area-controls
 {
   bottom: 0;
-  transform: translateY(50%);
+  // transform: translateY(50%);
+  height: 5px;
   .apos-transition;
 }
 
@@ -194,7 +200,7 @@
 {
   width: 100%;
   height: 2px;
-  transform: translateY(-13px);
+  transform: translateY(-2px);
   background-color: @apos-base;
   .apos-glow;
   z-index: 0;
@@ -216,6 +222,7 @@
   & > .apos-area-widgets > .apos-area-widget-wrapper > .apos-ui .apos-area-controls
   {
     top: auto;
+    padding: 10px 0;
     transform: none;
     position: relative;
     .apos-area-divider

--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -54,7 +54,7 @@
 
 .apos-hide { opacity: 0; }
 .apos-show { opacity: 1; }
-.apos-peek { opacity: @apos-translucent-opacity; }
+.apos-area .apos-peek { opacity: @apos-translucent-opacity; }
 
 .apos-area-widget {
   &:hover .apos-peek { pointer-events: auto;}
@@ -211,7 +211,7 @@
 .apos-rich-text-active .apos-area-controls { display: none !important; }
 
 // Special consideration for 'block-like' areas
-[data-apos-area-role="layout"]
+.apos-area--block-level-controls
 {
   & > .apos-ui
   {

--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -11,7 +11,6 @@
 
 .apos-area
 {
-  &:hover { background: red; }
   // When an area's limit is reached, it shouldn't display controls
   // to add more content. We use direct children selectors to in order
   // to support nested areas.
@@ -58,8 +57,6 @@
 .apos-peek { opacity: @apos-translucent-opacity; }
 
 .apos-area-widget {
-  // z-index: @apos-z-index-2;
-  // &:hover { z-index: @apos-z-index-4; }
   &:hover .apos-peek { pointer-events: auto;}
   >.apos-ui .apos-area-widget-controls:hover { opacity: 1 }
 

--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -3,8 +3,15 @@
 
 .apos-area, .apos-area-widgets, .apos-area-widget { position: relative; }
 
+.apos-peek
+{
+  pointer-events: none;
+}
+
+
 .apos-area
 {
+  &:hover { background: red; }
   // When an area's limit is reached, it shouldn't display controls
   // to add more content. We use direct children selectors to in order
   // to support nested areas.
@@ -51,7 +58,9 @@
 .apos-peek { opacity: @apos-translucent-opacity; }
 
 .apos-area-widget {
-
+  // z-index: @apos-z-index-2;
+  // &:hover { z-index: @apos-z-index-4; }
+  &:hover .apos-peek { pointer-events: auto;}
   >.apos-ui .apos-area-widget-controls:hover { opacity: 1 }
 
   // When an area has a limit of one, its children widgets shouldn't
@@ -91,6 +100,8 @@
   .apos-transition;
 }
 
+// .ui-draggable-dragging { position: absolute !important; }
+
 .apos-dragging .apos-area-item-separator
 {
   border-width: 1px;
@@ -120,7 +131,7 @@
     text-align: left;
     left: 0;
     right: 0;
-    top: 15px;
+    top: 12px;
     margin-left: auto;
     margin-right: auto;
     max-width: 200px;
@@ -139,6 +150,7 @@
 
 .apos-area-controls
 {
+  .apos-transition;
   position: absolute;
   width: 100%;
   text-align: center;
@@ -184,12 +196,36 @@
 .apos-area-controls .apos-area-divider
 {
   width: 100%;
-  height: 3px;
+  height: 2px;
   transform: translateY(-13px);
   background-color: @apos-base;
+  .apos-glow;
   z-index: 0;
 }
 // TODO figure out how to select these specifically enough that !important isn't necessary
 .apos-area-controls.apos-active { opacity: 1 !important; display: block; z-index: @apos-z-index-5; }
 .apos-dragging .apos-area-controls { opacity: 0 !important; }
 .apos-rich-text-active .apos-area-controls { display: none !important; }
+
+// Special consideration for 'block-like' areas
+[data-apos-area-role="layout"]
+{
+  & > .apos-ui
+  {
+    display: block;
+    position: relative;
+  }
+  & > .apos-ui .apos-area-controls,
+  & > .apos-area-widgets > .apos-area-widget-wrapper > .apos-ui .apos-area-controls
+  {
+    top: auto;
+    transform: none;
+    position: relative;
+    .apos-area-divider
+    {
+      .apos-glow(@apos-secondary);
+      background-color: @apos-secondary;
+    }
+    .apos-button--circular { background-color: @apos-secondary; }
+  }
+}

--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -232,4 +232,11 @@
     }
     .apos-button--circular { background-color: @apos-secondary; }
   }
+
+  // color contextual controls as well
+  & > .apos-area-widgets > .apos-area-widget-wrapper > .apos-area-widget > .apos-ui .apos-button--in-context
+  {
+    .apos-glow(@apos-secondary);
+    border: 2px solid @apos-secondary;
+  }
 }

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -80,6 +80,8 @@ apos.define('apostrophe-areas-editor', {
         self.stopEditingRichText();
       });
       self.$el.mouseover(function(e) {
+        console.log(self.$el);
+        console.log('hover');
         self.$el.addClass('apos-hover');
         e.stopPropagation();
       });

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -80,8 +80,6 @@ apos.define('apostrophe-areas-editor', {
         self.stopEditingRichText();
       });
       self.$el.mouseover(function(e) {
-        console.log(self.$el);
-        console.log('hover');
         self.$el.addClass('apos-hover');
         e.stopPropagation();
       });

--- a/lib/modules/apostrophe-areas/public/js/user.js
+++ b/lib/modules/apostrophe-areas/public/js/user.js
@@ -45,9 +45,9 @@ apos.define('apostrophe-areas', {
         $el.on('mouseover', function(e) {
           var $self = $(this);
           e.stopPropagation();
-
           $('.apos-area-widget-controls').removeClass('apos-peek');
           $self.find('[data-apos-widget-controls]:first .apos-area-widget-controls').addClass('apos-peek');
+          $self.next().children().addClass('apos-peek');
         });
       };
 
@@ -55,6 +55,7 @@ apos.define('apostrophe-areas', {
         $el.on('mouseleave', function(e) {
           var $self = $(this);
           $self.find('[data-apos-widget-controls]:first .apos-area-widget-controls').removeClass('apos-peek');
+          $self.next().children().removeClass('apos-peek');
         });
       }
 

--- a/lib/modules/apostrophe-areas/views/area.html
+++ b/lib/modules/apostrophe-areas/views/area.html
@@ -2,7 +2,7 @@
 {# JSON, for adding new widgets #}
 {%- set canEdit = data.area._edit and data.options.edit != false -%}
 {%- set isSingleton = data.options.limit == 1 and data.options.type -%}
-<div class="apos-area" {% if data.options.role %}data-apos-area-role={{ data.options.role }} {% endif %}data-apos-area{% if canEdit %} data-apos-area-edit{% if not data.options.virtual %} data-autosave{% endif %} data-options='{{ apos.utils.omit(data.options, 'area') | jsonAttribute({ single: true }) }}' data-doc-id="{{ data.area._docId }}" data-dot-path="{{ data.area._dotPath }}"{% endif %}>
+<div class="apos-area{% if data.options.blockLevelControls %} apos-area--block-level-controls{% endif %}"data-apos-area{% if canEdit %} data-apos-area-edit{% if not data.options.virtual %} data-autosave{% endif %} data-options='{{ apos.utils.omit(data.options, 'area') | jsonAttribute({ single: true }) }}' data-doc-id="{{ data.area._docId }}" data-dot-path="{{ data.area._dotPath }}"{% endif %}>
   {%- if canEdit -%}
     {%- if isSingleton -%}
       {% include "singletonControls.html" %}

--- a/lib/modules/apostrophe-areas/views/area.html
+++ b/lib/modules/apostrophe-areas/views/area.html
@@ -2,7 +2,7 @@
 {# JSON, for adding new widgets #}
 {%- set canEdit = data.area._edit and data.options.edit != false -%}
 {%- set isSingleton = data.options.limit == 1 and data.options.type -%}
-<div class="apos-area" data-apos-area{% if canEdit %} data-apos-area-edit{% if not data.options.virtual %} data-autosave{% endif %} data-options='{{ apos.utils.omit(data.options, 'area') | jsonAttribute({ single: true }) }}' data-doc-id="{{ data.area._docId }}" data-dot-path="{{ data.area._dotPath }}"{% endif %}>
+<div class="apos-area" {% if data.options.role %}data-apos-area-role={{ data.options.role }} {% endif %}data-apos-area{% if canEdit %} data-apos-area-edit{% if not data.options.virtual %} data-autosave{% endif %} data-options='{{ apos.utils.omit(data.options, 'area') | jsonAttribute({ single: true }) }}' data-doc-id="{{ data.area._docId }}" data-dot-path="{{ data.area._dotPath }}"{% endif %}>
   {%- if canEdit -%}
     {%- if isSingleton -%}
       {% include "singletonControls.html" %}

--- a/lib/modules/apostrophe-rich-text-widgets/public/css/components/rich-text-widget.less
+++ b/lib/modules/apostrophe-rich-text-widgets/public/css/components/rich-text-widget.less
@@ -5,8 +5,8 @@
   {
     >.apos-area-widget-controls--context
     {
-      top: 0;
-      transform: translateY(-50%);
+      top: auto;
+      bottom: 100%;
     }
     >.apos-area-widget-controls--data
     {

--- a/lib/modules/apostrophe-rich-text-widgets/public/css/components/rich-text-widget.less
+++ b/lib/modules/apostrophe-rich-text-widgets/public/css/components/rich-text-widget.less
@@ -33,3 +33,5 @@
     outline: @apos-green dashed 1px;
   }
 }
+
+[data-apos-widget-wrapper="apostrophe-rich-text"]:hover { z-index: @apos-z-index-6; }

--- a/lib/modules/apostrophe-ui/public/css/components/buttons.less
+++ b/lib/modules/apostrophe-ui/public/css/components/buttons.less
@@ -184,6 +184,9 @@
 .apos-button--circular
 {
   line-height: 0;
+  font-size: 12px;
+  padding: 9px;
+  .apos-rounded(@apos-padding-3);
   i
   {
     position: absolute;
@@ -192,6 +195,5 @@
     transform: translateX(-50%);
     .apos-transition--bounce;
   }
-  padding: 12px;
-  .apos-rounded(@apos-padding-3);
+
 }


### PR DESCRIPTION
Addresses #647 & #699 

A couple subtle changes:
## Rich Text Controls

Rich text widget controls now float completely above the widget, leaving the content of the widget unobscured while interacting with it. To achieve this without interfering with the widget above I'm toggling the `pointer-events` property to only be active when moving from the widget to the control set.

![image](http://g.recordit.co/i4DxX8325G.gif)
## Areas inside Areas (content widgets inside of layout widgets)

The classic Areas inside Areas pattern where the top and bottom controls of the outer widget are on the same horizontal as the first widgets of the inner areas

![image](http://g.recordit.co/uUZ20GuC5g.gif)

I've added a `role` option to the `apos.area` configuration that can be set to `layout`

```
{# ########################### #}
{# THE LAYOUT WIDGETS #}
{% macro layout(context, name) %}
  {{ apos.area(context, name, {
    widgets: {
      'pl-marquee': {},
      'pl-block-title-column': {},
      'pl-block-one-column': {},
      'pl-block-narrow-one-column': {},
      'pl-block-one-two-column': {},
      'pl-block-two-one-column': {}
    },
    role: 'layout'
  } )}}
{% endmacro %}
```

This gives some special consideration to the outer area. It gives its UI the set `apos-secondary` color and it also sets its controls to be to be transparent but _in document flow_ (@boutell don't fall out of your chair). Ultimately attempts to put the outer area controls in special offset places felt worse than the occasional 20px of white space between larger widgets.

The interface then works like this

![image](http://g.recordit.co/PumBWMbXHZ.gif)

Area interactions have lots of edge cases so I'd like to have some people test this branch in real life projects, hopefully ones with complex layout configurations. Also looking for feedback on the `role: layout` separation. This is a pattern both my 2.x projects have used, hoping it will be useful to people besides me.

Would be great if you could bash around on this in a complex page layout and see how it feels.

@agilbert @austinstarin @grdunn @jonlong @colpanik @boutell @kyjoya @bgantick
