### PR TITLE
we have been passing safe: true to indexes out of habit but it is not…

### DIFF
--- a/lib/modules/apostrophe-caches/index.js
+++ b/lib/modules/apostrophe-caches/index.js
@@ -133,7 +133,7 @@ module.exports = {
         self.cacheCollection = collection;
         return async.series({
           keyIndex: function(callback) {
-            return self.cacheCollection.ensureIndex({ key: 1, cache: 1 }, { safe: true, unique: true }, callback);
+            return self.cacheCollection.ensureIndex({ key: 1, cache: 1 }, { unique: true }, callback);
           },
           expireIndex: function(callback) {
             return self.cacheCollection.ensureIndex({ updated: 1 }, { expireAfterSeconds: 0 }, callback);

--- a/lib/modules/apostrophe-docs/lib/api.js
+++ b/lib/modules/apostrophe-docs/lib/api.js
@@ -15,26 +15,26 @@ module.exports = function(self, options) {
     async.series([ indexType, indexSlug, indexTitleSortified, indexUpdatedAt, indexTags, indexPublished, indexText ], callback);
 
     function indexType(callback) {
-      self.db.ensureIndex({ type: 1 }, { safe: true }, callback);
+      self.db.ensureIndex({ type: 1 }, {}, callback);
     }
 
     function indexSlug(callback) {
-      self.db.ensureIndex({ slug: 1 }, { safe: true, unique: true }, callback);
+      self.db.ensureIndex({ slug: 1 }, { unique: true }, callback);
     }
 
     function indexTitleSortified(callback) {
-      self.db.ensureIndex({ titleSortified: 1 }, { safe: true }, callback);
+      self.db.ensureIndex({ titleSortified: 1 }, { }, callback);
     }
 
     function indexUpdatedAt(callback) {
-      self.db.ensureIndex({ updatedAt: -1 }, { safe: true }, callback);
+      self.db.ensureIndex({ updatedAt: -1 }, { }, callback);
     }
 
     function indexTags(callback) {
-      self.db.ensureIndex({ tags: 1 }, { safe: true }, callback);
+      self.db.ensureIndex({ tags: 1 }, { }, callback);
     }
     function indexPublished(callback) {
-      self.db.ensureIndex({ published: 1 }, { safe: true }, callback);
+      self.db.ensureIndex({ published: 1 }, { }, callback);
     }
 
     function indexText(callback) {
@@ -48,7 +48,7 @@ module.exports = function(self, options) {
   };
 
   self.ensureTextIndex = function(callback) {
-    return self.db.ensureIndex( { highSearchText: 'text', lowSearchText: 'text', title: 'text', searchBoost: 'text' }, { default_language: self.options.searchLanguage || 'none', weights: { title: 100, searchBoost: 150, highSearchText: 10, lowSearchText: 2 }, safe: true }, callback);
+    return self.db.ensureIndex( { highSearchText: 'text', lowSearchText: 'text', title: 'text', searchBoost: 'text' }, { default_language: self.options.searchLanguage || 'none', weights: { title: 100, searchBoost: 150, highSearchText: 10, lowSearchText: 2 } }, callback);
   };
 
   // Returns a query cursor based on the permissions

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -967,7 +967,7 @@ module.exports = function(self, options) {
   self.ensureIndexes = function(callback) {
     return async.series([ indexPath ], callback);
     function indexPath(callback) {
-      self.apos.docs.db.ensureIndex({ path: 1 }, { safe: true, unique: true, sparse: true }, callback);
+      self.apos.docs.db.ensureIndex({ path: 1 }, { unique: true, sparse: true }, callback);
     }
   };
 

--- a/lib/modules/apostrophe-users/index.js
+++ b/lib/modules/apostrophe-users/index.js
@@ -184,10 +184,10 @@ module.exports = {
       return async.series([ indexUsername, indexEmail ], callback);
 
       function indexUsername(callback) {
-        self.safe.ensureIndex({ username: 1 }, { safe: true, unique: true }, callback);
+        self.safe.ensureIndex({ username: 1 }, { unique: true }, callback);
       }
       function indexEmail(callback) {
-        self.safe.ensureIndex({ email: 1 }, { safe: true, unique: true, sparse: true }, callback);
+        self.safe.ensureIndex({ email: 1 }, { unique: true, sparse: true }, callback);
       }
     };
 


### PR DESCRIPTION
… a thing and in some new version of mongodb it is actually erroring out.

Brian, please pull this down and test a project against it for which you already have a synced-down database, making sure you can start it up successfully and paste the output of:

`db.aposDocs.getIndexes();`

In the mongo shell.

Then try it with no database to start with by erasing the database for that site:

`db.dropDatabase();`

Again, make sure the site comes up OK (albeit with no content), and paste the getIndexes output.

Then we'll review this PR together and get it out as 2.9.2. 

Thanks!