### PR TITLE
Implemented #843, global preferences editing via the apostrophe-global module

### DIFF
--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -373,7 +373,7 @@ module.exports = {
       } else if (fs.existsSync(filePath)) {
         exists = true;
       }
-
+      
       if (exists) {
         self.pushed[self.assetTypes[type].key].push({ type: type, file: filePath, web: webPath, data: data, preshrunk: options.preshrunk, when: when, minify: options.minify });
       }

--- a/lib/modules/apostrophe-global/index.js
+++ b/lib/modules/apostrophe-global/index.js
@@ -20,11 +20,21 @@ var async = require('async');
 
 module.exports = {
 
-  extend: 'apostrophe-doc-type-manager',
+  extend: 'apostrophe-pieces',
 
   name: 'apostrophe-global',
   
   alias: 'global',
+  
+  label: 'Global Content',
+
+  pluralLabel: 'Global Content',
+  
+  searchable: false,
+  
+  beforeConstruct: function(self, options) {
+    options.removeFields = [ 'title', 'slug', 'tags', 'published' ].concat(options.removeFields || []);
+  },
 
   afterConstruct: function(self) {
     self.enableMiddleware();
@@ -120,12 +130,6 @@ module.exports = {
         req.data.global = result;
         return next();
       });
-    };
-
-    self.pushAssets = function() {
-      self.pushAsset('script', 'user', { when: 'user' });
-      self.pushAsset('script', 'editor', { when: 'user' });
-      self.pushAsset('stylesheet', 'user', { when: 'user' });
     };
 
     var superGetCreateSingletonOptions = self.getCreateSingletonOptions;

--- a/lib/modules/apostrophe-global/public/js/user.js
+++ b/lib/modules/apostrophe-global/public/js/user.js
@@ -1,5 +1,5 @@
 apos.define('apostrophe-global', {
-  extend: 'apostrophe-doc-type-manager',
+  extend: 'apostrophe-pieces',
 
   afterConstruct: function(self) {
     self.addClickHandlers();
@@ -12,6 +12,19 @@ apos.define('apostrophe-global', {
   construct: function(self, options) {
     
     self._id = self.options._id;
+
+    self.manage = function() {
+      if (!_.find(self.options.schema, function(field) {
+        return !field.contextual;
+      })) {
+        // No schema fields to edit, so skip all the way to version management for
+        // shared global content like the header and footer rather than
+        // displaying an empty modal
+        return apos.versions.edit(self._id);
+      }
+      // Go directly to editing the one and only global piece
+      return self.edit(self._id);
+    };
 
     self.addClickHandlers = function() {
       apos.ui.link('apos-versions', 'global', function($button) {

--- a/lib/modules/apostrophe-global/views/editorModal.html
+++ b/lib/modules/apostrophe-global/views/editorModal.html
@@ -1,0 +1,10 @@
+{%- import 'apostrophe-ui:components/buttons.html' as buttons -%}
+{%- extends 'editorBase.html' -%}
+{%- block controls -%}
+{{ buttons.minor('Cancel', { action: 'cancel' }) }}
+{{ buttons.minor('Versions', { action: 'versions' }) }}
+{{ buttons.major('Save ' + data.options.label, { action: 'save' }) }}
+{%- endblock -%}
+{%- block instructions -%}
+  {{ __('Here you can edit settings that apply to the site as a whole. The "versions" button also rolls back changes to shared content present on all pages.', (data.options.label | d(''))) }}
+{%- endblock -%}

--- a/lib/modules/apostrophe-pieces/lib/browser.js
+++ b/lib/modules/apostrophe-pieces/lib/browser.js
@@ -1,7 +1,10 @@
 var _ = require('lodash');
 
 module.exports = function(self, options) {
+  
+  var superPushAssets = self.pushAssets;
   self.pushAssets = function() {
+    superPushAssets();
     self.pushAsset('script', 'manager-modal', { when: 'user' });
     self.pushAsset('script', 'editor-modal', { when: 'user' });
     self.pushAsset('stylesheet', 'manager', { when: 'user' });


### PR DESCRIPTION
See #843

Implemented this, and also fixed a deep, hilarious bug: the pieces module has been clobbering the pushAsset call for user.js and certain others all this time. We missed it because people kept re-pushing these for their subclasses rather than kicking me hard enough. A simple application of the super pattern resolves this forever.

I think people probably just figured pushAsset didn't really cascade and push the same files in subclasses (it absolutely does, but if you override pushAsset and never call superPushAsset...)

