### PR TITLE
Add field type object

### DIFF
--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -810,7 +810,7 @@ module.exports = {
         return partial(field);
       }
     });
-    
+
     // Given a schema and a cursor, add filter methods to the cursor
     // for each of the fields in the schema, based on their field type,
     // if supported by the field type. If a field name exists in `options.override`
@@ -1527,6 +1527,16 @@ module.exports = {
     });
 
     self.addFieldType({
+      name: 'object',
+      converters: {
+        form: function(req, data, name, object, field, callback) {
+          object[name] = data[name];
+          return callback(null);
+        }
+      }
+    });
+
+    self.addFieldType({
       name: 'joinByOne',
       converters: {
         string: function(req, data, name, object, field, callback) {
@@ -1589,7 +1599,7 @@ module.exports = {
           safeFor: 'manage',
           launder: joinFilterLaunder
         });
-        
+
         self.addJoinSlugFilter(field, cursor, '');
       }
     });
@@ -1709,7 +1719,7 @@ module.exports = {
         }
       }
     });
-    
+
     function joinFilterLaunder(v) {
       if (Array.isArray(v)) {
         return self.apos.launder.ids(v);
@@ -1731,7 +1741,7 @@ module.exports = {
       }
       return undefined;
     };
-    
+
     // You don't need to call this. It is called for you when you invoke `toChoices` for any
     // cursor filter based on a join. It delivers an array of choice objects to its callback.
 
@@ -1792,9 +1802,9 @@ module.exports = {
         }
 
       };
-      
+
     };
-    
+
     // You don't need to call this. It is called for you as part of the mechanism that
     // adds cursor filter methods for all joins.
     //
@@ -1811,7 +1821,7 @@ module.exports = {
 
       var suffix = suffix || '';
       var name = field.name.replace(/^_/, '');
-      
+
       if (name === field.name) {
         // Nope, your join is not well-named
         return;
@@ -1820,7 +1830,7 @@ module.exports = {
         // Don't crush an existing filter by this name
         return;
       }
-      
+
       cursor.addFilter(name + suffix, {
         finalize: function(callback) {
           if (!self.cursorFilterInterested(cursor, name + suffix)) {
@@ -1893,7 +1903,7 @@ module.exports = {
         }
       });
     };
-    
+
     // Fetch the distinct values for the specified property via the specified
     // cursor and sort them before delivering them to the callback as the
     // second argument. Like `toDistinct`, but sorted. A convenience used
@@ -1908,7 +1918,7 @@ module.exports = {
         return callback(null, results);
       });
     };
-    
+
     // For most cursor filters, if the value is undefined or null,
     // the filter should do nothing. This method implements that test.
 

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -276,7 +276,7 @@ apos.define('apostrophe-schemas', {
         $element.find('input,select,textarea').first().focus();
       }
     };
-    
+
     // Show the tab group containing the given element, if not already visible,
     // by triggering the appropriate tab button.
     self.showGroupContaining = function($element) {
@@ -567,6 +567,42 @@ apos.define('apostrophe-schemas', {
         if ($field.data('apos-array')) {
           data[name] = $field.data('apos-array');
         }
+        return setImmediate(callback);
+      }
+    });
+
+    self.addFieldType({
+      name: 'object',
+      populate: function populate(data, name, $field, $el, field, callback) {
+        var $fieldset = self.findFieldset($el, name);
+        _.each(field.schema, function (subField) {
+          var $input = self.findSafeInFieldset($fieldset, subField.name, '[name=' + subField.name + ']');
+          var $subFieldSet = self.findFieldset($fieldset, subField.name);
+
+          if (subField.required === true) {
+            $subFieldSet.addClass('apos-required');
+          }
+
+          if (subField.type === 'object') {
+            // recursive call : no need for callback as the real callback will be called at the end of this loop
+            populate(data[name], subField.name, $subFieldSet, $fieldset, subField, function() { return; })
+          } else { $input.val(data[name][subField.name]); }
+        })
+
+        return setImmediate(callback);
+      },
+      convert: function convert(data, name, $field, $el, field, callback) {
+        var $fieldset = self.findFieldset($el, name);
+        _.each(field.schema, function (subField) {
+          var $input = self.findSafeInFieldset($fieldset, subField.name, '[name=' + subField.name + ']');
+
+          if (subField.type === 'object') {
+            var $subFieldSet = self.findFieldset($fieldset, subField.name);
+            // recursive call : no need for callback as the real callback will be called at the end of this loop
+            convert(data[name], subField.name, $subFieldSet, $fieldset, subField, function() { return; })
+          } else { data[name][subField.name] = $input.val(); }
+        })
+
         return setImmediate(callback);
       }
     });

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -586,7 +586,9 @@ apos.define('apostrophe-schemas', {
           if (subField.type === 'object') {
             // recursive call : no need for callback as the real callback will be called at the end of this loop
             populate(data[name], subField.name, $subFieldSet, $fieldset, subField, function() { return; })
-          } else { $input.val(data[name][subField.name]); }
+          } else {
+            $input.val(data[name][subField.name]);
+          }
         })
 
         return setImmediate(callback);
@@ -600,7 +602,9 @@ apos.define('apostrophe-schemas', {
             var $subFieldSet = self.findFieldset($fieldset, subField.name);
             // recursive call : no need for callback as the real callback will be called at the end of this loop
             convert(data[name], subField.name, $subFieldSet, $fieldset, subField, function() { return; })
-          } else { data[name][subField.name] = $input.val(); }
+          } else {
+            data[name][subField.name] = $input.val();
+          }
         })
 
         return setImmediate(callback);

--- a/lib/modules/apostrophe-schemas/views/macros.html
+++ b/lib/modules/apostrophe-schemas/views/macros.html
@@ -219,3 +219,11 @@
 {%- macro joinBody(field) -%}
   <div data-chooser>{# ajax populates me #}</div>
 {%- endmacro -%}
+
+{%- macro object(field) -%}
+  <fieldset class="apos-field apos-field-{{ field.type | css }} apos-field-{{ field.name | css }}" data-name="{{ field.name }}">
+  {% for item in field.schema %}
+    {{ apos.schemas.field(item) }}
+  {% endfor %}
+  </fieldset>
+{%- endmacro -%}

--- a/lib/modules/apostrophe-schemas/views/object.html
+++ b/lib/modules/apostrophe-schemas/views/object.html
@@ -1,0 +1,2 @@
+{%- import "macros.html" as schemas -%}
+{{ schemas.object(data) }}


### PR DESCRIPTION
Add a new field type "object" to handle nested objects in mongo data.

It can be used as an "array" type, that is to say with a schema using other field types, even objects (so objects in objects):

```js
module.exports = {
  extend: 'apostrophe-pieces',
  name: 'module-test',
  label: 'Test',
  addFields: [
    {
        name: 'objectFirstLevel',
        label: 'Object First Level',
        type: 'object',
        schema: [
          {
            name: 'randomField1',
            label: 'Random Field 1',
            type: 'string',
            required: true
          }, {
            name: 'randomField2',
            label: 'Random Field 2',
            type: 'boolean'
          }, {
            name: 'objectSecondLevel',
            label: 'Object Second Level',
            type: 'object',
            schema: [{
              name: 'randomField3',
              label: 'Random Field 3',
              type: 'string',
              required: true
            }, {
              name: 'randomField4',
              label: 'Random Field 4',
              type: 'integer'
            }]
          }
        ]
      }]
    }
  ]
}
```