### PR TITLE
Prepend protocol to dev server URL

### DIFF
--- a/lib/modules/apostrophe-express/index.js
+++ b/lib/modules/apostrophe-express/index.js
@@ -459,7 +459,7 @@ module.exports = {
         }
         var server;
         if (port.toString().match(/^\d+$/)) {
-          console.log("Listening on " + address + ":" + port);
+          console.log("Listening on http://" + address + ":" + port);
           server = self.apos.baseApp.listen(port, address);
         } else {
           console.log("Listening at " + port);


### PR DESCRIPTION
Rationale for this:

1. It will always be http for a local dev server.
2. In some terminal programs, you can click a valid URL to have it open in the browser. Prepending the protocol allows this.