### PR TITLE
* The `expressMiddleware` property of a module can already be a funct…

### DIFF
--- a/lib/modules/apostrophe-db/index.js
+++ b/lib/modules/apostrophe-db/index.js
@@ -46,7 +46,7 @@ module.exports = {
     // Open the database connection. Always use MongoClient with its
     // sensible defaults. Build a URI if we need to so we can call it
     // in a consistent way
-    self.connectToMongo = function(callback){
+    self.connectToMongo = function(callback) {
       var uri = 'mongodb://';
       
       if (process.env.APOS_MONGODB_URI) {

--- a/lib/modules/apostrophe-express/index.js
+++ b/lib/modules/apostrophe-express/index.js
@@ -518,16 +518,53 @@ module.exports = {
       self.findModuleMiddleware();
     }
     
-    // Locate modules with middleware and add it to the list
+    // Locate modules with `expressMiddleware` properties and add those functions or arrays
+    // of functions the list in `self.moduleMiddleware`.
+    //
+    // If `expressMiddleware` is an object, look for function(s) in its `middleware` property
+    // and implement the `before` option if present.
+
     self.findModuleMiddleware = function() {
+      var labeledList = [];
       _.each(self.apos.modules, function(module, name) {
-        if (!module.expressMiddleware) {
+        var prop = module.expressMiddleware;
+        var obj;
+        if (!prop) {
           return;
         }
-        if (Array.isArray(module.expressMiddleware)) {
-          self.moduleMiddleware = self.moduleMiddleware.concat(module.expressMiddleware);
-        } else if (typeof(module.expressMiddleware) === 'function') {
-          self.moduleMiddleware.push(module.expressMiddleware);
+        if (Array.isArray(prop) || (typeof(prop) === 'function')) {
+          obj = {
+            middleware: prop
+          };
+        } else {
+          obj = prop;
+        }
+        obj.module = name;
+        // clone so we can safely delete a property
+        labeledList.push(_.clone(obj));
+      });
+      do {
+        var beforeIndex = _.findIndex(labeledList, function(item) {
+          return item.before;
+        });
+        if (beforeIndex === -1) {
+          break;
+        }
+        var item = labeledList[beforeIndex];
+        var otherIndex = _.findIndex(labeledList, { module: item.before });
+        if ((otherIndex !== -1) && (otherIndex < beforeIndex)) {
+          labeledList.splice(beforeIndex, 1);
+          labeledList.splice(otherIndex, 0, item);
+        }
+        delete item.before;
+      } while(true);
+      console.log(labeledList);
+      _.each(labeledList, function(item) {
+        var prop = item.middleware;
+        if (Array.isArray(prop)) {
+          self.moduleMiddleware = self.moduleMiddleware.concat(prop);
+        } else if (typeof(prop) === 'function') {
+          self.moduleMiddleware.push(prop);
         }
       });
     };

--- a/lib/modules/apostrophe-global/index.js
+++ b/lib/modules/apostrophe-global/index.js
@@ -131,10 +131,11 @@ module.exports = {
       });
     };
 
-    // Add the `addGlobalToData` middleware.
+    // Add the `addGlobalToData` middleware. Do it via the `expressMiddleware` property
+    // so it runs in a well-behaved sequence with other module middleware.
 
     self.enableMiddleware = function() {
-      self.apos.app.use(self.addGlobalToData);
+      self.expressMiddleware = self.addGlobalToData;
     };
 
     // Standard middleware. Fetch the global doc and add it to `req.data` as `req.data.global`.

--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -155,10 +155,15 @@ module.exports = {
     // Add Passport's initialize and session middleware.
     // Also add middleware to add the `req.data.user` property.
 
-    self.enableMiddleware = function(){
-      self.apos.app.use(self.passport.initialize());
-      self.apos.app.use(self.passport.session());
-      self.apos.app.use(self.addUserToData);
+    self.enableMiddleware = function() {
+      // Add it via the expressMiddleware mechanism so that it happens before
+      // third-party module middleware, as intended, allowing that middleware
+      // to see req.user
+      self.expressMiddleware = [
+        self.passport.initialize(),
+        self.passport.session(),
+        self.addUserToData
+      ];
     };
 
     // Add the `/login` route, both GET (show the form) and POST (submit the form).

--- a/lib/modules/apostrophe-templates/views/outerLayoutBase.html
+++ b/lib/modules/apostrophe-templates/views/outerLayoutBase.html
@@ -15,12 +15,20 @@
     {% endblock %}
 
     {% if data.user %}
-    <div class="apos-ui">
-      <div class="apos-context-menu-container">
-        {{ apos.pages.publishMenu({ publishMenu: data.publishMenu, page: data.page, piece: data.piece, bottom: true }) }}
-        {{ apos.pages.menu({ contextMenu: data.contextMenu, page: data.page, bottom: true })}}
-      </div>
-    </div>
+      {% block apostropheContextMenuWrapper %}
+        <div class="apos-ui">
+          {% block apostropheContextMenu %}
+            <div class="apos-context-menu-container">
+              {% block beforeApostropheContextMenu %}
+              {% endblock %}
+              {{ apos.pages.publishMenu({ publishMenu: data.publishMenu, page: data.page, piece: data.piece, bottom: true }) }}
+              {{ apos.pages.menu({ contextMenu: data.contextMenu, page: data.page, bottom: true })}}
+              {% block afterApostropheContextMenu %}
+              {% endblock %}
+            </div>
+          {% endblock %}
+        </div>
+      {% endblock %}
     {% endif %}
     <div class="apos-refreshable" data-apos-refreshable>
       {% block beforeMain %}{% endblock %}


### PR DESCRIPTION
…ion or array of functions, which are executed as middleware in the order the module is activated. In addition, it may now be an object. The object must have a `middleware` property, which is a function or array of functions as before. It may also have a `before` property, which must be the name of another module. This changes the execution order: the middleware for the current module will run prior to that of the module specified with `before`.
* Use `expressMiddleware` more consistently within Apostrophe's core modules.
* Provide `apostropheContextMenuWrapper`, `beforeApostropheContextMenu` and `afterApostropheContextMenu` nunjucks blocks to allow extension of the context menu in the outer layout.