### PR TITLE
Allow body-parser customization at the app.js level

### DIFF
--- a/lib/modules/apostrophe-express/index.js
+++ b/lib/modules/apostrophe-express/index.js
@@ -277,12 +277,21 @@ module.exports = {
         self.apos.app.use(self.csrf);
       }
 
+      
+      // Allow the options for bodyParser to be customized
+      // in app.js
+      var _bodyParserOptions = _.extend({
+        json:{ },
+        urlencoded:{extended: true}
+      },options.bodyParser);
+
+      
       // extended: true means that people[address[street]] works
       // like it does in a PHP urlencoded form. This has a cost
       // but is too useful and familiar to leave out. -Tom and Ben
 
-      self.apos.app.use(bodyParser.urlencoded({ extended: true }));
-      self.apos.app.use(bodyParser.json({}));
+      self.apos.app.use(bodyParser.urlencoded(_bodyParserOptions.urlencoded));
+      self.apos.app.use(bodyParser.json(_bodyParserOptions.json));
       self.apos.app.use(connectFlash());
       self.apos.app.use(self.apos.i18n.init);
       self.apos.app.use(self.absoluteUrl);


### PR DESCRIPTION
Apostorphe uses body-parser however this cannot be customized at the application level. Not even by overriding the middlewares using the "middelware" array.

body-parser also provides a way to set the "limit" of the request body, which is a common solution for the *request entity too large* nodejs error.

The proposed change allows the developer to customize the body-parser "limit" at the app.js level, or data/local.js level