### PR TITLE
In apostrophe-rich-text-widgets, initialize CKEditor on instanceReady

### DIFF
--- a/lib/modules/apostrophe-rich-text-widgets/public/js/editor.js
+++ b/lib/modules/apostrophe-rich-text-widgets/public/js/editor.js
@@ -101,9 +101,7 @@ apos.define('apostrophe-rich-text-widgets-editor', {
         self.setActive(false);
       });
 
-      // Why is this necessary? Without it we don't get focus. If we don't use a timeout
-      // focus is stolen back. As it is we still lose our place in the text. ):
-      setTimeout(function() {
+      self.ckeditorInstance.on('instanceReady', function(event) {
         // This should not be necessary, but without the &nbsp; we are unable to
         // focus on an "empty" rich text after first clicking away an then clicking back.
         // And without the call to focus() people have to double click for no
@@ -115,7 +113,7 @@ apos.define('apostrophe-rich-text-widgets-editor', {
         self.ckeditorInstance.focus();
         self.$richText.data('aposRichTextState', 'started');
         self.$widget.trigger('aposRichTextStarted');
-      }, 250);
+      });
 
       self.setActive(true);
       self.started = true;


### PR DESCRIPTION
Fixes #802. Previously, a new CKEditor instance would be initialized after a timeout of 250ms. With this change, it's initialized when the `instanceReady` event is fired.