### PR TITLE
Bring Lansdowne image bug fix to Apos images core

### DIFF
--- a/lib/modules/apostrophe-images/views/manageGridPage.html
+++ b/lib/modules/apostrophe-images/views/manageGridPage.html
@@ -1,17 +1,19 @@
 {%- import "apostrophe-ui:components/fields.html" as fields -%}
 {%- import "apostrophe-ui:components/buttons.html" as buttons -%}
 {% for piece in data.pieces -%}
-  <div class="apos-manage-grid-piece" data-focus-{{ piece.type }} data-edit-dbl-{{ data.options.name | css }}="{{ piece._id }}" data-piece="{{ piece._id }}">
-    <div class="apos-manage-grid-image">
-      <img src="{{ apos.attachments.url(piece.attachment, { size: 'one-third' } ) }}" alt="">
-      <div class="apos-image-screen"></div>
-      <div class="apos-manage-grid-piece-controls">
-        {% set verb = 'rescue' if piece.trash else 'edit' %}
-        {% set label = 'Rescue' if piece.trash else 'Edit' %}
-        {{ buttons.minor(label, { action: verb + '-' + data.options.name | css, value: piece._id, icon: 'caret-right' }) }}
+  {% if piece.attachment %}
+    <div class="apos-manage-grid-piece" data-focus-{{ piece.type }} data-edit-dbl-{{ data.options.name | css }}="{{ piece._id }}" data-piece="{{ piece._id }}">
+      <div class="apos-manage-grid-image">
+        <img src="{{ apos.attachments.url(piece.attachment, { size: 'one-third' } ) }}" alt="">
+        <div class="apos-image-screen"></div>
+        <div class="apos-manage-grid-piece-controls">
+          {% set verb = 'rescue' if piece.trash else 'edit' %}
+          {% set label = 'Rescue' if piece.trash else 'Edit' %}
+          {{ buttons.minor(label, { action: verb + '-' + data.options.name | css, value: piece._id, icon: 'caret-right' }) }}
+        </div>
       </div>
+      <div class="apos-manage-grid-piece-label">{{ piece.title }}</div>
+      {{ fields.checkbox(data.options.name + '-select') }}
     </div>
-    <div class="apos-manage-grid-piece-label">{{ piece.title }}</div>
-    {{ fields.checkbox(data.options.name + '-select') }}
-  </div>
+  {% endif %}
 {%- endfor %}


### PR DESCRIPTION
The below code causes an exception that blows up the site if `piece.attachment` doesn't exist.

`<img src="{{ apos.attachments.url(piece.attachment, { size: 'one-third' } ) }}" alt="">`

The logic in this PR prevents that exception.

See Zendesk issue 650.