### PR TITLE
the instantiate: false property is no longer required when using impr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.11.1
+
+Developers are no longer required to explicitly set `instantiate: false` when adding an npm module that uses the `improve` property to enhance a different module. In addition, bugs were fixed in the underlying `moog-require` module to ensure that assets can be loaded from the `public` and `views` folders of modules that use `improve`.
+
 ## 2.11.0
 
 All tests passing.

--- a/index.js
+++ b/index.js
@@ -247,7 +247,8 @@ module.exports = function(options) {
   function instantiateModules(callback) {
     self.modules = {};
     return async.eachSeries(_.keys(self.options.modules), function(item, callback) {
-      if (self.options.modules[item] && (self.options.modules[item].instantiate === false)) {
+      var improvement = self.synth.isImprovement(item);
+      if (self.options.modules[item] && (improvement || self.options.modules[item].instantiate === false)) {
         // We don't want an actual instance of this module, we are using it
         // as an abstract base class in this particular project (but still
         // configuring it, to easily carry those options to subclasses, which

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {
@@ -48,7 +48,7 @@
     "mkdirp": "^0.5.0",
     "moment": "^2.9.0",
     "mongodb": "^2.0.0",
-    "moog-require": "^0.3.0",
+    "moog-require": "^0.4.0",
     "nunjucks": "^2.0.0",
     "oembetter": "^0.1.10",
     "passport": "^0.3.0",


### PR DESCRIPTION
…ove, also depend on a newer moog-require that has proper behavior for asset chains and autoloading with improve