### PR TITLE
widgets can have template options "moveable" and "trashable" set to f…

### DIFF
--- a/lib/modules/apostrophe-areas/views/widgetControls.html
+++ b/lib/modules/apostrophe-areas/views/widgetControls.html
@@ -1,19 +1,23 @@
 {%- import 'apostrophe-ui:components/buttons.html' as buttons -%}
 <div class="apos-ui" data-apos-widget-controls>
   <div class="apos-buttons apos-area-widget-controls apos-area-widget-controls--context">
-    <div class="apos-button-group">
-      {{ buttons.inGroup('', { icon: 'arrows', action: 'drag-item' }) }}
-      {{ buttons.inGroup('', { icon: 'arrow-up', action: 'move-item', value: 'up' }) }}
-      {{ buttons.inGroup('', { icon: 'arrow-down', action: 'move-item', value: 'down' }) }}
-    </div>
+    {% if data.options.moveable != false %}
+      <div class="apos-button-group">
+        {{ buttons.inGroup('', { icon: 'arrows', action: 'drag-item' }) }}
+        {{ buttons.inGroup('', { icon: 'arrow-up', action: 'move-item', value: 'up' }) }}
+        {{ buttons.inGroup('', { icon: 'arrow-down', action: 'move-item', value: 'down' }) }}
+      </div>
+    {% endif %}
     {%- if not data.manager.removeEditButton -%}
       {%- set label = data.options.editLabel or 'Edit ' + data.manager.label -%}
       <div class="apos-button-group apos-button-group--data">
         {{ buttons.inGroup(label, { action: 'edit-item' }) }}
       </div>
     {%- endif -%}
-    <div class="apos-button-group">
-      {{ buttons.inGroup('', { icon: 'trash', action: 'trash-item' }) }}
-    </div>
+    {% if data.options.trashable != false %}
+      <div class="apos-button-group">
+        {{ buttons.inGroup('', { icon: 'trash', action: 'trash-item' }) }}
+      </div>
+    {% endif %}
   </div>
 </div>


### PR DESCRIPTION
…alse to remove apostrophe move/trash UI

```
    {{ apos.singleton(data.page, 'imageSingleton', 'apostrophe-images', {
      trashable: false,
      moveable: false
    }) }}
```