### PR TITLE
* Ability to disable contextual editing for a specific request with `…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,7 @@ Thanks to Michelin for their support of this work.
 
 All tests passing.
 
-* Performance enhancement: when fetching `req.data.home` directly in the absence of `req.page._ancestors[0]`, such as on the home page itself or a non-page route like `/login`, we must apply the same default filters before applying the filter options, namely `.areas(false).joins(false)`, otherwise duplicate queries are made.
+* Performance enhancement: when fetching `req.data.home` directly in the absence of `req.data.page._ancestors[0]`, such as on the home page itself or a non-page route like `/login`, we must apply the same default filters before applying the filter options, namely `.areas(false).joins(false)`, otherwise duplicate queries are made.
 
 * Fixed bug in as-yet-unused `schemas.export` method caught by babel's linter.
 

--- a/index.js
+++ b/index.js
@@ -111,6 +111,10 @@ module.exports = function(options) {
       return callback(null);
     });
   };
+  
+  self.destroy = function(callback) {
+    return self.callAll('apostropheDestroy', callback);
+  };
 
   // Helper function for other modules to determine whether the application
   // is running as a server or a task

--- a/lib/modules/apostrophe-areas/lib/api.js
+++ b/lib/modules/apostrophe-areas/lib/api.js
@@ -31,6 +31,13 @@ module.exports = function(self, options) {
   // `apos.area` and `apos.singleton` template helpers.
 
   self.renderArea = function(area, options) {
+    // Ability to disable editing for a specific request
+    if (self.apos.templates.contextReq.disableEditing) {
+      if (area._edit && (options.edit !== false)) {
+        area._disabledEditing = true;
+      }
+      area._edit = false;
+    }
     return self.partial('area', {
       area: area,
       options: options,

--- a/lib/modules/apostrophe-areas/public/js/user.js
+++ b/lib/modules/apostrophe-areas/public/js/user.js
@@ -209,6 +209,8 @@ apos.define('apostrophe-areas', {
       }
       return manager.setData($widget, data);
     };
+    
+    apos.areas = self;
 
   }
 });

--- a/lib/modules/apostrophe-areas/views/area.html
+++ b/lib/modules/apostrophe-areas/views/area.html
@@ -2,7 +2,7 @@
 {# JSON, for adding new widgets #}
 {%- set canEdit = data.area._edit and data.options.edit != false -%}
 {%- set isSingleton = data.options.limit == 1 and data.options.type -%}
-<div class="apos-area{% if data.options.blockLevelControls %} apos-area--block-level-controls{% endif %}"data-apos-area{% if canEdit %} data-apos-area-edit{% if not data.options.virtual %} data-autosave{% endif %} data-options='{{ apos.utils.omit(data.options, 'area') | jsonAttribute({ single: true }) }}' data-doc-id="{{ data.area._docId }}" data-dot-path="{{ data.area._dotPath }}"{% endif %}>
+<div class="apos-area{% if data.options.blockLevelControls %} apos-area--block-level-controls{% endif %}" {{ " data-apos-area-disabled-editing" if data.area._disabledEditing }} data-apos-area{% if canEdit %} data-apos-area-edit{% if not data.options.virtual %} data-autosave{% endif %}{% endif %}{% if canEdit or data.area._disabledEditing %} data-options='{{ apos.utils.omit(data.options, 'area') | jsonAttribute({ single: true }) }}' data-doc-id="{{ data.area._docId }}" data-dot-path="{{ data.area._dotPath }}"{% endif %}>
   {%- if canEdit -%}
     {%- if isSingleton -%}
       {% include "singletonControls.html" %}

--- a/lib/modules/apostrophe-db/index.js
+++ b/lib/modules/apostrophe-db/index.js
@@ -142,5 +142,12 @@ module.exports = {
       }, callback );
     });
    };
+   
+   self.apostropheDestroy = function(callback) {
+     if (!self.db) {
+       return setImmediate(callback);
+     }
+     return self.db.close(false, callback);
+   }
   }
 };

--- a/lib/modules/apostrophe-docs/index.js
+++ b/lib/modules/apostrophe-docs/index.js
@@ -16,9 +16,10 @@ module.exports = {
   alias: 'docs',
 
   afterConstruct: function(self, callback) {
-    return async.series([ self.enableCollection, self.ensureIndexes ], callback);
+    return async.series([ self.enableCollection ], callback);
+    // ensureIndexes is called on modulesReady to give other modules a shot at an opinion
   },
-
+  
   construct: function(self, options) {
 
     self.apos.define('apostrophe-cursor', require('./lib/cursor.js'));

--- a/lib/modules/apostrophe-docs/lib/api.js
+++ b/lib/modules/apostrophe-docs/lib/api.js
@@ -10,16 +10,21 @@ module.exports = function(self, options) {
     });
   };
 
+  // Index on the slug property. Emits a slugIndex event with a params object
+  // so it can be altered by other listening modules
+
+  self.ensureSlugIndex = function(callback) {
+    var params = { slug: 1 };
+    self.apos.emit('slugIndex', params);
+    return self.db.ensureIndex(params, { unique: true }, callback);
+  };
+
   self.ensureIndexes = function(callback) {
 
-    async.series([ indexType, indexSlug, indexTitleSortified, indexUpdatedAt, indexTags, indexPublished, indexText ], callback);
+    async.series([ indexType, self.ensureSlugIndex, indexTitleSortified, indexUpdatedAt, indexTags, indexPublished, indexText ], callback);
 
     function indexType(callback) {
       self.db.ensureIndex({ type: 1 }, {}, callback);
-    }
-
-    function indexSlug(callback) {
-      self.db.ensureIndex({ slug: 1 }, { unique: true }, callback);
     }
 
     function indexTitleSortified(callback) {
@@ -705,6 +710,16 @@ module.exports = function(self, options) {
     //   console.trace();
     // }
     return self.managers[type];
+  };
+
+  // When all modules are awake, ensure the indexes on the docs collection.
+  // We delay this to give other modules a chance to have an opinion on
+  // the index parameters via events. Modules should not rely on 
+  // index uniqueness at first-time startup prior to modulesReady. This
+  // is not an issue after first-time startup.
+  
+  self.modulesReady = function(callback) {
+    return self.ensureIndexes(callback);
   };
 
   // Add fields to the list of those unsuitable for

--- a/lib/modules/apostrophe-docs/lib/cursor.js
+++ b/lib/modules/apostrophe-docs/lib/cursor.js
@@ -1042,7 +1042,7 @@ module.exports = {
           if (lateCriteria) {
             _.assign(criteria, lateCriteria);
           }
-          // console.log(JSON.stringify(criteria, null, '  '));
+          // console.log(require('util').inspect(criteria, { depth: 10 }));
           var mongo = self.db.find(self.get('criteria'), self.get('projection'));
           var util = require('util');
           var skip = self.get('skip');

--- a/lib/modules/apostrophe-docs/lib/cursor.js
+++ b/lib/modules/apostrophe-docs/lib/cursor.js
@@ -1042,6 +1042,7 @@ module.exports = {
           if (lateCriteria) {
             _.assign(criteria, lateCriteria);
           }
+          // console.log(JSON.stringify(criteria, null, '  '));
           var mongo = self.db.find(self.get('criteria'), self.get('projection'));
           var util = require('util');
           var skip = self.get('skip');

--- a/lib/modules/apostrophe-express/index.js
+++ b/lib/modules/apostrophe-express/index.js
@@ -558,7 +558,6 @@ module.exports = {
         }
         delete item.before;
       } while(true);
-      console.log(labeledList);
       _.each(labeledList, function(item) {
         var prop = item.middleware;
         if (Array.isArray(prop)) {

--- a/lib/modules/apostrophe-express/index.js
+++ b/lib/modules/apostrophe-express/index.js
@@ -162,6 +162,7 @@ var fs = require('fs');
 var _ = require('lodash');
 var minimatch = require('minimatch');
 var async = require('async');
+var enableDestroy = require('server-destroy');
 
 module.exports = {
 
@@ -457,23 +458,30 @@ module.exports = {
             console.log("I see no data/port file, defaulting to port " + port);
           }
         }
-        var server;
         if (port.toString().match(/^\d+$/)) {
           console.log("Listening on " + address + ":" + port);
-          server = self.apos.baseApp.listen(port, address);
+          self.server = self.apos.baseApp.listen(port, address);
         } else {
           console.log("Listening at " + port);
-          server = self.apos.baseApp.listen(port);
+          self.server = self.apos.baseApp.listen(port);
         }
+        enableDestroy(self.server);
         if (self.apos.options.afterListen) {
-          server.on('error', function(err) {
+          self.server.on('error', function(err) {
             return self.apos.options.afterListen(err);
           });
-          server.on('listening', function() {
+          self.server.on('listening', function() {
             return self.apos.options.afterListen(null);
           });
         }
       };
+    };
+    
+    self.apostropheDestroy = function(callback) {
+      if (!self.server) {
+        return setImmediate(callback);
+      }
+      return self.server.destroy(callback);
     };
 
     // Standard middleware. Sets the `req.absoluteUrl` property for all requests,

--- a/lib/modules/apostrophe-pages/index.js
+++ b/lib/modules/apostrophe-pages/index.js
@@ -246,8 +246,7 @@ module.exports = {
     self.pushAssets();
     self.validateTypeChoices();
     return async.series([
-      self.registerTrashPageType,
-      self.ensureIndexes
+      self.registerTrashPageType
     ], callback);
   },
 
@@ -272,6 +271,7 @@ module.exports = {
 
     self.modulesReady = function(callback) {
       return async.series([
+        self.ensureIndexes,
         self.registerGenericPageTypes,
         self.manageOrphans
       ], callback);

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -1003,7 +1003,7 @@ module.exports = function(self, options) {
     slugs.unshift(slug);
 
     cursor.sort({ slug: -1 });
-
+    
     cursor.and({ slug: { $in: slugs } });
   };
 
@@ -1035,7 +1035,11 @@ module.exports = function(self, options) {
   self.ensureIndexes = function(callback) {
     return async.series([ indexPath ], callback);
     function indexPath(callback) {
-      self.apos.docs.db.ensureIndex({ path: 1 }, { unique: true, sparse: true }, callback);
+      var params = {
+        path: 1
+      };
+      self.apos.emit('pathIndex', params);
+      self.apos.docs.db.ensureIndex(params, { unique: true, sparse: true }, callback);
     }
   };
 
@@ -1540,5 +1544,19 @@ module.exports = function(self, options) {
       }
     });
   };
+  
+  // Register a function to be invoked after the
+  // context menu is output. This allows for adding additional contextual
+  // UI in that general area of the page without changing the outerLayout template.
+  // It is commonly used in the implementation of optional npm modules that
+  // enhance the Apostrophe UI.
+  //
+  // Your function will receive `req`, for convenience. Since page template rendering
+  // is already in progress it will be equal to `self.apos.templates.contextReq`.
 
+  self.addAfterContextMenu = function(helper) {
+    self.afterContextMenuHelpers = self.afterContextMenuHelpers || [];
+    self.afterContextMenuHelpers.push(helper);
+  };
+  
 };

--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -280,7 +280,7 @@ module.exports = function(self, options) {
   };
 
   // Move a page already in the page tree to another location.
-
+  //
   // position can be 'before', 'after' or 'inside' and
   // determines the moved page's new relationship to
   // the target page.
@@ -289,23 +289,52 @@ module.exports = function(self, options) {
   // error, also an array of objects with _id and slug
   // properties, indicating the new slugs of all
   // modified pages.
+  //
+  // *Less commonly used features*
+  //
+  // These are mainly for use by modules that extend Apostrophe's model layer,
+  // such as `apostrophe-workflow`.
+  //
+  // The `options` argument may be omitted entirely.
+  //
+  // If `options.criteria` is present, it is merged with
+  // all MongoDB criteria used to read and write the database in `self.move`.
+  // If `options.filters` is present, those filters are invoked
+  // on any Apostrophe cursor find() calls used to read and write the database in `self.move`. 
+  //
+  // In addition, `options` is passed back to the callback as a third argument,
+  // which is useful to detect recursive scenarios that come up in the
+  // workflow module.
+  //
+  // `options` is also passed back to the `pageMovePermissions` callAll method,
+  // and passed as the `options` property of the `info` parameter of `pageAfterMove`.
+  //
+  // After the moved and target pages are fetched, the `pageBeforeMove` callAll method is invoked with
+  // `req, moved, target, position, options` and an optional callback.
+  //
+  // `pageBeforeMove` may safely modify top-level properties of `options` without an impact
+  // beyond the exit of the current `self.move` call. If modifying deeper properties, clone them.
 
-  self.move = function(req, movedId, targetId, position, callback) {
+  self.move = function(req, movedId, targetId, position, options, callback) {
+    if (arguments.length === 5) {
+      callback = options;
+      options = {};
+    } else {
+      options = _.clone(options);
+    }
     var moved, target, parent, oldParent, changed = [];
     var rank;
     var originalPath;
     var originalSlug;
-    return async.series([ getMoved, getTarget, determineRankAndNewParent, permissions, nudgeNewPeers, moveSelf, updateDescendants, trashDescendants, afterMoved ], finish);
+    return async.series([ getMoved, getTarget, beforeMove, determineRankAndNewParent, permissions, nudgeNewPeers, moveSelf, updateDescendants, trashDescendants, afterMoved ], finish);
     function getMoved(callback) {
-      if (moved) {
-        return setImmediate(callback);
-      }
-      return self.find(req, { _id: movedId })
+      return self.find(req, mergeCriteria({ _id: movedId }))
         .permission(false)
         .trash(null)
         .published(null)
         .areas(false)
-        .ancestors({ depth: 1, trash: null, published: null, areas: false, permission: false })
+        .ancestors(_.assign({ depth: 1, trash: null, published: null, areas: false, permission: false }, options.filters || {}))
+        .applyFilters(options.filters || {})
         .toObject(function(err, page) {
           if (!page) {
             return callback(new Error('no such page'));
@@ -327,15 +356,13 @@ module.exports = function(self, options) {
       );
     }
     function getTarget(callback) {
-      if (target) {
-        return callback(null);
-      }
-      return self.find(req, { _id: targetId })
+      return self.find(req, mergeCriteria({ _id: targetId }))
         .permission(false)
         .trash(null)
         .published(null)
         .areas(false)
-        .ancestors({ depth: 1, trash: null, published: null, areas: false, permission: false })
+        .ancestors(_.assign({ depth: 1, trash: null, published: null, areas: false, permission: false }, options.filters || {}))
+        .applyFilters(options.filters || {})
         .toObject(function(err, page) {
           if (!page) {
             return callback(new Error('no such page'));
@@ -346,6 +373,17 @@ module.exports = function(self, options) {
           }
           return callback(null);
         }
+      );
+    }
+    function beforeMove(callback) {
+      return self.apos.callAll(
+        'pageBeforeMove',
+        req,
+        moved,
+        target,
+        position,
+        options,
+        callback
       );
     }
     function determineRankAndNewParent(callback) {
@@ -369,22 +407,15 @@ module.exports = function(self, options) {
       return setImmediate(callback);
     }
     function permissions(callback) {
-      if (!moved._publish) {
-        return callback(new Error('forbidden'));
-      }
-      // You can always move a page into the trash. You can
-      // also change the order of subpages if you can
-      // edit the subpage you're moving. Otherwise you
-      // must have edit permissions for the new parent page.
-      if ((oldParent._id !== parent._id) && (parent.type !== 'trash') && (!parent._edit)) {
-        return callback(new Error('forbidden'));
-      }
-      return callback(null);
+      return self.apos.callAll('pageMovePermissions', req, moved, {
+        oldParent: oldParent,
+        parent: parent
+      }, options, callback);
     }
     function nudgeNewPeers(callback) {
       // Nudge down the pages that should now follow us
       // Always remember multi: true
-      self.apos.docs.db.update({ path: self.matchDescendants(parent), level: parent.level + 1, rank: { $gte: rank } }, { $inc: { rank: 1 } }, { multi: true }, function(err, count) {
+      self.apos.docs.db.update(mergeCriteria({ path: self.matchDescendants(parent), level: parent.level + 1, rank: { $gte: rank } }), { $inc: { rank: 1 } }, { multi: true }, function(err, count) {
         return callback(err);
       });
     }
@@ -428,13 +459,24 @@ module.exports = function(self, options) {
       return self.update(req, moved, callback);
     }
     function updateDescendants(callback) {
-      return self.updateDescendantsAfterMove(req, moved, originalPath, originalSlug, function(err, _changed) {
-        if (err) {
-          return callback(err);
-        }
-        changed = changed.concat(_changed);
-        return callback(null);
-      });
+      if (self.updateDescendantsAfterMove.length >= 6) {
+        return self.updateDescendantsAfterMove(req, moved, originalPath, originalSlug, options, function(err, _changed) {
+          if (err) {
+            return callback(err);
+          }
+          changed = changed.concat(_changed);
+          return callback(null);
+        });
+      } else {
+        // Support old overrides with only 5 arguments for bc
+        return self.updateDescendantsAfterMove(req, moved, originalPath, originalSlug, function(err, _changed) {
+          if (err) {
+            return callback(err);
+          }
+          changed = changed.concat(_changed);
+          return callback(null);
+        });
+      }
     }
     function trashDescendants(callback) {
       // Make sure our descendants have the same trash status
@@ -456,7 +498,7 @@ module.exports = function(self, options) {
       if (_.isEmpty(action)) {
         return setImmediate(callback);
       }
-      return self.apos.docs.db.update({ path: matchParentPathPrefix }, action, { multi: true }, callback);
+      return self.apos.docs.db.update(mergeCriteria({ path: matchParentPathPrefix }), action, { multi: true }, callback);
     }
     function afterMoved(callback) {
       return self.apos.callAll(
@@ -466,7 +508,10 @@ module.exports = function(self, options) {
         {
           originalSlug: originalSlug,
           originalPath: originalPath,
-          changed: changed
+          changed: changed,
+          target: target,
+          position: position,
+          options: options
         },
         callback
       );
@@ -474,9 +519,38 @@ module.exports = function(self, options) {
 
     function finish(err) {
       if (err) {
-        return callback(err);
+        return callback(err, null, options);
       }
-      return callback(null, changed);
+      return callback(null, changed, options);
+    }
+    
+    function mergeCriteria(criteria) {
+      if (options.criteria) {
+        criteria = { $and: [ criteria, options.criteria ] };
+      }
+      return criteria;
+    }
+  };
+  
+  // Based on `req`, `moved`, `data.moved`, `data.oldParent` and `data.parent`, decide whether
+  // this move should be permitted. If it should not be, throw an error.
+  // This is invoed with `callAll`, so other methods may implement it and
+  // may optionally take a callback as a second argument, in which case errors
+  // should be passed to the callback rather than thrown.
+  //
+  // `options` is the same options object that was passed to `self.move`, or an empty object
+  // if none was passed.
+
+  self.pageMovePermissions = function(req, moved, data, options) {
+    if (!moved._publish) {
+      throw new Error('forbidden');
+    }
+    // You can always move a page into the trash. You can
+    // also change the order of subpages if you can
+    // edit the subpage you're moving. Otherwise you
+    // must have edit permissions for the new parent page.
+    if ((data.oldParent._id !== data.parent._id) && (data.parent.type !== 'trash') && (!data.parent._edit)) {
+      throw new Error('forbidden');
     }
   };
 
@@ -630,13 +704,10 @@ module.exports = function(self, options) {
     self.parked = self.parked.concat(pageOrPages);
   };
 
-  /**
-   * Any module may have a method with this name
-   * in which case it will be called after
-   * pages are moved.
-   *
-   */
-
+  // We don't need an implementation here in the core, but other
+  // modules may provide a method by this name, in which case it will
+  // automatically be invoked after a page is moved.
+  //
   // self.pageAfterMove = function(req, moved, info, callback) {
   //   // eventually invoke callback
   // };
@@ -1079,7 +1150,12 @@ module.exports = function(self, options) {
   // null and an array of objects with _id and slug properties, indicating
   // the new slugs for any objects that were modified.
 
-  self.updateDescendantsAfterMove = function(req, page, originalPath, originalSlug, callback) {
+  self.updateDescendantsAfterMove = function(req, page, originalPath, originalSlug, options, callback) {
+    if (arguments.length === 5) {
+      // bc with outdated overrides of code that calls this
+      callback = options;
+      options = {};
+    }
     // If our slug changed, then our descendants' slugs should
     // also change, if they are still similar. You can't do a
     // global substring replace in MongoDB the way you can
@@ -1096,7 +1172,7 @@ module.exports = function(self, options) {
     var matchParentPathPrefix = new RegExp('^' + self.apos.utils.regExpQuote(originalPath + '/'));
     var matchParentSlugPrefix = new RegExp('^' + self.apos.utils.regExpQuote(originalSlug + '/'));
     var done = false;
-    var cursor = self.apos.docs.db.find({ path: matchParentPathPrefix }, { slug: 1, path: 1, level: 1 });
+    var cursor = self.apos.docs.db.find(mergeCriteria({ path: matchParentPathPrefix }), { slug: 1, path: 1, level: 1 });
     return async.whilst(function() { return !done; }, function(callback) {
       return cursor.nextObject(function(err, desc) {
         if (err) {
@@ -1131,7 +1207,7 @@ module.exports = function(self, options) {
         return self.apos.docs.retryUntilUnique(req, desc, updateDescendant, callback);
 
         function updateDescendant(callback) {
-          return self.apos.docs.db.update({ _id: desc._id }, {
+          return self.apos.docs.db.update(mergeCriteria({ _id: desc._id }), {
             $set: _.pick(desc, 'path', 'slug', 'level')
           }, callback);
         }
@@ -1143,6 +1219,12 @@ module.exports = function(self, options) {
       }
       return callback(null, changed);
     });
+    function mergeCriteria(criteria) {
+      if (options.criteria) {
+        criteria = { $and: [ criteria, options.criteria ] };
+      }
+      return criteria;
+    }
   };
 
   self.parked = (self.options.minimumPark || [

--- a/lib/modules/apostrophe-pages/lib/helpers.js
+++ b/lib/modules/apostrophe-pages/lib/helpers.js
@@ -1,3 +1,5 @@
+var _ = require('lodash');
+
 module.exports = function(self, options) {
   self.addHelpers({
     menu: function(options){
@@ -8,6 +10,13 @@ module.exports = function(self, options) {
     },
     isAncestorOf: function(possibleAncestorPage, ofPage) {
       return self.isAncestorOf(possibleAncestorPage, ofPage);
+    },
+    afterContextMenu: function() {
+      return self.apos.templates.safe(
+        _.map(self.afterContextMenuHelpers || [], function(helper) {
+          return helper(self.apos.templates.contextReq);
+        }).join('')
+      );
     }
   });
 };

--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -682,5 +682,14 @@ module.exports = {
         return self.render(req, 'templateError');
       }
     };
+    
+    // Add a body class to be emitted when the page is rendered. This information
+    // is attached to `req.data`, where the string `req.data.aposBodyClasses` is built up.
+    // The default `outerLayoutBase.html` template outputs that string 
+    
+    self.addBodyClass = function(req, bodyClass) {
+      req.data.aposBodyClasses = (req.data.aposBodyClasses ? (req.data.aposBodyClasses + ' ') : '') + 
+        bodyClass;
+    };
   }
 };

--- a/lib/modules/apostrophe-templates/views/outerLayoutBase.html
+++ b/lib/modules/apostrophe-templates/views/outerLayoutBase.html
@@ -9,26 +9,19 @@
     {% block extraHead %}
     {% endblock %}
   </head>
-  <body class="{% block bodyClass %}{% endblock %}">
+  <body class="{{ data.aposBodyClasses }} {% block bodyClass %}{% endblock %}">
     {% block apostropheMenu %}
       {{ apos.adminBar.output() }}
     {% endblock %}
 
     {% if data.user %}
-      {% block apostropheContextMenuWrapper %}
-        <div class="apos-ui">
-          {% block apostropheContextMenu %}
-            <div class="apos-context-menu-container">
-              {% block beforeApostropheContextMenu %}
-              {% endblock %}
-              {{ apos.pages.publishMenu({ publishMenu: data.publishMenu, page: data.page, piece: data.piece, bottom: true }) }}
-              {{ apos.pages.menu({ contextMenu: data.contextMenu, page: data.page, bottom: true })}}
-              {% block afterApostropheContextMenu %}
-              {% endblock %}
-            </div>
-          {% endblock %}
+      <div class="apos-ui">
+        <div class="apos-context-menu-container">
+          {{ apos.pages.publishMenu({ publishMenu: data.publishMenu, page: data.page, piece: data.piece, bottom: true }) }}
+          {{ apos.pages.menu({ contextMenu: data.contextMenu, page: data.page, bottom: true })}}
+          {{ apos.pages.afterContextMenu() }}
         </div>
-      {% endblock %}
+      </div>
     {% endif %}
     <div class="apos-refreshable" data-apos-refreshable>
       {% block beforeMain %}{% endblock %}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "request": "^2.53.0",
     "rimraf": "^2.5.4",
     "sanitize-html": "^1.7.0",
+    "server-destroy": "^1.0.1",
     "sluggo": "^0.2.0",
     "syntax-error": "^1.1.6",
     "uglify-js": "^2.4.16",

--- a/test/admin-bar.js
+++ b/test/admin-bar.js
@@ -6,10 +6,6 @@ describe('Admin bar', function() {
 
   this.timeout(5000);
 
-  after(function() {
-    apos.db.dropDatabase();
-  });
-
   //////
   // EXISTENCE
   //////
@@ -22,7 +18,7 @@ describe('Admin bar', function() {
       modules: {
         'apostrophe-express': {
           secret: 'xxx',
-          port: 7954,
+          port: 7900,
           csrf: false
         },
         'apostrophe-admin-bar': {
@@ -60,7 +56,7 @@ describe('Admin bar', function() {
       },
       afterListen: function(err) {
         assert(!err);
-        done();
+        return destroy(apos, done);
       },
     });
   });
@@ -73,7 +69,7 @@ describe('Admin bar', function() {
       modules: {
         'apostrophe-express': {
           secret: 'xxx',
-          port: 7955,
+          port: 7900,
           csrf: false
         },
         'apostrophe-admin-bar': {
@@ -111,7 +107,7 @@ describe('Admin bar', function() {
       },
       afterListen: function(err) {
         assert(!err);
-        done();
+        return destroy(apos, done);
       },
     });
   });

--- a/test/areas.js
+++ b/test/areas.js
@@ -6,8 +6,8 @@ describe('Areas', function() {
 
   this.timeout(5000);
 
-  after(function() {
-    apos.db.dropDatabase();
+  after(function(done) {
+    return destroy(apos, done);
   });
 
   //////
@@ -22,7 +22,7 @@ describe('Areas', function() {
       modules: {
         'apostrophe-express': {
           secret: 'xxx',
-          port: 7953,
+          port: 7900,
           csrf: false
         }
       },

--- a/test/attachments.js
+++ b/test/attachments.js
@@ -7,6 +7,10 @@ var apos;
 
 describe('Attachment', function() {
 
+  after(function(done) {
+    return destroy(apos, done);
+  });
+
   this.timeout(5000);
 
   var uploadSource = __dirname + "/data/upload_tests/";
@@ -46,7 +50,7 @@ describe('Attachment', function() {
       
       modules: {
         'apostrophe-express': {
-          port: 7938
+          port: 7900
         }
       },
       afterInit: function(callback) {

--- a/test/base-module.js
+++ b/test/base-module.js
@@ -2,9 +2,13 @@ var assert = require('assert');
 
 describe('Base Module', function(){
 
-  this.timeout(5000);
-
   var apos;
+
+  after(function(done) {
+    return destroy(apos, done);
+  });
+
+  this.timeout(5000);
 
   it('should be subclassable', function(done){
     apos = require('../index.js')({

--- a/test/bootstrapping.js
+++ b/test/bootstrapping.js
@@ -6,7 +6,7 @@ describe('Apostrophe', function() {
   this.timeout(5000);
 
   it('should exist', function(done) {
-    var apos = require('../index.js');
+    apos = require('../index.js');
     assert(apos);
     return done();
   });

--- a/test/caches.js
+++ b/test/caches.js
@@ -2,11 +2,11 @@ var assert = require('assert');
 
 describe('Caches', function() {
 
-  this.timeout(5000);
-
-  after(function() {
-    apos.db.dropDatabase();
+  after(function(done) {
+    return destroy(apos, done);
   });
+
+  this.timeout(5000);
 
   var apos;
   var cache;

--- a/test/custom-pages.js
+++ b/test/custom-pages.js
@@ -9,8 +9,8 @@ describe('custom-pages', function() {
 
   this.timeout(5000);
 
-  after(function() {
-    apos.db.dropDatabase();
+  after(function(done) {
+    return destroy(apos, done);
   });
 
   //////
@@ -25,7 +25,7 @@ describe('custom-pages', function() {
       modules: {
         'apostrophe-express': {
           secret: 'xxx',
-          port: 7941
+          port: 7900
         },
         'nifty-pages': {
           extend: 'apostrophe-custom-pages'
@@ -195,7 +195,7 @@ describe('custom-pages', function() {
   });
 
   it('should match a dispatch route on a real live page request', function(done) {
-    return request('http://localhost:7941/niftyPages', function(err, response, body){
+    return request('http://localhost:7900/niftyPages', function(err, response, body){
       console.error(err);
       console.error(body);
       assert(!err);
@@ -209,7 +209,7 @@ describe('custom-pages', function() {
   });
 
   it('runs foo route with /foo remainder', function(done) {
-    return request('http://localhost:7941/niftyPages/foo', function(err, response, body){
+    return request('http://localhost:7900/niftyPages/foo', function(err, response, body){
       assert(!err);
       // Is our status code good?
       assert.equal(response.statusCode, 200);
@@ -220,7 +220,7 @@ describe('custom-pages', function() {
   });
 
   it('yields 404 with bad remainder (not matching any dispatch routes)', function(done) {
-    return request('http://localhost:7941/niftyPages/tututu', function(err, response, body){
+    return request('http://localhost:7900/niftyPages/tututu', function(err, response, body){
       assert(!err);
       // Is our status code good?
       assert.equal(response.statusCode, 404);

--- a/test/db.js
+++ b/test/db.js
@@ -1,11 +1,17 @@
 var assert = require('assert');
 
+var apos;
+
 describe('Db', function(){
+
+  after(function(done) {
+    return destroy(apos, done);
+  });
 
   this.timeout(5000);
 
   it('should exist on the apos object with a connection at port 27017', function(done){
-    var apos = require('../index.js')({
+    apos = require('../index.js')({
       root: module,
       shortName: 'test',
       

--- a/test/docs.js
+++ b/test/docs.js
@@ -9,8 +9,8 @@ describe('Docs', function() {
 
   this.timeout(5000);
 
-  after(function() {
-    apos.db.dropDatabase();
+  after(function(done) {
+    return destroy(apos, done);
   });
 
   //////
@@ -25,7 +25,7 @@ describe('Docs', function() {
       modules: {
         'apostrophe-express': {
           secret: 'xxx',
-          port: 7939
+          port: 7900
         },
         'test-people': {
           extend: 'apostrophe-doc-type-manager',

--- a/test/express.js
+++ b/test/express.js
@@ -6,10 +6,6 @@ describe('Express', function() {
 
   this.timeout(5000);
 
-  after(function() {
-    apos.db.dropDatabase();
-  });
-
   it('express should exist on the apos object', function(done){
     apos = require('../index.js')({
       root: module,
@@ -18,7 +14,7 @@ describe('Express', function() {
       modules: {
         'apostrophe-express': {
           secret: 'xxx',
-          port: 7936
+          port: 7900
         },
         'express-test': {},
         'templates-test': {},
@@ -56,7 +52,7 @@ describe('Express', function() {
   var jar;
 
   function getCsrfToken(jar) {
-    var csrfCookie = _.find(jar.getCookies('http://localhost:7936/'), { key: apos.csrfCookieName });
+    var csrfCookie = _.find(jar.getCookies('http://localhost:7900/'), { key: apos.csrfCookieName });
     if (!csrfCookie) {
       return null;
     }
@@ -69,7 +65,7 @@ describe('Express', function() {
     jar = request.jar();
     request({
       method: 'GET',
-      url: 'http://localhost:7936/tests/welcome',
+      url: 'http://localhost:7900/tests/welcome',
       jar: jar
     }, function(err, response, body) {
       assert(body.toString() === 'ok');
@@ -80,7 +76,7 @@ describe('Express', function() {
   it('should flunk a POST request with no X-XSRF-TOKEN header', function(done){
     request({
       method: 'POST',
-      url: 'http://localhost:7936/tests/body',
+      url: 'http://localhost:7900/tests/body',
       form: {
         person: {
           age: '30'
@@ -97,7 +93,7 @@ describe('Express', function() {
   it('should flunk a POST request with no cookies at all', function(done){
     request({
       method: 'POST',
-      url: 'http://localhost:7936/tests/body',
+      url: 'http://localhost:7900/tests/body',
       form: {
         person: {
           age: '30'
@@ -114,7 +110,7 @@ describe('Express', function() {
     var csrfToken = 'BOGOSITY';
     request({
       method: 'POST',
-      url: 'http://localhost:7936/tests/body',
+      url: 'http://localhost:7900/tests/body',
       form: {
         person: {
           age: '30'
@@ -135,7 +131,7 @@ describe('Express', function() {
     assert(csrfToken);
   	request({
   		method: 'POST',
-  		url: 'http://localhost:7936/tests/body',
+  		url: 'http://localhost:7900/tests/body',
   		form: {
   			person: {
   				age: '30'
@@ -155,7 +151,7 @@ describe('Express', function() {
     var csrfToken = getCsrfToken(jar);
     request({
       method: 'POST',
-      url: 'http://localhost:7936/tests/body',
+      url: 'http://localhost:7900/tests/body',
       json: {
         person: {
           age: '30'
@@ -175,7 +171,7 @@ describe('Express', function() {
     var csrfToken = getCsrfToken(jar);
     request({
       method: 'POST',
-      url: 'http://localhost:7936/modules/express-test/test2',
+      url: 'http://localhost:7900/modules/express-test/test2',
       json: {
         person: {
           age: '30'
@@ -187,7 +183,8 @@ describe('Express', function() {
       }
     }, function(err, response, body) {
       assert(body.toString() === '30');
-      done();
+      // Last one before a new apos object
+      return destroy(apos, done);
     });
   });
 
@@ -201,7 +198,7 @@ describe('Express', function() {
       prefix: '/prefix',
       modules: {
         'apostrophe-express': {
-          port: 7937,
+          port: 7900,
           csrf: false
         },
         'express-test': {},
@@ -231,7 +228,7 @@ describe('Express', function() {
  	it('should take same requests at the prefix', function(done){
     request({
   		method: 'POST',
-  		url: 'http://localhost:7937/prefix/tests/body',
+  		url: 'http://localhost:7900/prefix/tests/body',
   		form: {
   			person: {
   				age: '30'
@@ -239,7 +236,8 @@ describe('Express', function() {
   		}
   	}, function(err, response, body) {
   		assert(body.toString() === '30');
-  		done();
+      // Last one before a new apos object
+      return destroy(apos, done);
   	});
   });
   
@@ -251,7 +249,7 @@ describe('Express', function() {
       baseUrl: 'https://example.com',
       modules: {
         'apostrophe-express': {
-          port: 7957,
+          port: 7900,
           csrf: false
         },
         'express-test': {},
@@ -272,7 +270,8 @@ describe('Express', function() {
         var req = apos.tasks.getReq({ url: '/test' });
         assert(req.baseUrl === 'https://example.com');
         assert(req.absoluteUrl === 'https://example.com/test');
-        done();
+        // Last one before a new apos object
+        return destroy(apos, done);
       }
     });    
   });
@@ -286,7 +285,7 @@ describe('Express', function() {
       prefix: '/subdir',
       modules: {
         'apostrophe-express': {
-          port: 7958,
+          port: 7900,
           csrf: false
         },
         'express-test': {},
@@ -309,7 +308,8 @@ describe('Express', function() {
         assert(req.baseUrl === 'https://example.com');
         assert(req.baseUrlWithPrefix === 'https://example.com/subdir');
         assert(req.absoluteUrl === 'https://example.com/subdir/test');
-        done();
+        // Last use of this apos object
+        return destroy(apos, done);
       }
     });    
   });

--- a/test/images.js
+++ b/test/images.js
@@ -40,6 +40,10 @@ describe('Images', function() {
 
   this.timeout(5000);
 
+  after(function(done) {
+    return destroy(apos, done);
+  });
+
   it('should be a property of the apos object', function(done) {
     this.timeout(5000);
     this.slow(2000);
@@ -50,7 +54,7 @@ describe('Images', function() {
       
       modules: {
         'apostrophe-express': {
-          port: 7951
+          port: 7900
         }
       },
       afterInit: function(callback) {

--- a/test/launder.js
+++ b/test/launder.js
@@ -4,6 +4,10 @@ describe('Launder', function(){
 
   this.timeout(5000);
 
+  after(function(done) {
+    return destroy(apos, done);
+  });
+
   var apos;
 
   it('should exist on the apos object', function(done){

--- a/test/locales/en.json
+++ b/test/locales/en.json
@@ -7,5 +7,7 @@
 	"Login": "Login",
 	"Username or Email": "Username or Email",
 	"Password": "Password",
-	"Log In": "Log In"
+	"Log In": "Log In",
+	"An error has occurred": "An error has occurred",
+	"An error has occurred. We're working on it. We apologize for the inconvenience.": "An error has occurred. We're working on it. We apologize for the inconvenience."
 }

--- a/test/locks.js
+++ b/test/locks.js
@@ -9,6 +9,10 @@ describe('Locks', function() {
 
   this.timeout(5000);
 
+  after(function(done) {
+    return destroy(apos, done);
+  });
+
   it('should be a property of the apos object', function(done) {
     this.timeout(5000);
     this.slow(2000);
@@ -19,7 +23,7 @@ describe('Locks', function() {
       
       modules: {
         'apostrophe-express': {
-          port: 7956
+          port: 7900
         },
         // Make some subclasses of the locks module. NORMALLY A BAD IDEA. But
         // we're doing it to deliberately force them to contend with each other,

--- a/test/login.js
+++ b/test/login.js
@@ -10,8 +10,8 @@ describe('Login', function() {
 
   this.timeout(5000);
 
-  after(function() {
-    apos.db.dropDatabase();
+  after(function(done) {
+    return destroy(apos, done);
   });
 
   //////
@@ -26,7 +26,7 @@ describe('Login', function() {
       modules: {
         'apostrophe-express': {
           secret: 'xxx',
-          port: 7948,
+          port: 7900,
           csrf: false
         }
       },
@@ -67,7 +67,7 @@ describe('Login', function() {
   it('should not see logout link yet', function(done){
     // otherwise logins are not remembered in a session
     var jar = request.jar();
-    return request('http://localhost:7948/', function(err, response, body) {
+    return request('http://localhost:7900/', function(err, response, body) {
       assert(!err);
       //Is our status code good?
       assert.equal(response.statusCode, 200);
@@ -84,7 +84,7 @@ describe('Login', function() {
 
   it('should be able to login a user', function(done){
     // otherwise logins are not remembered in a session
-    return request.post('http://localhost:7948/login', {
+    return request.post('http://localhost:7900/login', {
       form: { username: 'HarryPutter', password: 'crookshanks' },
       followAllRedirects: true,
       jar: loginLogoutJar
@@ -100,7 +100,7 @@ describe('Login', function() {
 
   it('should be able to login a user with their email', function(done){
     // otherwise logins are not remembered in a session
-    return request.post('http://localhost:7948/login', {
+    return request.post('http://localhost:7900/login', {
       form: { username: 'hputter@aol.com', password: 'crookshanks' },
       followAllRedirects: true,
       jar: loginEmailLogoutJar
@@ -116,7 +116,7 @@ describe('Login', function() {
 
   it('should be able to log out', function(done){
     // otherwise logins are not remembered in a session
-    return request('http://localhost:7948/logout', {
+    return request('http://localhost:7900/logout', {
       followAllRedirects: true,
       jar: loginLogoutJar
     }, function(err, response, body){
@@ -131,7 +131,7 @@ describe('Login', function() {
 
   it('should be able to log out after having logged in with email', function(done){
     // otherwise logins are not remembered in a session
-    return request('http://localhost:7948/logout', {
+    return request('http://localhost:7900/logout', {
       followAllRedirects: true,
       jar: loginEmailLogoutJar
     }, function(err, response, body){

--- a/test/oembed.js
+++ b/test/oembed.js
@@ -10,8 +10,8 @@ describe('Oembed', function() {
 
   this.timeout(5000);
 
-  after(function() {
-    apos.db.dropDatabase();
+  after(function(done) {
+    return destroy(apos, done);
   });
 
   //////
@@ -26,7 +26,7 @@ describe('Oembed', function() {
       modules: {
         'apostrophe-express': {
           secret: 'xxx',
-          port: 7952,
+          port: 7900,
           csrf: false
         }
       },
@@ -57,7 +57,7 @@ describe('Oembed', function() {
   });
 
   it('Should deliver an oembed response for YouTube', function(done) {
-    return request('http://localhost:7952/modules/apostrophe-oembed/query?' + qs.stringify(
+    return request('http://localhost:7900/modules/apostrophe-oembed/query?' + qs.stringify(
     {
       url: youtube
     }), function(err, response, body) {

--- a/test/pages.js
+++ b/test/pages.js
@@ -10,8 +10,8 @@ describe('Pages', function() {
 
   this.timeout(5000);
 
-  after(function() {
-    apos.db.dropDatabase();
+  after(function(done) {
+    return destroy(apos, done);
   });
 
   //////
@@ -26,7 +26,7 @@ describe('Pages', function() {
       modules: {
         'apostrophe-express': {
           secret: 'xxx',
-          port: 7940
+          port: 7900
         },
         'apostrophe-pages': {
           park: [],
@@ -392,7 +392,7 @@ describe('Pages', function() {
 
 
   it('should be able to serve a page', function(done){
-    return request('http://localhost:7940/child', function(err, response, body){
+    return request('http://localhost:7900/child', function(err, response, body){
       assert(!err);
       //Is our status code good?
       assert.equal(response.statusCode, 200);
@@ -408,7 +408,7 @@ describe('Pages', function() {
   });
 
   it('should not be able to serve a nonexistent page', function(done){
-    return request('http://localhost:7940/nobodyschild', function(err, response, body){
+    return request('http://localhost:7900/nobodyschild', function(err, response, body){
       assert(!err);
       // Is our status code good?
       assert.equal(response.statusCode, 404);

--- a/test/permissions.js
+++ b/test/permissions.js
@@ -7,6 +7,10 @@ describe('Permissions', function() {
 
   var apos;
 
+  after(function(done) {
+    return destroy(apos, done);
+  });
+
   it('should have a permissions property', function(done) {
     apos = require('../index.js')({
       root: module,

--- a/test/pieces-pages.js
+++ b/test/pieces-pages.js
@@ -10,8 +10,8 @@ describe('Pieces Pages', function() {
 
   this.timeout(5000);
 
-  after(function() {
-    apos.db.dropDatabase();
+  after(function(done) {
+    return destroy(apos, done);
   });
 
   //////
@@ -26,7 +26,7 @@ describe('Pieces Pages', function() {
       modules: {
         'apostrophe-express': {
           secret: 'xxx',
-          port: 7943
+          port: 7900
         },
         'events': {
           extend: 'apostrophe-pieces',
@@ -103,7 +103,7 @@ describe('Pieces Pages', function() {
 
   it('should be able to access index page with first event on it, but not eleventh event', function(done) {
 
-    return request('http://localhost:7943/events', function(err, response, body) {
+    return request('http://localhost:7900/events', function(err, response, body) {
       assert(!err);
       // Is our status code good?
       assert.equal(response.statusCode, 200);
@@ -116,7 +116,7 @@ describe('Pieces Pages', function() {
 
   it('should be able to access second page', function(done) {
 
-    return request('http://localhost:7943/events?page=2', function(err, response, body) {
+    return request('http://localhost:7900/events?page=2', function(err, response, body) {
       assert(!err);
       // Is our status code good?
       assert.equal(response.statusCode, 200);
@@ -128,7 +128,7 @@ describe('Pieces Pages', function() {
   });
 
   it('should be able to access "show" page for first event, should not also contain second event', function(done) {
-    return request('http://localhost:7943/events/event-001', function(err, response, body) {
+    return request('http://localhost:7900/events/event-001', function(err, response, body) {
       assert(!err);
       // Is our status code good?
       assert.equal(response.statusCode, 200);

--- a/test/pieces-widgets.js
+++ b/test/pieces-widgets.js
@@ -10,8 +10,8 @@ describe('Pieces Widgets', function() {
 
   this.timeout(5000);
 
-  after(function() {
-    apos.db.dropDatabase();
+  after(function(done) {
+    return destroy(apos, done);
   });
 
   //////
@@ -26,7 +26,7 @@ describe('Pieces Widgets', function() {
       modules: {
         'apostrophe-express': {
           secret: 'xxx',
-          port: 7944
+          port: 7900
         },
         'events': {
           extend: 'apostrophe-pieces',
@@ -155,7 +155,7 @@ describe('Pieces Widgets', function() {
 
   it('should find appropriate events and not others in a page containing tag and id-based event widgets', function(done) {
 
-    return request('http://localhost:7944/page-with-events', function(err, response, body) {
+    return request('http://localhost:7900/page-with-events', function(err, response, body) {
       assert(!err);
       // Is our status code good?
       assert.equal(response.statusCode, 200);
@@ -192,7 +192,7 @@ describe('Pieces Widgets', function() {
   var jar;
 
   function getCsrfToken(jar) {
-    var csrfCookie = _.find(jar.getCookies('http://localhost:7944/'), { key: 'XSRF-TOKEN' });
+    var csrfCookie = _.find(jar.getCookies('http://localhost:7900/'), { key: 'XSRF-TOKEN' });
     if (!csrfCookie) {
       return null;
     }
@@ -207,7 +207,7 @@ describe('Pieces Widgets', function() {
   //   jar = request.jar();
   //   request({
   //     method: 'GET',
-  //     url: 'http://localhost:7944/page-with-events',
+  //     url: 'http://localhost:7900/page-with-events',
   //     jar: jar
   //   }, function(err, response, body) {
   //     assert.equal(response.statusCode, 200);
@@ -215,7 +215,7 @@ describe('Pieces Widgets', function() {
   //     // Now let's get a modal so we can bless the joins
   //     return request({
   //       method: 'POST',
-  //       url: 'http://localhost:7944/modules/events-widgets/modal',
+  //       url: 'http://localhost:7900/modules/events-widgets/modal',
   //       json: {
   //         _id: 'wevent007'
   //       },
@@ -229,7 +229,7 @@ describe('Pieces Widgets', function() {
   //       assert.equal(response.statusCode, 200);
   //       return request({
   //         method: 'POST',
-  //         url: 'http://localhost:7944/modules/apostrophe-docs/autocomplete',
+  //         url: 'http://localhost:7900/modules/apostrophe-docs/autocomplete',
   //         json: {
   //           term: 'wig',
   //           field: {

--- a/test/pieces.js
+++ b/test/pieces.js
@@ -10,8 +10,8 @@ describe('Pieces', function() {
 
   this.timeout(5000);
 
-  after(function() {
-    apos.db.dropDatabase();
+  after(function(done) {
+    return destroy(apos, done);
   });
 
   //////
@@ -26,7 +26,7 @@ describe('Pieces', function() {
       modules: {
         'apostrophe-express': {
           secret: 'xxx',
-          port: 7942
+          port: 7900
         },
         'things': {
           extend: 'apostrophe-pieces',

--- a/test/push.js
+++ b/test/push.js
@@ -7,6 +7,10 @@ describe('Templates', function(){
 
   this.timeout(5000);
 
+  after(function(done) {
+    return destroy(apos, done);
+  });
+
   it('should have a push property', function(done) {
   	apos = require('../index.js')({
       root: module,
@@ -15,7 +19,7 @@ describe('Templates', function(){
       modules: {
         'apostrophe-express': {
           secret: 'xxx',
-          port: 7959
+          port: 7900
         }
       },
       afterInit: function(callback) {

--- a/test/schemaFilters.js
+++ b/test/schemaFilters.js
@@ -10,6 +10,10 @@ describe('Schema Filters', function() {
 
   this.timeout(5000);
 
+  after(function(done) {
+    return destroy(apos, done);
+  });
+
   //////
   // EXISTENCE
   //////
@@ -22,7 +26,7 @@ describe('Schema Filters', function() {
       modules: {
         'apostrophe-express': {
           secret: 'xxx',
-          port: 7956
+          port: 7900
         },
         'cats': {
           extend: 'apostrophe-pieces',

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -202,8 +202,12 @@ var hasArea = {
 };
 
 describe('Schemas', function() {
-
+  
   this.timeout(5000);
+
+  after(function(done) {
+    return destroy(apos, done);
+  });
 
   //////
   // EXISTENCE
@@ -217,7 +221,7 @@ describe('Schemas', function() {
       modules: {
         'apostrophe-express': {
           secret: 'xxx',
-          port: 7951
+          port: 7900
         }
       },
       afterInit: function(callback) {

--- a/test/search.js
+++ b/test/search.js
@@ -9,8 +9,8 @@ describe('Search', function() {
 
   this.timeout(5000);
 
-  after(function() {
-    apos.db.dropDatabase();
+  after(function(done) {
+    return destroy(apos, done);
   });
 
   //////
@@ -25,7 +25,7 @@ describe('Search', function() {
       modules: {
         'apostrophe-express': {
           secret: 'xxx',
-          port: 7945
+          port: 7900
         },
         'events': {
           extend: 'apostrophe-pieces',

--- a/test/tags.js
+++ b/test/tags.js
@@ -10,8 +10,8 @@ describe('Tags', function() {
 
   this.timeout(5000);
 
-  after(function() {
-    apos.db.dropDatabase();
+  after(function(done) {
+    return destroy(apos, done);
   });
 
   it('should be a property of the apos object', function(done) {
@@ -22,7 +22,7 @@ describe('Tags', function() {
       modules: {
         'apostrophe-express': {
           secret: 'xxx',
-          port: 7946,
+          port: 7900,
           csrf: {
             // We're not here to test CSRF, so make the test simpler
             exceptions: [ '/modules/apostrophe-tags/autocomplete' ]
@@ -110,7 +110,7 @@ describe('Tags', function() {
 
   it('should provide an api route for autocomplete', function(done){
     return request({
-      url: 'http://localhost:7946/modules/apostrophe-tags/autocomplete',
+      url: 'http://localhost:7900/modules/apostrophe-tags/autocomplete',
       method: 'POST',
       form: { term: 'ag' },
     }, function(err, response, body) {
@@ -130,7 +130,7 @@ describe('Tags', function() {
 
   it('should provide an api route for autocomplete', function(done){
     return request({
-      url: 'http://localhost:7946/modules/apostrophe-tags/autocomplete',
+      url: 'http://localhost:7900/modules/apostrophe-tags/autocomplete',
       method: 'POST',
       form: { term: 'ag', prefix: true },
     }, function(err, response, body) {

--- a/test/templates.js
+++ b/test/templates.js
@@ -7,6 +7,10 @@ describe('Templates', function(){
 
   this.timeout(5000);
 
+  after(function(done) {
+    return destroy(apos, done);
+  });
+
   it('should have a templates property', function(done) {
   	apos = require('../index.js')({
       root: module,
@@ -15,7 +19,7 @@ describe('Templates', function(){
       modules: {
         'apostrophe-express': {
           secret: 'xxx',
-          port: 7934
+          port: 7900
         },
         'express-test': {},
         'templates-test': {},

--- a/test/urls.js
+++ b/test/urls.js
@@ -8,6 +8,10 @@ describe('Urls', function() {
   var apos;
   var start;
 
+  after(function(done) {
+    return destroy(apos, done);
+  });
+
   it('should exist on the apos object', function(done){
     apos = require('../index.js')({
       root: module,

--- a/test/users.js
+++ b/test/users.js
@@ -10,8 +10,8 @@ describe('Users', function() {
 
   this.timeout(5000);
 
-  after(function() {
-    apos.db.dropDatabase();
+  after(function(done) {
+    return destroy(apos, done);
   });
 
   //////
@@ -26,7 +26,7 @@ describe('Users', function() {
       modules: {
         'apostrophe-express': {
           secret: 'xxx',
-          port: 7947
+          port: 7900
         }
       },
       afterInit: function(callback) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -7,6 +7,10 @@ describe('Utils', function(){
 
   var apos;
 
+  after(function(done) {
+    return destroy(apos, done);
+  });
+
   it('should exist on the apos object', function(done){
     apos = require('../index.js')({
       root: module,
@@ -163,14 +167,14 @@ describe('Utils', function(){
       var input = {
         "attachment" : {
       		"_id" : "a205filea1media97",
-      		"title" : "http-window-punkave-com-wp-content-uploads-2009-01-n56601994_30792414_5081-225x300-jpg",
+      		"title" : "http-window-punkave-com-wp-content-uploads-2009-01-n56601994_30790014_5081-225x300-jpg",
       		"width" : 225,
       		"height" : 300,
       		"length" : 22014,
       		"md5" : 22014,
       		"extension" : "jpg",
       		"group" : "images",
-      		"name" : "http-window-punkave-com-wp-content-uploads-2009-01-n56601994_30792414_5081-225x300-jpg",
+      		"name" : "http-window-punkave-com-wp-content-uploads-2009-01-n56601994_30790014_5081-225x300-jpg",
       		"landscape" : false,
       		"portrait" : true,
       		"a15Export" : true,
@@ -178,7 +182,7 @@ describe('Utils', function(){
       			"p'window",
       			"2009"
       		],
-      		"searchText" : "http window punkave com wp content uploads 2009 01 n56601994 30792414 5081 225x300 jpg http window punkave com wp content uploads 2009 01 n56601994 30792414 5081 225x300 jpg jpg",
+      		"searchText" : "http window punkave com wp content uploads 2009 01 n56601994 30790014 5081 225x300 jpg http window punkave com wp content uploads 2009 01 n56601994 30790014 5081 225x300 jpg jpg",
       		"type" : "attachment"
       	}
       };

--- a/test/versions.js
+++ b/test/versions.js
@@ -11,8 +11,8 @@ describe('Versions', function() {
 
   this.timeout(5000);
 
-  after(function() {
-    apos.db.dropDatabase();
+  after(function(done) {
+    return destroy(apos, done);
   });
 
 	//////
@@ -26,7 +26,7 @@ describe('Versions', function() {
       modules: {
         'apostrophe-express': {
           secret: 'xxx',
-          port: 7950
+          port: 7900
         },
 
         // Create a custom schema for test-person so we can
@@ -622,7 +622,7 @@ describe('Versions', function() {
   //     modules: {
   //       'apostrophe-express': {
   //         secret: 'xxx',
-  //         port: 7949
+  //         port: 7900
   //       },
   //       'apostrophe-versions':{
   //       	enabled: false


### PR DESCRIPTION
…req.disableEditing = true`, utilized by workflow module; but the data attributes necessary to gather information about the area are still output, which is also important for workflow.

* areas module exported to `apos.areas` browser side as well, making its options accessible to the workflow module.
* docs and pages modules don't call `ensureIndexes` until `modulesReady`, emit new events allowing other modules to alter the index properties (workflow)
* `self.apos.pages.addAfterContextMenu(helper)` accepts a helper function to be called by `outerLayout` immediately after the context menu is emitted; this allows extension of the UI by new modules without forcing developers to manually alter `outerLayoutBase`. The helper function receives `req` for convenience, it is always `apos.templates.contextReq` since we are already rendering the page at this point
* `self.apos.templates.addBodyClass(req, bodyClass)` adds a body CSS class to be output on this request. Multiple classes may be added as a single string separated by spaces. They are combined with other calls to this method and the `bodyClass` nunjucks block in `outerLayoutBase`. This allows extension of the UI by new modules without forcing developers to manually alter `outerLayoutBase`.
* Reverted some unnecessary new nunjucks blocks from previous workflow accommodations commit now that we have a cleaner way.
* Fixed some stray references to "req.page" in documentation (should be `req.data.page`).