### PR TITLE
sourcemaps in dev

### DIFF
--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -1078,6 +1078,18 @@ module.exports = {
     
     self.enableLessMiddleware = function() {
       self.apos.app.use(lessMiddleware(self.apos.rootDir + '/public', {
+        // Source map support in the middleware. This is cool, however:
+        // https://github.com/less/less.js/issues/2033
+        // Limits the usefulness until Chrome and Firefox get clued up
+        render: {
+          sourceMap: {
+            sourceMapFileInline: true,
+            sourceMapBasepath: self.apos.rootDir + '/public',
+            // otherwise paths wind up prefixed with an extra /css and browsers
+            // cannot find them
+            sourceMapRootpath: '..'
+          }
+        },
         postprocess: {
           css: function(css, req) {
             if (!self.apos.prefix) {


### PR DESCRIPTION
This is just basic sourcemap support for less files in dev, where the less-middleware is in use. Just needed to be configured properly.

However there is a known issue in both Chrome and Firefox that hampers the utility of this:

https://github.com/less/less.js/issues/2033
