### PR TITLE
Revert "each widget now has one piece of admin chrome that combines Edit butt…"

### DIFF
--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -86,7 +86,7 @@
   left: @apos-padding-1;
 }
 
-.apos-area-widget--contextual>.apos-ui .apos-button-group--data { display: none; }
+.apos-area-widget--contextual>.apos-ui .apos-area-widget-controls--data { display: none; }
 
 // Styles for the drag-target separator between widgets.
 .apos-area-item-separator
@@ -247,11 +247,9 @@
   }
 
   // color contextual controls as well
-  & > .apos-area-widgets > .apos-area-widget-wrapper > .apos-area-widget > .apos-ui .apos-buttons
+  & > .apos-area-widgets > .apos-area-widget-wrapper > .apos-area-widget > .apos-ui .apos-button--in-context
   {
     .apos-glow(@apos-secondary);
     border: 2px solid @apos-secondary;
-    .apos-button:hover { color: @apos-secondary; }
-    .apos-button[data-apos-trash-item]:hover { color: darken(@apos-red, 20%); }
   }
 }

--- a/lib/modules/apostrophe-areas/views/widgetControls.html
+++ b/lib/modules/apostrophe-areas/views/widgetControls.html
@@ -1,19 +1,17 @@
 {%- import 'apostrophe-ui:components/buttons.html' as buttons -%}
 <div class="apos-ui" data-apos-widget-controls>
-  <div class="apos-buttons apos-area-widget-controls apos-area-widget-controls--context">
-    <div class="apos-button-group">
+  <div class="apos-area-widget-controls apos-area-widget-controls--context">
+    <div class="apos-button apos-button--in-context apos-button--group">
       {{ buttons.inGroup('', { icon: 'arrows', action: 'drag-item' }) }}
       {{ buttons.inGroup('', { icon: 'arrow-up', action: 'move-item', value: 'up' }) }}
       {{ buttons.inGroup('', { icon: 'arrow-down', action: 'move-item', value: 'down' }) }}
-    </div>
-    {%- if not data.manager.removeEditButton -%}
-      {%- set label = data.options.editLabel or 'Edit ' + data.manager.label -%}
-      <div class="apos-button-group apos-button-group--data">
-        {{ buttons.inGroup(label, { action: 'edit-item' }) }}
-      </div>
-    {%- endif -%}
-    <div class="apos-button-group">
       {{ buttons.inGroup('', { icon: 'trash', action: 'trash-item' }) }}
     </div>
   </div>
+  {%- if not data.manager.removeEditButton -%}
+    {%- set label = data.options.editLabel or 'Edit ' + data.manager.label -%}
+    <div class="apos-area-widget-controls apos-area-widget-controls--data">
+      {{ buttons.inContext(label, { action: 'edit-item' }) }}
+    </div>
+  {%- endif -%}
 </div>

--- a/lib/modules/apostrophe-ui/public/css/components/buttons.less
+++ b/lib/modules/apostrophe-ui/public/css/components/buttons.less
@@ -1,21 +1,3 @@
-.apos-buttons
-{
-  background: @white;
-  .apos-rounded;
-  .apos-button-border(@apos-green);
-  .apos-button-group
-  {
-    float: left;
-    margin: 0 @apos-padding-1 / 2;
-  }
-  .apos-button
-  {
-    border-radius: 0;
-  }
-}
-
-[data-apos-trash-item].apos-button { color: @apos-red; }
-
 .apos-button
 {
   position: relative;
@@ -44,7 +26,6 @@
   &:hover
   {
     .apos-glow;
-    cursor: pointer;
   }
   &:active
   {
@@ -65,7 +46,7 @@
     }
   }
 
-  // i { margin-left: 4px; }
+  i { margin-left: 4px; }
 }
 
 // SPINNER =====================
@@ -186,11 +167,8 @@
   .apos-transition;
   &:hover
   {
-    color: @apos-primary;
+    background-color: @apos-light;
     .apos-drop-shadow(0, 0, 0, 0);
-    &[data-apos-trash-item] {
-      color: darken(@apos-red, 20%);
-    }
   }
 }
 


### PR DESCRIPTION
Reverts punkave/apostrophe#849

@stuartromanek your branch seems to have eliminated singleton edit controls (possibly only if the singleton already exists, I'm not sure). Sending this back to your workshop for that one.

Also, it contains a reference to `@white`, which fails on projects without a @white and should probably be `@apos-white`.