### PR TITLE
declutter the versions database by robustly checking whether saving a…

### DIFF
--- a/lib/modules/apostrophe-areas/lib/api.js
+++ b/lib/modules/apostrophe-areas/lib/api.js
@@ -145,6 +145,15 @@ module.exports = function(self, options) {
             return callback(new Error('forbidden'));
           }
         }
+        
+        var existingArea = deep(doc, dotPath);
+        var existingItems = (existingArea && existingArea.items) || [];
+        if (_.isEqual(self.apos.utils.clonePermanent(items), self.apos.utils.clonePermanent(existingItems))) {
+          // No real change — don't waste a version and clutter the database.
+          // Sometimes only the server-side sanitizers can tell accurately that
+          // nothing has changed. -Tom
+          return setImmediate(callback);
+        }
 
         deep(doc, dotPath, {
           type: 'area',


### PR DESCRIPTION
…n area is really necessary after server-side sanitizers have run. We were getting burned by differences that do not matter, like `&nbsp;` versus the unicode character for it.