### PR TITLE
consolidate Edit and Move controls in the editing interface

### DIFF
--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -86,7 +86,7 @@
   left: @apos-padding-1;
 }
 
-.apos-area-widget--contextual>.apos-ui .apos-area-widget-controls--data { display: none; }
+.apos-area-widget--contextual>.apos-ui .apos-button-group--data { display: none; }
 
 // Styles for the drag-target separator between widgets.
 .apos-area-item-separator
@@ -247,9 +247,11 @@
   }
 
   // color contextual controls as well
-  & > .apos-area-widgets > .apos-area-widget-wrapper > .apos-area-widget > .apos-ui .apos-button--in-context
+  & > .apos-area-widgets > .apos-area-widget-wrapper > .apos-area-widget > .apos-ui .apos-buttons
   {
     .apos-glow(@apos-secondary);
     border: 2px solid @apos-secondary;
+    .apos-button:hover { color: @apos-secondary; }
+    .apos-button[data-apos-trash-item]:hover { color: darken(@apos-red, 20%); }
   }
 }

--- a/lib/modules/apostrophe-areas/views/widgetControls.html
+++ b/lib/modules/apostrophe-areas/views/widgetControls.html
@@ -1,17 +1,19 @@
 {%- import 'apostrophe-ui:components/buttons.html' as buttons -%}
 <div class="apos-ui" data-apos-widget-controls>
-  <div class="apos-area-widget-controls apos-area-widget-controls--context">
-    <div class="apos-button apos-button--in-context apos-button--group">
+  <div class="apos-buttons apos-area-widget-controls apos-area-widget-controls--context">
+    <div class="apos-button-group">
       {{ buttons.inGroup('', { icon: 'arrows', action: 'drag-item' }) }}
       {{ buttons.inGroup('', { icon: 'arrow-up', action: 'move-item', value: 'up' }) }}
       {{ buttons.inGroup('', { icon: 'arrow-down', action: 'move-item', value: 'down' }) }}
+    </div>
+    {%- if not data.manager.removeEditButton -%}
+      {%- set label = data.options.editLabel or 'Edit ' + data.manager.label -%}
+      <div class="apos-button-group apos-button-group--data">
+        {{ buttons.inGroup(label, { action: 'edit-item' }) }}
+      </div>
+    {%- endif -%}
+    <div class="apos-button-group">
       {{ buttons.inGroup('', { icon: 'trash', action: 'trash-item' }) }}
     </div>
   </div>
-  {%- if not data.manager.removeEditButton -%}
-    {%- set label = data.options.editLabel or 'Edit ' + data.manager.label -%}
-    <div class="apos-area-widget-controls apos-area-widget-controls--data">
-      {{ buttons.inContext(label, { action: 'edit-item' }) }}
-    </div>
-  {%- endif -%}
 </div>

--- a/lib/modules/apostrophe-ui/public/css/components/buttons.less
+++ b/lib/modules/apostrophe-ui/public/css/components/buttons.less
@@ -1,6 +1,7 @@
 .apos-buttons
 {
   background: @apos-white;
+  .apos-glow;
   .apos-rounded;
   .apos-button-border(@apos-green);
   .apos-button-group

--- a/lib/modules/apostrophe-ui/public/css/components/buttons.less
+++ b/lib/modules/apostrophe-ui/public/css/components/buttons.less
@@ -1,4 +1,3 @@
-
 .apos-buttons
 {
   background: @apos-white;
@@ -46,6 +45,7 @@
   &:hover
   {
     .apos-glow;
+    cursor: pointer;
   }
   &:active
   {
@@ -66,7 +66,7 @@
     }
   }
 
-  i { margin-left: 4px; }
+  // i { margin-left: 4px; }
 }
 
 // SPINNER =====================
@@ -187,8 +187,11 @@
   .apos-transition;
   &:hover
   {
-    background-color: @apos-light;
+    color: @apos-primary;
     .apos-drop-shadow(0, 0, 0, 0);
+    &[data-apos-trash-item] {
+      color: darken(@apos-red, 20%);
+    }
   }
 }
 

--- a/lib/modules/apostrophe-ui/public/css/components/buttons.less
+++ b/lib/modules/apostrophe-ui/public/css/components/buttons.less
@@ -1,6 +1,6 @@
 .apos-buttons
 {
-  background: @white;
+  background: @apos-white;
   .apos-rounded;
   .apos-button-border(@apos-green);
   .apos-button-group


### PR DESCRIPTION
![consolidated](https://camo.githubusercontent.com/abd10001e855dc6a4e7b89aea3efb61853aadecb/687474703a2f2f672e7265636f726469742e636f2f4269737a4955344e797a2e676966)

(this is a cleaned up version of https://github.com/punkave/apostrophe/pull/849)
