### PR TITLE
Add Node.js stable and Node.js LTS versions to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  - "stable"
+  - "lts/*"
   - "0.10"
 sudo: false
 services:


### PR DESCRIPTION
I haven't removed the CI build against Node.js 0.10 in case you still have some clients using this version. But running the CI against "stable" and "lts" is preferable over 0.10 anyway.

PS : "lts" has been added to NVM (which Travis CI relies on) recently: https://github.com/creationix/nvm/pull/1070