### PR TITLE
Prefer MongoDB URI from settings over environment variable

### DIFF
--- a/lib/modules/apostrophe-db/index.js
+++ b/lib/modules/apostrophe-db/index.js
@@ -48,12 +48,12 @@ module.exports = {
     // in a consistent way
     self.connectToMongo = function(callback) {
       var uri = 'mongodb://';
-      
-      if (process.env.APOS_MONGODB_URI) {
-        uri = process.env.APOS_MONGODB_URI;
-      } else if (options.uri) {
+
+      if (options.uri) {
         uri = options.uri;
-      }  else {
+      } else if (process.env.APOS_MONGODB_URI) {
+        uri = process.env.APOS_MONGODB_URI;
+      } else {
         if (options.user) {
           uri += options.user + ':' + options.password + '@';
         }
@@ -67,7 +67,7 @@ module.exports = {
           options.name = self.apos.shortName;
         }
         uri += options.host + ':' + options.port + '/' + options.name;
-      } 
+      }
       return mongo.MongoClient.connect(uri, function (err, dbArg) {
         self.apos.db = dbArg;
         if (err) {


### PR DESCRIPTION
This PR makes Apostrophe take the user-defined settings first when setting the database URI. Right now the environment variable overrides it.

However, this may break projects if people are using the dev DB in their settings and the environment variable for production. In which case, "it's a feature, not a bug." But that's for you to decide, since I don't know how people typically use this.

The rationale for this change is that an environment variable is difficult to discover when debugging, and seeing the configuration could lead someone to believe that the DB is set to something that it's not. If you just have code like this and nothing else in your config:

```js
db: {
    uri: 'mongodb://localhost:27017/apostrophe-sandbox'
}
```

it will lead people to believe that this is fact the DB location. Discovering the env variable will take digging and is not very friendly to developers. You have to be *in the know*.

I imagine a better dev/prod tactic would be to have app.js check `NODE_ENV` for debug, set the dev URL if so, and use an environment variable if prod.