### PR TITLE
Add an insert method to apostrophe-attachments to match pieces behaviour

### DIFF
--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -27,6 +27,11 @@ module.exports = function(self, options) {
   // permissions for backend tasks purposes.
 
   self.insert = function(req, file, options, callback) {
+    if (arguments.length === 3) {
+      callback = arguments[2];
+      options = {};
+    }
+
     var extension = path.extname(file.name);
     if (extension && extension.length) {
       extension = extension.substr(1);

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -100,7 +100,7 @@ module.exports = function(self, options) {
     }
 
     function remember(callback) {
-      if (options && options.permissions !== false) {
+      if (!options || options && options.permissions !== false) {
         info.ownerId = self.apos.permissions.getEffectiveUserId(req);
       }
       info.createdAt = new Date();

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -20,6 +20,13 @@ module.exports = function(self, options) {
   // configure jquery fileupload to submit one per request.)
 
   self.accept = function(req, file, callback) {
+    self.insert(req, file, {}, callback);
+  };
+
+  // Extending the functionnality of `accept`. Provide a way to bypass
+  // permissions for backend tasks purposes.
+
+  self.insert = function(req, file, options, callback) {
     var extension = path.extname(file.name);
     if (extension && extension.length) {
       extension = extension.substr(1);
@@ -44,8 +51,12 @@ module.exports = function(self, options) {
     };
 
     function permissions(callback) {
-      // TODO port permissions
-      return callback(self.apos.permissions.can(req, 'edit-attachment') ? null : 'forbidden');
+      if (options && options.permissions === false) {
+        return callback(null);
+      } else {
+        // TODO port permissions
+        return callback(self.apos.permissions.can(req, 'edit-attachment') ? null : 'forbidden');
+      }
     }
 
     function md5(callback) {
@@ -84,7 +95,9 @@ module.exports = function(self, options) {
     }
 
     function remember(callback) {
-      info.ownerId = self.apos.permissions.getEffectiveUserId(req);
+      if (options && options.permissions !== false) {
+        info.ownerId = self.apos.permissions.getEffectiveUserId(req);
+      }
       info.createdAt = new Date();
       return self.db.insert(info, callback);
     }

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -20,7 +20,7 @@ module.exports = function(self, options) {
   // configure jquery fileupload to submit one per request.)
 
   self.accept = function(req, file, callback) {
-    self.insert(req, file, {permissions: true}, callback);
+    self.insert(req, file, { permissions: true }, callback);
   };
 
   // Extending the functionnality of `accept`. Provide a way to bypass

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -20,7 +20,7 @@ module.exports = function(self, options) {
   // configure jquery fileupload to submit one per request.)
 
   self.accept = function(req, file, callback) {
-    self.insert(req, file, {}, callback);
+    self.insert(req, file, {permissions: true}, callback);
   };
 
   // Extending the functionnality of `accept`. Provide a way to bypass


### PR DESCRIPTION
Allow backend modules to insert attachments. Basically it's an override of the `accept` method with a `permissions: false` option.