### PR TITLE
Update user.js

### DIFF
--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -668,8 +668,8 @@ apos.define('apostrophe-schemas', {
           }
           var removed = _.filter(choices, { __removed: true });
           choices = _.difference(choices, removed);
-          data[field.idsField] = _.pluck(choices, 'value');
-          data[field.removedIdsField] = _.pluck(removed, 'value');
+          data[field.idsField] = _.map(choices, 'value');
+          data[field.removedIdsField] = _.map(removed, 'value');
           if (field.relationship) {
             data[field.relationshipsField] = data[field.relationshipsField] || {};
             var relationships = data[field.relationshipsField];


### PR DESCRIPTION
_.pluck was removed from loadash as of 4.0.0. Currently when attempting to save updated page settings in apostrophe 2.11.0 when saving page settings from the apostrophe admin ui, an error is returned from the ajax call "_.pluck is not a function." This change replaces _.pluck with _.map fixing the issue and making it work with later versions of lodash.