### PR TITLE
Pass root option to clean-css when minifying CSS

### DIFF
--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -66,7 +66,7 @@ module.exports = {
       // at this point we should just finish
       return callback(null);
     });
-    
+
     self.extractBundleIfAppropriate();
     self.setAssetTypes();
     self.setTypeMap();
@@ -78,7 +78,7 @@ module.exports = {
     self.pushDefaults();
 
   },
-  
+
   beforeConstruct: function(self, options) {
     if (options.minify === undefined) {
       options.minify = options.apos.launder.boolean(process.env.APOS_MINIFY);
@@ -215,7 +215,7 @@ module.exports = {
         }
       };
     };
-    
+
     self.setTypeMap = function() {
       // Name of both folder and extension in
       // public/ for this type of asset
@@ -269,7 +269,7 @@ module.exports = {
 
       self.generation = generation;
     };
-    
+
     // Extract an asset bundle if appropriate. The default implementation
     // looks for an APOS_BUNDLE=XYZ environment variable and, if present, extracts
     // a bundle with the name XYZ
@@ -280,7 +280,7 @@ module.exports = {
         self.fromBundle = true;
       }
     };
-    
+
     // Extract the named asset bundle, as created by the
     // apostrophe:generation task with the --create-bundle=NAME
     // option. An asset bundle is just a folder from which files are
@@ -409,7 +409,7 @@ module.exports = {
       if (self.apos.isTask() && !self.isGenerationTask) {
         return setImmediate(callback);
       }
-      
+
       self.tooLateToPushAssets = true;
 
       if (self.fromBundle) {
@@ -483,7 +483,7 @@ module.exports = {
       });
       return callback(null);
     };
-    
+
     // Get the effective project root folder. This will be the actual
     // project root folder except when creating an asset bundle to be
     // unpacked later
@@ -530,7 +530,7 @@ module.exports = {
         // things rather than making symlinks. YES, it IS CORRECT to reverse
         // the order of the arguments like this. Think about how people talk
         // about symbolic links vs. how they talk about copying things. -Tom
-        
+
         return self.removeThenRecursiveCopy(to, from);
       }
       // Always recreate the links so we're not befuddled by links
@@ -578,7 +578,7 @@ module.exports = {
       }
       self.recursiveCopy(from, to);
     };
-    
+
     // Copy the existing folder at `from` to the new folder `to`.
     // If `to` already exists files are added or overwritten as appropriate
     // and files not present in `from` are left intact.
@@ -620,7 +620,7 @@ module.exports = {
         }
         fs.closeSync(fromHandle);
         fs.closeSync(toHandle);
-      }      
+      }
     };
 
     self.buildLessMasters = function(callback) {
@@ -823,7 +823,9 @@ module.exports = {
         if (!self.cleanCss) {
           // CSS minifier https://github.com/GoalSmashers/clean-css
           var CleanCss = require('clean-css');
-          self.cleanCss = new CleanCss({});
+          self.cleanCss = new CleanCss({
+            root: self.apos.rootDir + '/public'
+          });
         }
         var minified = self.cleanCss.minify(code);
         if (minified.warnings.length) {
@@ -1075,7 +1077,7 @@ module.exports = {
       // respect Apostrophe's prefix automatically
       self.apos.push.browserCall('always', 'apos.prefixAjax()');
     };
-    
+
     self.enableLessMiddleware = function() {
       self.apos.app.use(lessMiddleware(self.apos.rootDir + '/public', {
         // Source map support in the middleware. This is cool, however:
@@ -1119,7 +1121,7 @@ module.exports = {
       },
       {
         compress: false
-      }));      
+      }));
     };
 
     // Prefix all URLs in CSS with the global site prefix
@@ -1144,7 +1146,7 @@ module.exports = {
       });
       return css;
     };
-    
+
     self.servePublicAssets = function() {
       self.apos.app.use(self.apos.express.static(self.apos.rootDir + '/public'));
     };
@@ -1253,6 +1255,6 @@ module.exports = {
     // in construct. -Tom
     self.setDefaultStylesheets();
     self.setDefaultScripts();
-    
+
   }
 };


### PR DESCRIPTION
This PR fixes #809. LESS will preserve @import statements for regular CSS files when compiling files, which means that when minifying, clean-css is the module responsible for the final concatenation of all CSS files. Before this change, the @import paths would be absolute, and clean-css wouldn't know where to start looking.

Looks like my editor removed a bit of trailing whitespace here as well, so the diff is a bit larger than the actual change.