### PR TITLE
support for middleware in any module via an `expressMiddleware` prope…

### DIFF
--- a/lib/modules/apostrophe-express/index.js
+++ b/lib/modules/apostrophe-express/index.js
@@ -146,10 +146,19 @@
 // available via `req.files`. See the
 // [connect-multiparty](https://npmjs.org/package/connect-multiparty) npm module.
 // This middleware is used by [apostrophe-attachments](../apostrophe-attachments/index.html).
+//
+// ## Module-specific middleware
+//
+// In addition, this module will look for an `expressMiddleware` property
+// in EVERY module. If such a property is found, it will be invoked as
+// middleware on ALL routes, after the required middleware (such as the body parser) and
+// before the configured middleware. If the property is an array, all of the functions
+// in the array are invoked as middleware.
 
 var fs = require('fs');
 var _ = require('lodash');
 var minimatch = require('minimatch');
+var async = require('async');
 
 module.exports = {
 
@@ -157,6 +166,8 @@ module.exports = {
     self.createApp();
     self.prefix();
     self.requiredMiddleware();
+    self.useModuleMiddleware();
+    self.configuredMiddleware();
     self.optionalMiddleware();
     self.addListenMethod();
     self.enableCsrf();
@@ -307,13 +318,29 @@ module.exports = {
       //   return next();
       // });
 
+    };
+
+    self.moduleMiddleware = [];
+    
+    // Implement middleware added via self.expressMiddleware properties in modules.
+    self.useModuleMiddleware = function() {
+      self.apos.app.use(function(req, res, next) {
+        return async.eachSeries(self.moduleMiddleware, function(fn, callback) {
+          return fn(req, res, function() {
+            return callback(null);
+          });
+        }, next);
+      });
+    };
+
+    self.configuredMiddleware = function() {
       if (options.middleware) {
         _.each(options.middleware, function(fn) {
           self.apos.app.use(fn);
         });
       }
     };
-
+    
     self.enableCsrf = function() {
       // The kernel of apostrophe in browserland needs this info, so
       // make it conveniently available to the assets module when it
@@ -448,6 +475,25 @@ module.exports = {
     self.absoluteUrl = function(req, res, next) {
       req.absoluteUrl = (self.options.baseUrl || (req.protocol + '://' + req.get('Host'))) + self.apos.prefix + req.url;
       next();
+    };
+    
+    // Locate modules with middleware and add it to the list
+    self.afterInit = function() {
+      self.findModuleMiddleware();
+    }
+    
+    // Locate modules with middleware and add it to the list
+    self.findModuleMiddleware = function() {
+      _.each(self.apos.modules, function(module, name) {
+        if (!module.expressMiddleware) {
+          return;
+        }
+        if (Array.isArray(module.expressMiddleware)) {
+          self.moduleMiddleware = self.moduleMiddleware.concat(module.expressMiddleware);
+        } else if (typeof(module.expressMiddleware) === 'function') {
+          self.moduleMiddleware.push(module.expressMiddleware);
+        }
+      });
     };
   }
 };


### PR DESCRIPTION
…rty, which may be a middleware function or an array of them. The middleware is run right after the required base middleware, such as bodyParser and the creation of req.data, and before everything else, including all routes