### PR TITLE
Smart errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.5.2
+
+* New `blockLevelControls: true` option to areas ensures controls for "blocks," i.e. "layout" widgets whose primary purpose is to contain other widgets, can be easily distinguished from controls for "regular" areas nested inside them. Think of a "two-column" or "three-column" widget with three areas in its template. The controls for these areas are displayed in a distinct color and various visual affordances are made to ensure they are accessible when things would otherwise be tightly spaces.
+* General improvements to the usability of area-related controls.
+* The search index now correctly includes the text of string and select schema fields found in widgets, pieces, pages, etc., as it always did before in 0.5. You may use `searchable: false` to disable this on a per-field basis.
+* Search indexing has been refactored for clarity (no changes to working APIs).
+* Checkboxes for the `checkboxes` schema field type are now styled.
+* "View file" links in the file library are now styled as buttons.
+
 ## 2.5.1
 
 All tests passing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.5.2
 
+All tests passing.
+
 * New `blockLevelControls: true` option to areas ensures controls for "blocks," i.e. "layout" widgets whose primary purpose is to contain other widgets, can be easily distinguished from controls for "regular" areas nested inside them. Think of a "two-column" or "three-column" widget with three areas in its template. The controls for these areas are displayed in a distinct color and various visual affordances are made to ensure they are accessible when things would otherwise be tightly spaces.
 * General improvements to the usability of area-related controls.
 * The search index now correctly includes the text of string and select schema fields found in widgets, pieces, pages, etc., as it always did before in 0.5. You may use `searchable: false` to disable this on a per-field basis.

--- a/index.js
+++ b/index.js
@@ -136,9 +136,14 @@ module.exports = function(options) {
       } else {
         // In the absence of a callback to handle initialization failure,
         // we have to assume there's just one instance of Apostrophe and
-        // we can print the error and end the app
+        // we can print the error and end the app.
+        
+        // Currently v8's err.stack property contains both the stack and the error message,
+        // but that's weird and could be temporary, so if it ever changes, output both. -Tom
+        if ((typeof(err.stack) !== 'string') || (err.stack.indexOf(err.toString()) === -1)) {
+          console.error(err);
+        }
         console.error(err.stack);
-        console.error(err);
         process.exit(1);
       }
     }
@@ -252,8 +257,6 @@ module.exports = function(options) {
       return self.synth.create(item, { apos: self }, function(err, obj) {
         if (err) {
           console.error('Error while constructing the ' + item + ' module');
-          console.error(err.stack);
-          console.error(err);
           return callback(err);
         }
         return callback(null);

--- a/lib/modules/apostrophe-areas/lib/helpers.js
+++ b/lib/modules/apostrophe-areas/lib/helpers.js
@@ -70,6 +70,12 @@ module.exports = function(self, options) {
     // corresponding value should be an object, and is passed on as options to
     // widgets of that type appearing in this area.
     //
+    // If `blockLevelControls: true` is present, the controls for this area are given
+    // extra vertical space and rendered in a distinct color. These are affordances
+    // to ensure the user can clearly distinguish the controls of an area used for layout, i.e.
+    // an area that contains "two column" and "three column" widgets containing areas
+    // of their own.
+    //
     // The `name` property distinguishes this area from other areas in
     // the same `doc`.
     //

--- a/lib/modules/apostrophe-module/index.js
+++ b/lib/modules/apostrophe-module/index.js
@@ -18,6 +18,7 @@ var _ = require('lodash');
 var async = require('async');
 var moment = require('moment');
 var fs = require('fs');
+var syntaxError = require('syntax-error');
 
 module.exports = {
   beforeConstruct: function(self, options) {
@@ -488,7 +489,24 @@ module.exports = {
           synthesized = true;
         } else {
           // Load the definition; supply `extend` if it is not set
-          definition = require(path);
+          try {
+            definition = require(path);
+          } catch (e) {
+            // We need to stop the show in any case, but first print
+            // a more helpful syntax error message if we can
+            // find it via substack's node-syntax-error module. Without this
+            // we get no line number information, a known limitations of node/v8
+            // as opposed to Firefox. -Tom
+            if (e instanceof SyntaxError) {
+              var err = syntaxError(fs.readFileSync(path), path);
+              if (err) {
+                throw new Error(err.toString() + '\n^^^^ LOOK UP HERE FOR THE ERROR DEFINING THE RELATED TYPE ' + name);
+              }
+            }
+            // Intentionally fall through and throw the error further on to
+            // stop the show
+            throw e;
+          }
           related.filename = path;
         }
         extend = definition.extend;

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "rimraf": "^2.5.4",
     "sanitize-html": "^1.7.0",
     "sluggo": "^0.2.0",
+    "syntax-error": "^1.1.6",
     "uglify-js": "^2.4.16",
     "underscore.string": "^3.0.2",
     "uploadfs": "^1.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* Introduce a syntax error, like an extra {, into a cursor.js file and you'll see that you get a much more useful error message than before when you type "node app", because the line number is included.
* With any error during apostrophe startup, you get just one error message and stack trace, not multiple copies.