### PR TITLE
wondering if it makes sense to give the area widget controls more z-index

### DIFF
--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -71,9 +71,9 @@
 .apos-area-widget-controls
 {
   position: absolute;
-  z-index: @apos-z-index-3;
+  z-index: @apos-z-index-5;
   .apos-transition;
-  &:hover { z-index: @apos-z-index-4; }
+  &:hover { z-index: @apos-z-index-6; }
 }
 .apos-area-widget-controls--context
 {


### PR DESCRIPTION
The issue I'm trying to solve for is when you have a widget that with editing controls that would always be obscured by the Apostrophe menu button or the page menu button. In my specific case, it was the footer:

![image](https://cloud.githubusercontent.com/assets/70999/21646478/5dcbdf5a-d264-11e6-82b6-41ff8aa04f9b.png)

Without this change, it's basically impossible to edit my footer content.

The change does mean that as you scroll by widget controls will hover over the Apostrophe menu button. This might be something we don't like:

![image](https://cloud.githubusercontent.com/assets/70999/21646531/822dad74-d264-11e6-9747-b94448ade721.png)

Not sure if this is the best solution, but I think we should figure out a way to make this work that doesn't require doing area/widget specific overrides in the project level