### PR TITLE
Attachment fields can now be trashed (cleared) if the field has the "…

### DIFF
--- a/lib/modules/apostrophe-attachments/public/js/user.js
+++ b/lib/modules/apostrophe-attachments/public/js/user.js
@@ -41,6 +41,8 @@ apos.define('apostrophe-attachments', {
       var $fieldset = apos.schemas.findFieldset($el, name);
       self.updateExisting($fieldset, object[name], field);
 
+      var $trashButton = $fieldset.find('[data-apos-trash]');
+
       // A bulk upload button is provided separately at the array level
       // if multipleUpload: true is set on an array schema field. -Tom
 
@@ -52,6 +54,11 @@ apos.define('apostrophe-attachments', {
         // input element gets replaced after each use, so we have to
         // find it each time we want to click it programmatically. -Tom
         $fieldset.find('input[type="file"]').click();
+      });
+      
+      $trashButton.on('click', function() {
+        self.updateExisting($fieldset, null, field);
+        return false;
       });
 
       $input.fileupload({
@@ -107,22 +114,12 @@ apos.define('apostrophe-attachments', {
     };
 
     self.addHandlers = function() {
-      apos.ui.link('apos-trash', 'attachment', function($el, _id) {
-        self.api('trash', { _id: _id }, function(result) {
-          if (result.status !== 'ok') {
-            return;
-          }
-          var $existing = $el.closest('[data-existing]');
-          $existing.hide();
-        });
-        return false;
-      });
       apos.ui.link('apos-crop', 'attachment', function($el, _id) {
         var $existing = $el.closest('[data-existing]');
 
         var attachment = $existing.data('existing');
         var field = $existing.data('field');
-        var $fieldset = $el.closest('fieldset');
+        var $fieldset = $el.closest('[data-name]');
         // TODO what about minSize, etc. in this context?
         var options = {};
         options.minSize = (field.hints && field.hints.minSize);

--- a/lib/modules/apostrophe-attachments/views/attachment.html
+++ b/lib/modules/apostrophe-attachments/views/attachment.html
@@ -7,14 +7,16 @@
     <div class="apos-attachment-preview"><img data-preview src="" alt=""></div>
     <span class="apos-attachment-name" data-name></span> 
     <div class="apos-button-group">
-      <a class="apos-button apos-button--action" href="#" data-link>View file</a>
+      <a class="apos-button apos-button--action" href="#" data-link target="_blank">View file</a>
+      {% if field.crop %}
+        <a class="apos-button apos-button--action" href="#" data-crop-attachment>Crop image</a>
+      {% endif %}
+      {% if field.trash %}
+        {{ buttons.danger('Delete File', { action: 'trash' }) }}
+      {% endif %}
     </div>
-    {% if field.crop %}
-      <a href="#" data-crop-attachment>crop</a>
-    {% endif %}
   </div>
   <input type="file" name="{{ field.name }}" style="display:none" data-uploader />
-  {#<a href="#" data-trash-attachment>{{ buttons.danger('Delete File', { action: 'trash-attachment' }) }}</a>#}
   {{ buttons.action('Upload File', { action: 'uploader-target' }) }}
 {% endmacro %}
 


### PR DESCRIPTION
…trash: true" property. This must be enabled explicitly because for common cases like apostrophe-images and apostrophe-files it is too easily confused with trashing the entire piece, which is what you really want in those cases. There is no history feature right in the field, but you could get back to an old version of any pre-existing piece via the pieces history and that would get you back the attachment. An issue is that the actual file is therefore not removed or made inaccessible. There is indeed no way to make an attachment truly inaccessible so far in 2.0.