### PR TITLE
Better empty area droppable state

### DIFF
--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -109,6 +109,16 @@
   margin: @apos-margin-1/2 0;
 }
 
+.apos-dragging .apos-empty .apos-area-widgets
+{
+  display: block;
+  height: 100%;
+}
+.apos-dragging .apos-empty .apos-area-item-separator
+{
+  height: 100%;
+}
+
 .apos-empty .apos-area-item-separator
 {
   height: 100%;

--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -114,6 +114,7 @@
   display: block;
   height: 100%;
 }
+
 .apos-dragging .apos-empty .apos-area-item-separator
 {
   height: 100%;


### PR DESCRIPTION
Some CSS must have with item separators, this makes sure that empty area's dropzones are nice, juicy targets, unlike this

http://recordit.co/ihWPvWEHeK