### PR TITLE
Sanitize field type object

### DIFF
--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -602,7 +602,7 @@ module.exports = {
         });
         joins = joins.concat(_joins);
         _.each(schema, function(field) {
-          if (field.type === 'array') {
+          if (field.type === 'array' || field.type === 'object') {
             findJoins(field.schema, arrays.concat(field.name));
           }
         });

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -1527,6 +1527,29 @@ module.exports = {
     });
 
     self.addFieldType({
+      name: 'object',
+      converters: {
+        form: function(req, data, name, object, field, callback) {
+          var schema = field.schema;
+          data = data[name];
+          
+          if (data == null || typeof data !== 'object' || Array.isArray(data)) {
+            data = {};
+          }
+
+          return self.convert(req, schema, 'form', data, object, function(err) {
+            if (err) {
+              return callback(err);
+            }
+
+            object[name] = data;
+            return callback(null);
+          });
+        }
+      }
+    });
+
+    self.addFieldType({
       name: 'joinByOne',
       converters: {
         string: function(req, data, name, object, field, callback) {

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -1532,17 +1532,15 @@ module.exports = {
         form: function(req, data, name, object, field, callback) {
           var schema = field.schema;
           data = data[name];
-          
           if (data == null || typeof data !== 'object' || Array.isArray(data)) {
             data = {};
           }
-
-          return self.convert(req, schema, 'form', data, object, function(err) {
+          var result = {};
+          return self.convert(req, schema, 'form', data, result, function(err) {
             if (err) {
               return callback(err);
             }
-
-            object[name] = data;
+            object[name] = result;
             return callback(null);
           });
         }

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -574,10 +574,16 @@ apos.define('apostrophe-schemas', {
     self.addFieldType({
       name: 'object',
       populate: function(data, name, $field, $el, field, callback) {
+        if (data[name] == undefined) {
+          data[name] = {};
+        }
         var $fieldset = self.findFieldset($el, name);
         self.populate($fieldset, field.schema, data[name], callback);
       },
       convert: function(data, name, $field, $el, field, callback) {
+        if (data[name] == undefined) {
+          data[name] = {};
+        }
         var $fieldset = self.findFieldset($el, name);
         self.convert($fieldset, field.schema, data[name], callback);
       }

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -572,6 +572,18 @@ apos.define('apostrophe-schemas', {
     });
 
     self.addFieldType({
+      name: 'object',
+      populate: function(data, name, $field, $el, field, callback) {
+        var $fieldset = self.findFieldset($el, name);
+        self.populate($fieldset, field.schema, data[name], callback);
+      },
+      convert: function(data, name, $field, $el, field, callback) {
+        var $fieldset = self.findFieldset($el, name);
+        self.convert($fieldset, field.schema, data[name], callback);
+      }
+    });
+    
+    self.addFieldType({
       name: 'joinByOne',
       populate: function(data, name, $field, $el, field, callback) {
         var manager;

--- a/lib/modules/apostrophe-schemas/views/macros.html
+++ b/lib/modules/apostrophe-schemas/views/macros.html
@@ -219,3 +219,11 @@
 {%- macro joinBody(field) -%}
   <div data-chooser>{# ajax populates me #}</div>
 {%- endmacro -%}
+
+{%- macro object(field) -%}
+  <fieldset class="apos-field apos-field-{{ field.type | css }} apos-field-{{ field.name | css }}" data-name="{{ field.name }}">
+  {% for item in field.schema %}
+    {{ apos.schemas.field(item) }}
+  {% endfor %}
+  </fieldset>
+{%- endmacro -%}

--- a/lib/modules/apostrophe-schemas/views/object.html
+++ b/lib/modules/apostrophe-schemas/views/object.html
@@ -1,0 +1,2 @@
+{%- import "macros.html" as schemas -%}
+{{ schemas.object(data) }}


### PR DESCRIPTION
I closed PR#872 to respect whitespaces.

Add a new field type "object" to handle nested objects in mongo data.

It can be used as an "array" type, that is to say with a schema using other field types, even objects (so objects in objects) and complex structures (attachments, areas, joinByOne, joinByArray, ...):

```js
module.exports = {
  extend: 'apostrophe-pieces',
  name: 'module-test',
  label: 'Test',
  addFields: [
    {
        name: 'objectFirstLevel',
        label: 'Object First Level',
        type: 'object',
        schema: [
          {
            name: 'randomField1',
            label: 'Random Field 1',
            type: 'string',
            required: true
          }, {
            name: 'randomField2',
            label: 'Random Field 2',
            type: 'boolean'
          }, {
            name: 'objectSecondLevel',
            label: 'Object Second Level',
            type: 'object',
            schema: [{
              name: 'randomField3',
              label: 'Random Field 3',
              type: 'string',
              required: true
            }, {
              name: 'randomField4',
              label: 'Random Field 4',
              type: 'integer'
            }]
          }
        ]
      }]
    }
  ]
}
```