### PR TITLE
resolves #900. pieces are now contextual by default.

### DIFF
--- a/lib/modules/apostrophe-pieces-pages/index.js
+++ b/lib/modules/apostrophe-pieces-pages/index.js
@@ -14,7 +14,7 @@
 //
 // ### `piecesFilters`
 //
-// If present, this is an array of objects with `name` properties. The named cursor filters are 
+// If present, this is an array of objects with `name` properties. The named cursor filters are
 // marked as `safeFor: "public"` if they exist, and an array of choices for each is populated
 // in `req.data.piecesFilters.tags` (if the field in question is `tags`), etc. The choices in the
 // array are objects with `label` and `value` properties.
@@ -152,7 +152,7 @@ module.exports = {
           return callback();
         });
       }
-      
+
       return async.series([getFilters, totalPieces, findPieces], function(err) {
         return self.beforeIndex(req, callback);
       });
@@ -328,7 +328,7 @@ module.exports = {
     // help the contextual editing tools in various modules
 
     self.pushContextPiece = function(req) {
-      if (self.pieces.options.contextual && req.data.piece) {
+      if (self.pieces.contextual && req.data.piece) {
         req.browserCall('apos.contextPiece = ?', _.pick(req.data.piece, '_id', 'title', 'slug', 'type'));
       }
     };

--- a/lib/modules/apostrophe-pieces/index.js
+++ b/lib/modules/apostrophe-pieces/index.js
@@ -26,7 +26,7 @@ module.exports = {
   },
 
   beforeConstruct: function(self, options) {
-    self.contextual = options.contextual;
+    self.contextual = true ? (options.contextual !== false) : false;
 
     if (self.contextual) {
       // If the piece is edited contextually, default the published state to false
@@ -115,7 +115,7 @@ module.exports = {
         style: 'pill'
       }
     ].concat(options.addFilters || []);
-    
+
     options.batchOperations = [
       {
         name: 'trash',
@@ -134,7 +134,7 @@ module.exports = {
       {
         name: 'publish',
         label: 'Publish',
-        unlessFilter: { 
+        unlessFilter: {
           published: true
         },
         requiredField: 'publish'


### PR DESCRIPTION
Closes #900.

I have switched the logic up ever so slightly so that contextual is now true by default. I have tested this by creating a new piece type and checking to see how the option affects its behavior when creating a new piece when a page module is/isn't present and whether or not an index page exists.

The `contextual` flag is already smart enough to know NOT to try to go to a show page if a `-pages` module does not exist for the piece type in question or if an index page does not yet exist in the database.

Two iterations ago, we discussed the potential negative implications of default `contextual: true` and it was noted that many developers create piece types that are intended to appear in a list view on an index page, but NEVER have a show page (ex. news posts that just link out to external articles).

It was proposed that we introduce a `showPage` flag to `pieces-pages` that would address this use case. My thinking is that `showPage: false` will automatically set its corresponding piece type to `contextual: false` and override a `contextual: true` flag if explicitly set.

I created a separate issue for the `showPage` flag and will close that separately: #931

✌️ 