### PR TITLE
The search index now includes string and select schema field text, ev…

### DIFF
--- a/lib/modules/apostrophe-doc-type-manager/index.js
+++ b/lib/modules/apostrophe-doc-type-manager/index.js
@@ -33,6 +33,7 @@ module.exports = {
     self.apos.docs.setManager(self.name, self);
     self.pushAssets();
     self.pushDefineSingleton();
+    self.addSearchIndexListener();
   },
 
   beforeConstruct: function(self, options) {

--- a/lib/modules/apostrophe-doc-type-manager/lib/api.js
+++ b/lib/modules/apostrophe-doc-type-manager/lib/api.js
@@ -172,4 +172,39 @@ module.exports = function(self, options) {
     });
   };
 
+  // Adds a listener for the `docSearchIndex` Apostrophe event, pointing to the
+  // `searchIndexListener` method.
+
+  self.addSearchIndexListener = function() {
+    self.apos.on('docSearchIndex', self.searchIndexListener);
+  };
+  
+  // Invoked when a `docSearchIndex` event takes place, this method adds
+  // additional search texts to the `texts` array (modify it in place by
+  // pushing new objects to it). These texts influence search results.
+  // The default behavior is quite useful, so you won't often need to
+  // override this.
+  //
+  // Each "text" is an *object* and must have at least `weight` and `text` properties.
+  // If `weight` is >= 10, the text will be included in autocomplete searches and
+  // given higher priority in full-text searches. Otherwise it will be included
+  // only in full-text searches.
+  //
+  // If `silent` is `true`, the `searchSummary` property will not contain
+  // the text.
+  //
+  // By default this method invokes `schemas.indexFields`, which will push
+  // texts for all of the schema fields that support this unless they are
+  // explicitly set `searchable: false`.
+  //
+  // In any case, the text of rich text widgets is always included as
+  // lower-priority search text.
+  
+  self.searchIndexListener = function(doc, texts) {
+    if (doc.type !== self.name) {
+      return;
+    }
+    self.apos.schemas.indexFields(self.schema, doc, texts);
+  };
+
 };

--- a/lib/modules/apostrophe-pieces-widgets/index.js
+++ b/lib/modules/apostrophe-pieces-widgets/index.js
@@ -67,6 +67,10 @@ module.exports = {
     addFields.push({
       type: 'select',
       name: 'by',
+      // This just keeps the words "id", "all" and "tag" from cluttering
+      // up the search index. It has NO impact on the searchability
+      // of the pieces. -Tom
+      searchable: false,
       label: 'Select...',
       def: byChoices[0] && byChoices[0].value,
       choices: byChoices

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -418,17 +418,19 @@ module.exports = {
       });
     };
 
-    // Index the object's fields for participation in Apostrophe search
-    self.indexFields = function(schema, object, lines) {
+    // Index the object's fields for participation in Apostrophe search unless
+    // `searchable: false` is set for the field in question
+
+    self.indexFields = function(schema, object, texts) {
       _.each(schema, function(field) {
-        if (field.search === false) {
+        if (field.searchable === false) {
           return;
         }
         var fieldType = self.fieldTypes[field.type];
         if (!fieldType.index) {
           return;
         }
-        fieldType.index[field.type](object[field.name], field, lines);
+        fieldType.index(object[field.name], field, texts);
       });
     };
 
@@ -933,6 +935,15 @@ module.exports = {
           });
         }
       },
+      index: function(value, field, texts) {
+        // Make sure fields of type "tags" that aren't the default "tags" field participate
+        // in search at some level
+        var silent = (field.silent === undefined) ? true : field.silent;
+        if (!Array.isArray(value)) {
+          value = [];
+        }
+        texts.push({ weight: field.weight || 15, text: value.join(' '), silent: silent });
+      },
       exporters: {
         csv: function(req, object, field, name, output, callback) {
           // no formating, set the field
@@ -1174,6 +1185,11 @@ module.exports = {
       },
       bless: function(req, field) {
         self.bless(req, field.schema || []);
+      },
+      index: function(value, field, texts) {
+        _.each(value || [], function(item) {
+          self.apos.schemas.indexFields(field.schema, item, texts);
+        });
       }
     });
 

--- a/lib/modules/apostrophe-search/index.js
+++ b/lib/modules/apostrophe-search/index.js
@@ -22,6 +22,7 @@ module.exports = {
     self.dispatchAll();
     self.enableFilters();
     self.pushAssets();
+    self.apos.tasks.add(self.__meta.name, 'index', self.indexTask);
   },
 
   construct: function(self, options) {
@@ -59,6 +60,12 @@ module.exports = {
       }
     };
 
+    // This method implements the search results page. It populates `req.data.docs`
+    // and provides pagination via `req.data.currentPage` and `req.data.totalPages`,
+    // not to be confused with `req.data.totalDocs` which is the total number of
+    // documents matching the search. The filters configured for the module are
+    // respected.
+    
     self.indexPage = function(req, callback) {
 
       // Finesse so we can use queryToFilters but we still support q, which is
@@ -218,28 +225,23 @@ module.exports = {
     // via callAll by the docs module
 
     self.docBeforeSave = function(req, doc, options) {
+      return self.indexDoc(req, doc);
+    };
+
+    // Index one doc for participation in search
+
+    self.indexDoc = function(req, doc) {
       var page;
       var prior;
 
-      // Index the doc
       var texts = self.getSearchTexts(doc);
-      // These texts have a weight property so they are ideal for feeding
-      // to something better, but for now we'll prep for a dumb, simple regex search
-      // via mongo that is not aware of the weight of fields. This is pretty
-      // slow on big corpuses but it does have the advantage of being compatible
-      // with the presence of other criteria. Our workaround for the lack of
-      // really good weighting is to make separate texts available for searches
-      // based on high-weight fields and searches based on everything
 
-      // Make sure our texts aren't empty before we try to jam them into anything
       _.each(texts, function(text){
         if(text.text === undefined) {
           text.text = '';
         }
       });
 
-      // Individual widget types play with weights a little, but the really
-      // big numbers are reserved for metadata fields. Look for those
       var highTexts = _.filter(texts, function(text) {
         return text.weight > 10;
       });
@@ -258,6 +260,25 @@ module.exports = {
         lowSearchText: lowText,
         searchSummary: searchSummary
       });
+    };
+    
+    // Implements the `apostrophe-search:index` task, which re-indexes all pages.
+    // This should only be needed if you have changed your mind about the
+    // `searchable` property for various schema fields. Indexing is automatic
+    // every time a doc is saved
+    
+    self.indexTask = function(apos, argv, callback) {
+      var req = self.apos.tasks.getReq();
+      return self.apos.migrations.eachDoc({}, _.partial(self.indexTaskOne, req), callback);
+    };
+    
+    // Indexes just one document as part of the implementation of the
+    // `apostrophe-search:index` task. This isn't the method you want to
+    // override. See `indexDoc` and `getSearchTexts`
+
+    self.indexTaskOne = function(req, doc, callback) {
+      self.indexDoc(req, doc);
+      return self.apos.docs.db.update({ _id: doc._id }, doc, callback);
     };
 
     // Returns texts which are a reasonable basis for

--- a/lib/modules/apostrophe-widgets/index.js
+++ b/lib/modules/apostrophe-widgets/index.js
@@ -284,6 +284,10 @@ module.exports = {
 
     };
 
+    self.addSearchTexts = function(widget, texts) {
+      self.apos.schemas.indexFields(self.schema, widget, texts);
+    };
+
     // A POST route to render `widgetEditor.html`. `data.label` and
     // `data.schema` are available to the template.
 


### PR DESCRIPTION
…en if nested in an array. This brings us back to parity with 0.5. The docSearchIndex event is listened for by doc type managers. Fields can be kept out of search with "searchable: false", which matches the syntax used elsewhere in 2.0. Fields of type "tags" are also included. An "apostrophe-search:index" task has been added to rebuild the index with these advantages; you do NOT need to run it regularly, indexing is automatic on save. Search indexing has been factored out to an "indexDoc" method in apostrophe-search for better overriding.