### PR TITLE
lazy join configuration has been implemented

### DIFF
--- a/lib/modules/apostrophe-pieces/index.js
+++ b/lib/modules/apostrophe-pieces/index.js
@@ -192,7 +192,8 @@ module.exports = {
       throw new Error('apostrophe-pieces require name option');
     }
     if (!options.label) {
-      throw new Error('apostrophe-pieces require label option');
+      // Englishify it
+      options.label = _.startCase(options.name);
     }
     options.pluralLabel = options.pluralLabel || options.label + 's';
 

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -2114,6 +2114,8 @@ module.exports = {
       });
     };
     
+    self.validatedSchemas = {};
+
     // Validate a schema for errors. This is about validating the schema itself,
     // not a data object. For instance, a field without a type property is flagged.
     // Serious errors throw an exception, while certain lesser errors just print a message
@@ -2124,6 +2126,12 @@ module.exports = {
     // of a `joinByOne` field, or the `label` property of anything.
     
     self.validate = function(schema, options) {
+      // Infinite recursion prevention
+      if (self.validatedSchemas[options.type + ':' + options.subtype]) {
+        return;
+      }
+      self.validatedSchemas[options.type + ':' + options.subtype] = true;
+
       _.each(schema, function(field) {
         var fieldType = self.fieldTypes[field.type];
         if (!fieldType) {

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -1624,10 +1624,19 @@ module.exports = {
           warn('Name of join field does not start with _. This is permitted for bc but it will fill your database with duplicate outdated data. Please fix it.');
         }
         if (!field.idField) {
-          fail('idField property is missing. Hint: joinByOne takes idField, NOT idsField.');
+          if (field.idsField) {
+            fail('joinByOne takes idField, not idsField. You can also omit it, in which case a reasonable value is supplied.');
+          }
+          // Supply reasonable value
+          field.idField = field.name.replace(/^_/, '') + 'Id';
         }
         if (!field.withType) {
-          fail('withType property is missing. Hint: it must match the "name" property of a doc type');
+          // Try to supply reasonable value based on join name
+          var withType = field.name.replace(/^_/, '');
+          if (!_.find(self.apos.docs.managers, { name: withType })) {
+            fail('withType property is missing. Hint: it must match the "name" property of a doc type. If you are defining only one join, you can omit withType and give your join the same name as the other type, with a leading _.');
+          }
+          field.withType = withType;
         }
         if (!_.find(self.apos.docs.managers, { name: field.withType })) {
           fail('withType property, ' + field.withType + ', does not match the "name" property of any doc type. Hint: this is not the same thing as a module name. Usually singular.');
@@ -1641,22 +1650,53 @@ module.exports = {
         return self.joinDriver(req, joinr.byOneReverse, true, objects, field.idField, undefined, field.name, options, callback);
       },
       validate: function(field, options, warn, fail) {
+        var forwardJoin;
         if (!field.name.match(/^_/)) {
           warn('Name of join field does not start with _. This is permitted for bc but it will fill your database with duplicate outdated data. Please fix it.');
         }
-        if (!field.idField) {
-          fail('idField property is missing. Hint: joinByOneReverse takes idField, NOT idsField.');
-        }
         if (!field.withType) {
-          fail('withType property is missing. Hint: it must match the "name" property of a doc type');
+          // Try to supply reasonable value based on join name
+          var withType = field.name.replace(/^_/, '').replace(/s$/, '');
+          if (!_.find(self.apos.docs.managers, { name: withType })) {
+            fail('withType property is missing. Hint: it must match the "name" property of a doc type.  Or omit it and give your join the same name as the other type, with a leading _ and optional trailing s.');
+          }
+          field.withType = withType;
         }
         var otherModule = _.find(self.apos.docs.managers, { name: field.withType });
         if (!otherModule) {
           fail('withType property, ' + field.withType + ', does not match the "name" property of any doc type. Hint: this is not the same thing as a module name. Usually singular.');
         }
-        var forwardJoin = _.find(otherModule.schema, { type: 'joinByOne', idField: field.idField });
+        if (!(field.reverseOf || field.idField)) {
+          // Look for a join with our type in the other type
+          // Mjust validate it first to add any implied fields there too
+          self.validate(otherModule.schema, { type: 'doc type', subtype: otherModule.name });
+          forwardJoin = _.find(otherModule.schema, { withType: options.subtype });
+          if (forwardJoin) {
+            field.reverseOf = forwardJoin.name;
+          }
+        }
+        if (field.reverseOf) {
+          var forwardJoin = _.find(otherModule.schema, { type: 'joinByOne', name: field.reverseOf });
+          if (!forwardJoin) {
+            fail('reverseOf property does not match the name property of any join in the schema for ' + field.withType + '. Hint: you are taking advantage of a join already being edited in the schema for that type, "reverse" must match "name".');
+          }
+          // Make sure the other join has any missing fields auto-supplied before
+          // trying to access them
+          self.validate([ forwardJoin ], { type: 'doc type', subtype: otherModule.name });
+          field.idField = forwardJoin.idField;
+        }
+        if (!field.idField) {
+          if (field.idsField) {
+            fail('joinByOneReverse takes idField, not idsField. Hint: just use reverseOf instead and specify the name of the join you are reversing.');
+          } else {
+            fail('joinByOneReverse requires either the reverseOf option or the idField option. Hint: just use reverseOf and specify the name of the join you are reversing.');
+          }
+        }
         if (!forwardJoin) {
-          fail('idField property does not match the idField property of any join in the schema for ' + field.withType + '. Hint: you are taking advantage of a join already being edited in the schema for that type, your idField must be the same to find the data there.');
+          forwardJoin = _.find(otherModule.schema, { type: 'joinByOne', idField: field.idField });
+          if (!forwardJoin) {
+            fail('idField property does not match the idField property of any join in the schema for ' + field.withType + '. Hint: you are taking advantage of a join already being edited in the schema for that type, your idField must be the same to find the data there.');
+          }
         }
       }
     });
@@ -1773,6 +1813,22 @@ module.exports = {
           warn('Name of join field does not start with _. This is permitted for bc but it will fill your database with duplicate outdated data. Please fix it.');
         }
         if (!field.idsField) {
+          if (field.idField) {
+            fail('joinByArray takes idsField, not idField. You can also omit it, in which case a reasonable value is supplied.');
+          }
+          // Supply reasonable value
+          field.idsField = field.name.replace(/^_/, '') + 'Ids';
+        }
+        if (!field.withType) {
+          // Try to supply reasonable value based on join name. Join name will be plural,
+          // so consider that too
+          var withType = field.name.replace(/^_/, '').replace(/s$/, '');
+          if (!_.find(self.apos.docs.managers, { name: withType })) {
+            fail('withType property is missing. Hint: it must match the "name" property of a doc type. Or omit it and give your join the same name as the other type, with a leading _ and optional trailing s.');
+          }
+          field.withType = withType;
+        }
+        if (!field.idsField) {
           fail('idsField property is missing. Hint: joinByArray takes idsField, NOT idField.');
         }
         if (!field.withType) {
@@ -1780,6 +1836,13 @@ module.exports = {
         }
         if (!_.find(self.apos.docs.managers, { name: field.withType })) {
           fail('withType property, ' + field.withType + ', does not match the "name" property of any doc type. Hint: this is not the same thing as a module name. Usually singular.');
+        }
+        if (field.relationship && (!field.relationshipsField)) {
+          field.relationshipsField = field.name.replace(/^_/, '') + 'Relationships';
+        }
+        if (field.relationship && (!Array.isArray(field.relationship))) {
+          // TODO more validation here
+          fail('relationship field should be an array if present');
         }
       }
     });
@@ -1938,22 +2001,51 @@ module.exports = {
         return self.joinDriver(req, joinr.byArrayReverse, true, objects, field.idsField, field.relationshipsField, field.name, options, callback);
       },
       validate: function(field, options, warn, fail) {
+        var forwardJoin;
         if (!field.name.match(/^_/)) {
           warn('Name of join field does not start with _. This is permitted for bc but it will fill your database with duplicate outdated data. Please fix it.');
         }
-        if (!field.idsField) {
-          fail('idsField property is missing. Hint: joinByArrayReverse takes idsField, NOT idField.');
-        }
         if (!field.withType) {
-          fail('withType property is missing. Hint: it must match the "name" property of a doc type.');
+          // Try to supply reasonable value based on join name
+          var withType = field.name.replace(/^_/, '').replace(/s$/, '');
+          if (!_.find(self.apos.docs.managers, { name: withType })) {
+            fail('withType property is missing. Hint: it must match the "name" property of a doc type. Or omit it and give your join the same name as the other type, with a leading _ and optional trailing s.');
+          }
+          field.withType = withType;
         }
         var otherModule = _.find(self.apos.docs.managers, { name: field.withType });
         if (!otherModule) {
           fail('withType property, ' + field.withType + ', does not match the "name" property of any doc type. Hint: this is not the same thing as a module name. Usually singular.');
         }
-        var forwardJoin = _.find(otherModule.schema, { type: 'joinByArray', idsField: field.idsField });
+        if (!(field.reverseOf || field.idsField)) {
+          self.validate(otherModule.schema, { type: 'doc type', subtype: otherModule.name });
+          // Look for a join with our type in the other type
+          forwardJoin = _.find(otherModule.schema, { withType: options.subtype });
+          if (forwardJoin) {
+            field.reverseOf = forwardJoin.name;
+          }
+        }
+        if (field.reverseOf) {
+          forwardJoin = _.find(otherModule.schema, { type: 'joinByArray', name: field.reverseOf });
+          if (!forwardJoin) {
+            fail('reverseOf property does not match the name property of any joinByArray in the schema for ' + field.withType + '. Hint: you are taking advantage of a join already being edited in the schema for that type, "reverse" must match "name".');
+          }
+          // Make sure the other join has any missing fields auto-supplied before
+          // trying to access them
+          self.validate([ forwardJoin ], { type: 'doc type', subtype: otherModule.name });
+          field.idsField = forwardJoin.idsField;
+        }
+        if (!field.idsField) {
+          if (field.idField) {
+            fail('joinByOne takes reverseOf or idsField, not idField. Hint: just use reverseOf instead and specify the name of the join you are reversing.');
+          }
+          field.idsField = field.name.replace(/^_/, '') + 'Ids';
+        }
         if (!forwardJoin) {
-          fail('idsField property does not match the idsField property of any join in the schema for ' + field.withType + '. Hint: you are taking advantage of a join already being edited in the schema for that type, your idsField must be the same to find the data there.');
+          forwardJoin = _.find(otherModule.schema, { type: 'joinByArray', idsField: field.idsField });
+          if (!forwardJoin) {
+            fail('idsField property does not match the idsField property of any join in the schema for ' + field.withType + '. Hint: you are taking advantage of a join already being edited in the schema for that type, your idField must be the same to find the data there.');
+          }
         }
       }
     });
@@ -2022,17 +2114,26 @@ module.exports = {
       });
     };
     
+    // Validate a schema for errors. This is about validating the schema itself,
+    // not a data object. For instance, a field without a type property is flagged.
+    // Serious errors throw an exception, while certain lesser errors just print a message
+    // to stderr for bc.
+    //
+    // This method may also prevent errors by automatically supplying
+    // reasonable values for certain properties, such as the `idField` property
+    // of a `joinByOne` field, or the `label` property of anything.
+    
     self.validate = function(schema, options) {
       _.each(schema, function(field) {
         var fieldType = self.fieldTypes[field.type];
         if (!fieldType) {
           fail('Unknown schema field type.');
         }
-        if ((!field.label) && (!field.contextual)) {
-          warn('label property is missing. Allowed for bc, but you should fix it.');
-        }
         if (!field.name) {
           fail('name property is missing.');
+        }
+        if ((!field.label) && (!field.contextual)) {
+          field.label = _.startCase(field.name.replace(/^_/, ''));
         }
         if (fieldType.validate) {
           fieldType.validate(field, options, warn, fail);


### PR DESCRIPTION
Implements #652 

This is fully bc with the existing implementation of join configuration.

Here is a very well fleshed-out example, in which implicit configuration is used for many types of joins, plus the new `reverseOf` property is used to avoid having to guess at what `idField` or `idsField` might be.

Configuration is now implied wherever that is possible, and can still be explicit wherever it is not.

Also, "label" is now implied by "name" for all types, using the `_.startCase` method of lodash.

```
    'opinions': {
      name: 'opinion',
      extend: 'apostrophe-pieces',
      addFields: [
        {
          name: '_author',
          type: 'joinByOne'
        }
      ]
    },

    // authors module
    'authors': {
      name: 'author',
      extend: 'apostrophe-pieces',
      addFields: [
        {
          name: '_opinions',
          type: 'joinByOneReverse'
        },
        {
          name: '_comments',
          type: 'joinByOneReverse'
        },
        {
          name: '_commentsEdited',
          type: 'joinByOneReverse',
          withType: 'comment',
          reverseOf: '_editor'
        },
        {
          name: '_collabs',
          withType: 'collaboration',
          type: 'joinByArrayReverse'
        },
        {
          name: '_edited',
          withType: 'collaboration',
          type: 'joinByArrayReverse',
          reverseOf: '_editors'
        },
      ]
    },
    
    'comments': {
      name: 'comment',
      extend: 'apostrophe-pieces',
      addFields: [
        {
          name: '_author',
          type: 'joinByOne'
        },
        {
          name: '_editor',
          type: 'joinByOne',
          withType: 'author'
        }
      ]
    },
    
    'collaborations': {
      name: 'collaboration',
      extend: 'apostrophe-pieces',
      addFields: [
        {
          name: '_contributors',
          withType: 'author',
          type: 'joinByArray'
        },
        {
          name: '_editors',
          withType: 'author',
          type: 'joinByArray'
        },
      ]
    }
```
