### PR TITLE
in the manage view, users can now browse pieces by tag or any other f…

### DIFF
--- a/lib/modules/apostrophe-docs/lib/cursor.js
+++ b/lib/modules/apostrophe-docs/lib/cursor.js
@@ -606,6 +606,7 @@ module.exports = {
       finalize: function() {
         var trash = self.get('trash');
         if (trash === null) {
+          // We are interested regardless of trash state
           return;
         }
         if (!trash) {
@@ -632,6 +633,27 @@ module.exports = {
       safeFor: 'manage',
       launder: function(s) {
         return self.apos.launder.booleanOrNull(s);
+      },
+      choices: function(callback) {
+        return self.toDistinct('trash', function(err, values) {
+          if (err) {
+            return callback(err);
+          }
+          var choices = [];
+          if (_.contains(values, false)) {
+            choices.push({
+              value: '0',
+              label: 'Live'
+            });
+          }
+          if (_.contains(values, true)) {
+            choices.push({
+              value: '1',
+              label: 'Trash'
+            });
+          }
+          return callback(null, choices);
+        });
       }
     });
 
@@ -667,6 +689,27 @@ module.exports = {
       safeFor: 'manage',
       launder: function(s) {
         return self.apos.launder.booleanOrNull(s);
+      },
+      choices: function(callback) {
+        return self.toDistinct('published', function(err, values) {
+          if (err) {
+            return callback(err);
+          }
+          var choices = [];
+          if (_.contains(values, true)) {
+            choices.push({
+              value: '1',
+              label: 'Published'
+            });
+          }
+          if (_.contains(values, false)) {
+            choices.push({
+              value: '0',
+              label: 'Draft'
+            });
+          }
+          return callback(null, choices);
+        });
       }
     });
 
@@ -923,7 +966,6 @@ module.exports = {
           if (lateCriteria) {
             _.assign(criteria, lateCriteria);
           }
-          //console.log(require('util').inspect(criteria, { depth: 20 }));
           var mongo = self.db.find(self.get('criteria'), self.get('projection'));
           var util = require('util');
           var skip = self.get('skip');

--- a/lib/modules/apostrophe-modal/public/css/components/modal-filters.less
+++ b/lib/modules/apostrophe-modal/public/css/components/modal-filters.less
@@ -12,10 +12,12 @@
     display: inline-block;
     padding: 20px 10px 10px 10px;
     border-radius: 4px;
-    select {
+    select
+    {
       padding: 8px 25px 7px 10px;
     }
-    &::after {
+    &::after
+    {
       right: 20px;
     }
   }

--- a/lib/modules/apostrophe-modal/public/css/components/modal-filters.less
+++ b/lib/modules/apostrophe-modal/public/css/components/modal-filters.less
@@ -7,6 +7,19 @@
 		margin-top: @apos-margin-2;
 	}
 
+  .apos-field-input-select-wrapper
+  {
+    display: inline-block;
+    padding: 20px 10px 10px 10px;
+    border-radius: 4px;
+    select {
+      padding: 8px 25px 7px 10px;
+    }
+    &::after {
+      right: 20px;
+    }
+  }
+
 	.apos-modal-filters-toggles
 	{
 		float: left;

--- a/lib/modules/apostrophe-pieces/index.js
+++ b/lib/modules/apostrophe-pieces/index.js
@@ -95,7 +95,8 @@ module.exports = {
           }
         ],
         allowedInChooser: false,
-        def: true
+        def: true,
+        style: 'pill'
       },
       {
         name: 'trash',
@@ -110,7 +111,8 @@ module.exports = {
           }
         ],
         allowedInChooser: false,
-        def: false
+        def: false,
+        style: 'pill'
       }
     ].concat(options.addFilters || []);
     

--- a/lib/modules/apostrophe-pieces/lib/api.js
+++ b/lib/modules/apostrophe-pieces/lib/api.js
@@ -81,8 +81,11 @@ module.exports = function(self, options) {
     }
     cursor.perPage(self.options.perPage || 10);
     cursor.queryToFilters(filters);
+
     var results = {};
+
     return async.series({
+
       toCount: function(callback) {
         return cursor
           .toCount(function(err, count) {
@@ -95,6 +98,53 @@ module.exports = function(self, options) {
           }
         );
       },
+
+      populateFilters: function(callback) {
+
+        // Populate manage view filters by the same technique used
+        // for the `piecesFilters` option of `apostrophe-pieces-pages`
+
+        var allowedFilters = filters.chooser ? _.filter(self.filters, function(item) {
+          return item.allowedInChooser !== false;
+        }) : self.filters;
+        results.filters = {
+          options: [],
+          q: filters.search,
+          choices: {}
+        };
+
+        return async.eachSeries(allowedFilters, function(filter, callback) {
+          // The choices for each filter should reflect the effect of all filters
+          // except this one (filtering by topic pares down the list of categories and
+          // vice versa)
+          var value = cursor.get(filter);
+          var _cursor = cursor.clone();
+          // The default might not be good for our purposes. Set it to
+          // `null`, which appropriate filters, like `trash`, understand to mean
+          // "I am interested in things that are ignored by default and also live things"
+          _cursor[filter.name](null);
+          return _cursor.toChoices(filter.name, function(err, choices) {
+            if (err) {
+              return callback(err);
+            }
+            // Array of all filter objects allowed in this context:
+            //
+            // results.filters.options = [ { name: 'published', choices: [ ... usual ... ], def: ... } ]
+            //
+            // Single object with a property containing the value of EACH filter:
+            // 
+            // results.filters.choices = {
+            //   published: true
+            // }
+            results.filters.options.push(_.assign(_.clone(filter), { choices: choices }));
+            // These are the "choices you have made," not the "choices you can make."
+            results.filters.choices[filter.name] = filters[filter.name];
+            return callback(null);
+          });
+        }, callback);
+
+      },
+
       toArray: function(callback) {
         return cursor
           .toArray(function(err, pieces) {
@@ -108,7 +158,8 @@ module.exports = function(self, options) {
             return callback(null);
           }
         );
-      }
+      },
+
     }, function(err) {
       if (err) {
         return callback(err);

--- a/lib/modules/apostrophe-pieces/lib/api.js
+++ b/lib/modules/apostrophe-pieces/lib/api.js
@@ -158,7 +158,7 @@ module.exports = function(self, options) {
             return callback(null);
           }
         );
-      },
+      }
 
     }, function(err) {
       if (err) {

--- a/lib/modules/apostrophe-pieces/lib/routes.js
+++ b/lib/modules/apostrophe-pieces/lib/routes.js
@@ -84,13 +84,6 @@ module.exports = function(self, options) {
         results.options.pluralLabel = self.pluralLabel;
         results.options.manageViews = self.options.manageViews;
         results.schema = self.schema;
-        results.filters = {
-          options: filters.chooser ? _.filter(self.filters, function(item) {
-            return item.allowedInChooser !== false;
-          }) : self.filters,
-          choices: filters,
-          q: filters.search
-        };
         results.columns = self.columns;
         results.sorts = self.sorts;
         var actualSort = results.cursor.get('sort');

--- a/lib/modules/apostrophe-pieces/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/manager-modal.js
@@ -24,21 +24,9 @@ apos.define('apostrophe-pieces-manager-modal', {
       return {
         name: filter.name,
         setDefault: function() {
-          self.currentFilters[filter.name] = stringify(filter.def);
+          self.currentFilters[filter.name] = filter.def;
         }
       };
-      function stringify(def) {
-        if (typeof(def) === 'string') {
-          return def;
-        }
-        else if ((def === undefined) || (def === null)) {
-          return 'any';
-        } else if (def) {
-          return '1';
-        } else {
-          return '0';
-        }
-      }
     };
 
     self.beforeShow = function(callback) {
@@ -71,9 +59,6 @@ apos.define('apostrophe-pieces-manager-modal', {
         }
       ];
 
-      _.each(self.options.filters, function(filter) {
-        return self.filterTo
-      })
       var filterFields = _.filter(self.schema, function(field) {
         return !!(field.manage && field.manage.filter);
       });
@@ -89,6 +74,9 @@ apos.define('apostrophe-pieces-manager-modal', {
           self.currentFilters[filter.name] = 1;
         };
         filter.handler = filter.handler || function($el, value) {
+          if (value === '**ANY**') {
+            value = null;
+          }
           self.currentFilters[filter.name] = value;
           self.currentFilters.page = 1;
           self.refresh();
@@ -96,7 +84,12 @@ apos.define('apostrophe-pieces-manager-modal', {
         filter.setDefault();
         // One step of indirection to make overrides after this point possible
         self.link('apos-' + filter.name, function($el, value) {
+          // For pill button links
           filter.handler($el, value);
+        });
+        self.$filters.on('change', '[name="' + filter.name + '"]', function() {
+          // For select elements
+          filter.handler($(this), $(this).val());
         });
       });
 

--- a/lib/modules/apostrophe-pieces/views/piecesMacros.html
+++ b/lib/modules/apostrophe-pieces/views/piecesMacros.html
@@ -77,7 +77,7 @@
 
   #}<div class="apos-modal-filters-toggles">
     {%- for filter in filters.options -%}
-      {{ pills.base( module.filterChoicesToPillChoices(filter), filters.choices[filter.name] ) }}
+      {{ fields.select(filter.name, apos.utils.concat([ { label: filter.label or '—', value: "**ANY**" } ], filter.choices), filters.choices[filter.name]) }}
     {%- endfor -%}{#
 
   Search

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -1094,20 +1094,25 @@ module.exports = {
             return self.apos.launder.booleanOrNull(b);
           },
           choices: function(callback) {
-            return setImmediate(_.partial(callback, null, [
-              {
-                value: '',
-                label: "--"
-              },
-              {
-                value: '0',
-                label: 'No'
-              },
-              {
-                value: '1',
-                label: 'Yes'
+            return cursor.toDistinct(field.name, function(err, values) {
+              if (err) {
+                return callback(err);
               }
-            ]));
+              var choices = [];
+              if (_.contains(values, true)) {
+                choices.push({
+                  value: '1',
+                  label: 'Yes'
+                });
+              }
+              if (_.contains(values, true)) {
+                choices.push({
+                  value: '0',
+                  label: 'No'
+                });
+              }
+              return callback(null, choices);
+            });
           }
         });
       }

--- a/lib/modules/apostrophe-ui/views/components/fields.html
+++ b/lib/modules/apostrophe-ui/views/components/fields.html
@@ -13,11 +13,13 @@
   </label>
 {%- endmacro %}
 
-{% macro select(name, options) -%}
+{# "selected" value is typically not passed, but we do push it in when rendering manage filters. -Tom #}
+
+{% macro select(name, options, selected) -%}
   <div class="apos-field-input-select-wrapper">
     <select name="{{ name }}" class="apos-field-input apos-field-input-select">
       {%- for option in options -%}
-        <option value="{{ option.value }}">{{ __(option.label | d('')) }}</option>
+        <option {{ "selected" if option.value == selected }} value="{{ option.value }}">{{ __(option.label | d('')) }}</option>
       {%- endfor -%}
     </select>
   </div>


### PR DESCRIPTION
…ield that supports cursor filters

My goal here was to enable browsing by tag, which we have a client demand for.

To do that, you would say this in the config for your pieces module, which could include apostrophe-images, for instance:

```
    'apostrophe-images': {
      addFilters: [
        {
          name: 'tags',
          label: 'Tags'
        }
      ]
    }
```

To better accommodate this sort of thing, I got rid of the pill buttons for the publish and trash filters, so that they are more compact and follow the same UI pattern: a dropdown menu with a "—" choice for cases where you don't care about that particular setting.

Note that the filters all affect each other, i.e. your choices for tag are properly narrowed down by your choice for "publish", just like it is with piecesFilters.

In principle this was straightforward, in practice the devil was in the details. I was able to extend our existing API for manage filters, which only supported booleans, without bc breaks but it took a little doing. Also the "publish" and "trash" filters were not originally designed to display only the values that exist for items that match the rest of your active filters. Any breakdown of that pattern makes the whole experience confusing, so I had to work on that for quite a while.

The end result looks like this:

https://dl.dropboxusercontent.com/spa/jfyjetktfp495r1/mhc0s9pz.png

https://dl.dropboxusercontent.com/spa/jfyjetktfp495r1/5su_-elt.png

I took the position that the first entry in the select menu can be the label for the filter, and that once you pick one of the values it should be clear from context what the filter does. Also, picking that label again is how you clear it and go back to not caring about that field's value right now.

Perhaps the label of the first item should change when another item is currently selected.