### PR TITLE
the "from" argument to convert could previously be set to either "for…

### DIFF
--- a/lib/modules/apostrophe-attachments/lib/schemaField.js
+++ b/lib/modules/apostrophe-attachments/lib/schemaField.js
@@ -16,7 +16,7 @@ module.exports = function(self, options) {
   };
 
   self.converters = {
-    csv: function(req, data, name, object, field, callback) {
+    string: function(req, data, name, object, field, callback) {
       // TODO would be interesting to support filenames mapped to a
       // configurable folder, with sanitization
       return setImmediate(callback);

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -446,8 +446,8 @@ module.exports = {
       return async.eachSeries(schema, function(field, callback) {
         // Fields that are contextual are edited in the context of a
         // show page and do not appear in regular schema forms. They are
-        // however legitimate in imports, so we make sure it's a form
-        // and not a CSV that we're skipping it for. We also have to
+        // however legitimate in imports, so we make sure it's a form import
+        // and not a string import that we're skipping it for. We also have to
         // accept them when contextualConvertArea causes them to be
         // kicked upstairs into a contextual area save operation. So
         // if they are defined in the data, sanitize them normally;
@@ -713,8 +713,9 @@ module.exports = {
     //
     // ### `converters`
     //
-    // Required. An object with  `csv` and `form` sub-properties, functions which are invoked for
-    // CSV import and form submissions respectively. These are functions which accept:
+    // Required. An object with  `string` and `form` sub-properties, functions which are invoked for
+    // strings (as often needed for imports) and Apostrophe-specific form submissions respectively.
+    // These are functions which accept:
     //
     // `req, data, name, object, field, callback`
     //
@@ -724,9 +725,9 @@ module.exports = {
     // `field` contains the schema field definition, useful to access
     // `def`, `min`, `max`, etc.
     //
-    // If `form` is the same as `csv` you may write:
+    // If `form` can use the same logic as `string` you may write:
     //
-    // form: 'csv'
+    // form: 'string'
     //
     // To reuse it.
     //
@@ -764,14 +765,25 @@ module.exports = {
         fieldType = _.cloneDeep(self.fieldTypes[type.extend]);
         _.merge(fieldType, type);
       }
-      // Allow a field type to reuse another converter by specifying
-      // its name. Allows 'form' to expressly reuse 'csv'
-      _.each(_.keys(fieldType.converters), function(key) {
-        var value = fieldType.converters[key];
-        if (typeof(value) === 'string') {
-          fieldType.converters[key] = fieldType.converters[value];
-        }
-      });
+      // For bc. csv was a bad name for the string conerter, but
+      // we need to accept it, and even keep the property around
+      // for bc with those extending in sneaky ways
+      if (fieldType.converters) {
+        fieldType.converters.string = fieldType.converters.string || fieldType.converters.csv;
+        fieldType.converters.csv = fieldType.converters.string;
+        // Allow a field type to reuse another converter by specifying
+        // its name. Allows 'form' to expressly reuse 'string'
+        _.each(_.keys(fieldType.converters), function(key) {
+          var value = fieldType.converters[key];
+          if (typeof(value) === 'string') {
+            if (value === 'csv') {
+              // bc
+              value = 'string';
+            }
+            fieldType.converters[key] = fieldType.converters[value];
+          }
+        });
+      }
       self.fieldTypes[type.name] = fieldType;
     };
 
@@ -868,14 +880,14 @@ module.exports = {
     self.addFieldType({
       name: 'string',
       converters: {
-        csv: function(req, data, name, object, field, callback) {
+        string: function(req, data, name, object, field, callback) {
           object[name] = self.apos.launder.string(data[name], field.def);
           return setImmediate(callback);
         },
-        form: 'csv'
+        form: 'string'
       },
       exporters: {
-        csv: function(req, object, field, name, output, callback) {
+        string: function(req, object, field, name, output, callback) {
           // no formating, set the field
           output[name] = object[name];
           return setImmediate(callback);
@@ -915,7 +927,7 @@ module.exports = {
         // if field.page is true, expect a page slug (slashes allowed,
         // leading slash required). Otherwise, expect a object-style slug
         // (no slashes at all)
-        csv: function(req, data, name, object, field, callback) {
+        string: function(req, data, name, object, field, callback) {
           var options = {};
           if (field.page) {
             options.allow = '/';
@@ -934,7 +946,7 @@ module.exports = {
           }
           return setImmediate(callback);
         },
-        form: 'csv'
+        form: 'string'
       },
       addFilter: function(field, cursor) {
         cursor.addFilter(field.name, {
@@ -960,7 +972,7 @@ module.exports = {
     self.addFieldType({
       name: 'tags',
       converters: {
-        csv: function(req, data, name, object, field, callback) {
+        string: function(req, data, name, object, field, callback) {
           var tags;
           tags = self.apos.launder.tags(data[name]);
           object[name] = tags;
@@ -1020,7 +1032,7 @@ module.exports = {
         texts.push({ weight: field.weight || 15, text: value.join(' '), silent: silent });
       },
       exporters: {
-        csv: function(req, object, field, name, output, callback) {
+        string: function(req, object, field, name, output, callback) {
           // no formating, set the field
           output[name] = object[name].toString();
           return setImmediate(callback);
@@ -1031,17 +1043,17 @@ module.exports = {
     self.addFieldType({
       name: 'boolean',
       converters: {
-        csv: function(req, data, name, object, field, callback) {
+        string: function(req, data, name, object, field, callback) {
           object[name] = self.apos.launder.boolean(data[name], field.def);
           return setImmediate(callback);
         },
-        form: 'csv'
+        form: 'string'
       },
       empty: function(field, value) {
         return !value;
       },
       exporters: {
-        csv: function(req, object, field, name, output, callback) {
+        string: function(req, object, field, name, output, callback) {
           output[name] = self.apos.launder.boolean(object[name]).toString();
           return setImmediate(callback);
         }
@@ -1088,7 +1100,7 @@ module.exports = {
     self.addFieldType({
       name: 'checkboxes',
       converters: {
-        csv: function(req, data, name, object, field, callback) {
+        string: function(req, data, name, object, field, callback) {
           data[name] = self.apos.launder.string(data[name]).split(',');
 
           if (!Array.isArray(data[name])) {
@@ -1170,11 +1182,11 @@ module.exports = {
     self.addFieldType({
       name: 'select',
       converters: {
-        csv: function(req, data, name, object, field, callback) {
+        string: function(req, data, name, object, field, callback) {
           object[name] = self.apos.launder.select(data[name], field.choices, field.def);
           return setImmediate(callback);
         },
-        form: 'csv'
+        form: 'string'
       },
       index: function(value, field, texts) {
         var silent = (field.silent === undefined) ? true : field.silent;
@@ -1228,11 +1240,11 @@ module.exports = {
     self.addFieldType({
       name: 'integer',
       converters: {
-        csv: function(req, data, name, object, field, callback) {
+        string: function(req, data, name, object, field, callback) {
           object[name] = self.apos.launder.integer(data[name], field.def, field.min, field.max);
           return setImmediate(callback);
         },
-        form: 'csv',
+        form: 'string',
         addFilter: function(field, cursor) {
           return cursor.addFilter(field.name, {
             finalize: function() {
@@ -1259,11 +1271,11 @@ module.exports = {
     self.addFieldType({
       name: 'float',
       converters: {
-        csv: function(req, data, name, object, field, callback) {
+        string: function(req, data, name, object, field, callback) {
           object[name] = self.apos.launder.float(data[name], field.def, field.min, field.max);
           return setImmediate(callback);
         },
-        form: 'csv'
+        form: 'string'
       },
       addFilter: function(field, cursor) {
         return cursor.addFilter(field.name, {
@@ -1290,11 +1302,11 @@ module.exports = {
     self.addFieldType({
       name: 'url',
       converters: {
-        csv: function(req, data, name, object, field, callback) {
+        string: function(req, data, name, object, field, callback) {
           object[name] = self.apos.launder.url(data[name], field.def);
           return setImmediate(callback);
         },
-        form: 'csv'
+        form: 'string'
       },
       diffable: function(value) {
         // URLs are fine to diff and display
@@ -1329,11 +1341,11 @@ module.exports = {
     self.addFieldType({
       name: 'date',
       converters: {
-        csv: function(req, data, name, object, field, callback) {
+        string: function(req, data, name, object, field, callback) {
           object[name] = self.apos.launder.date(data[name], field.def);
           return setImmediate(callback);
         },
-        form: 'csv'
+        form: 'string'
       },
       addFilter: function(field, cursor) {
         return cursor.addFilter(field.name, {
@@ -1379,18 +1391,18 @@ module.exports = {
     self.addFieldType({
       name: 'time',
       converters: {
-        csv: function(req, data, name, object, field, callback) {
+        string: function(req, data, name, object, field, callback) {
           object[name] = self.apos.launder.time(data[name], field.def);
           return setImmediate(callback);
         },
-        form: 'csv'
+        form: 'string'
       }
     });
 
     self.addFieldType({
       name: 'password',
       converters: {
-        csv: function(req, data, name, object, field, callback) {
+        string: function(req, data, name, object, field, callback) {
           // This is the only field type that we never update unless
           // there is actually a new value — a blank password is not cool. -Tom
           if (data[name]) {
@@ -1398,7 +1410,7 @@ module.exports = {
           }
           return setImmediate(callback);
         },
-        form: 'csv'
+        form: 'string'
       }
     });
 
@@ -1410,7 +1422,7 @@ module.exports = {
     self.addFieldType({
       name: 'array',
       converters: {
-        // would be quite painful in csv
+        // no string converter, would be beyond awkward
         form: function(req, data, name, object, field, callback) {
           var schema = field.schema;
           data = data[name];
@@ -1450,7 +1462,7 @@ module.exports = {
     self.addFieldType({
       name: 'joinByOne',
       converters: {
-        csv: function(req, data, name, object, field, callback) {
+        string: function(req, data, name, object, field, callback) {
           var manager = self.apos.docs.getManager(field.withType);
           if (!manager) {
             return callback(new Error('join with type ' + field.withType + ' unrecognized'));
@@ -1525,7 +1537,7 @@ module.exports = {
     self.addFieldType({
       name: 'joinByArray',
       converters: {
-        csv: function(req, data, name, object, field, callback) {
+        string: function(req, data, name, object, field, callback) {
           var manager = self.apos.docs.getManager(field.withType);
           if (!manager) {
             return callback(new Error('join with type ' + field.withType + ' unrecognized'));

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -443,6 +443,10 @@ module.exports = {
       if (!req) {
         throw new Error("convert invoked without a req, do you have one in your context?");
       }
+      // bc
+      if (from === 'csv') {
+        from = 'string';
+      }
       return async.eachSeries(schema, function(field, callback) {
         // Fields that are contextual are edited in the context of a
         // show page and do not appear in regular schema forms. They are

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -829,7 +829,7 @@ module.exports = {
     self.addFieldType({
       name: 'area',
       converters: {
-        csv: function(req, data, name, object, field, callback) {
+        string: function(req, data, name, object, field, callback) {
           object[name] = self.apos.areas.fromPlaintext(data[name]);
           return setImmediate(callback);
         },

--- a/lib/modules/apostrophe-video-fields/lib/schemaField.js
+++ b/lib/modules/apostrophe-video-fields/lib/schemaField.js
@@ -16,7 +16,7 @@ module.exports = function(self, options) {
           };
           return setImmediate(callback);
         },
-        csv: function(req, data, name, object, field, callback) {
+        string: function(req, data, name, object, field, callback) {
           // TODO it would be nice to use oembed server side to populate the title
           // and thumbnail here
           object[name] = {

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -438,7 +438,7 @@ describe('Schemas', function() {
     });
   });
 
-  it('should convert CSV areas correctly', function(done) {
+  it('should convert string areas correctly', function(done) {
     var schema = apos.schemas.compose(hasArea);
     assert(schema.length === 1);
     var input = {
@@ -448,7 +448,7 @@ describe('Schemas', function() {
     };
     var req = t.req.admin(apos);
     var result = {};
-    return apos.schemas.convert(req, schema, 'csv', input, result, function(err) {
+    return apos.schemas.convert(req, schema, 'string', input, result, function(err) {
       assert(!err);
       // no irrelevant or missing fields
       assert(_.keys(result).length === 1);
@@ -463,7 +463,7 @@ describe('Schemas', function() {
     });
   });
 
-  it('should convert CSV areas gracefully when they are undefined', function(done) {
+  it('should convert string areas gracefully when they are undefined', function(done) {
     var schema = apos.schemas.compose(hasArea);
     assert(schema.length === 1);
     var input = {
@@ -473,7 +473,7 @@ describe('Schemas', function() {
     };
     var req = t.req.admin(apos);
     var result = {};
-    return apos.schemas.convert(req, schema, 'csv', input, result, function(err) {
+    return apos.schemas.convert(req, schema, 'string', input, result, function(err) {
       assert(!err);
       // no irrelevant or missing fields
       assert(_.keys(result).length === 1);
@@ -486,6 +486,31 @@ describe('Schemas', function() {
     });
   });
   
+  it('should accept csv as a bc equivalent for string in convert', function(done) {
+    var schema = apos.schemas.compose(hasArea);
+    assert(schema.length === 1);
+    var input = {
+      irrelevant: 'Irrelevant',
+      // Should get escaped, not be treated as HTML
+      body: 'This is the greatest <h1>thing</h1>'
+    };
+    var req = t.req.admin(apos);
+    var result = {};
+    return apos.schemas.convert(req, schema, 'string', input, result, function(err) {
+      assert(!err);
+      // no irrelevant or missing fields
+      assert(_.keys(result).length === 1);
+      // expected fields came through
+      assert(result.body);
+      assert(result.body.type === 'area');
+      assert(result.body.items);
+      assert(result.body.items[0]);
+      assert(result.body.items[0].type === 'apostrophe-rich-text');
+      assert(result.body.items[0].content === apos.utils.escapeHtml(input.body));
+      done();
+    });
+  });
+
   it('should clean up extra slashes in page slugs', function(done) {
     var req = t.req.admin(apos);
     var schema = apos.schemas.compose({ addFields: pageSlug });
@@ -494,7 +519,7 @@ describe('Schemas', function() {
       slug: '/wiggy//wacky///wobbly////whizzle/////'
     };
     var result = {};
-    return apos.schemas.convert(req, schema, 'csv', input, result, function(err) {
+    return apos.schemas.convert(req, schema, 'string', input, result, function(err) {
       assert(!err);
       assert(result.slug === '/wiggy/wacky/wobbly/whizzle');
       done();
@@ -509,7 +534,7 @@ describe('Schemas', function() {
       slug: '/'
     };
     var result = {};
-    return apos.schemas.convert(req, schema, 'csv', input, result, function(err) {
+    return apos.schemas.convert(req, schema, 'string', input, result, function(err) {
       assert(!err);
       assert(result.slug === '/');
       done();
@@ -524,7 +549,7 @@ describe('Schemas', function() {
       slug: '/wiggy//wacky///wobbly////whizzle/////'
     };
     var result = {};
-    return apos.schemas.convert(req, schema, 'csv', input, result, function(err) {
+    return apos.schemas.convert(req, schema, 'string', input, result, function(err) {
       assert(!err);
       assert(result.slug === 'wiggy-wacky-wobbly-whizzle');
       done();


### PR DESCRIPTION
…m" or "csv". "form" is the Apostrophe-specific format used by our APIs and is not changing. "csv" was a misnomer because it really meant "a plain text representation" (as typically but not always found in a CSV file). There is full bc with code that adds custom schema field types with "csv" converters, and unit test coverage of same.