### PR TITLE
in dev, we leave relative URLs in LESS files strictly alone. Producti…

### DIFF
--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -1045,12 +1045,8 @@ module.exports = {
       return less.render(fs.readFileSync(src, 'utf8'),
       {
         filename: src,
-        rootpath: path.dirname(stylesheet.web) + '/',
-        // Without this relative import paths are in trouble
-        paths: [ path.dirname(src) ],
-        // Convert all URLs to relative URLs, so the bundle
-        // can be moved around
-        relativeUrls: true
+        paths: [],
+        compress: true
         // syncImport doesn't seem to work anymore in 1.4, thus
         // we were pushed to write endAssets, although it makes
         // sense anyway


### PR DESCRIPTION
…on should match the expectation this creates. The old behavior worked when assets stayed put but broke relative URLs in asset bundles uploaded to S3. 

(This does require that the assets being fetched by relative URLs be part of the bundle, but this is already an appropriate assumption because S3 is a separate origin server.)