### PR TITLE
Remove CI tests on utterly obsolete 0.10 Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - "stable"
   - "lts/*"
-  - "0.10"
 sudo: false
 services:
   - docker


### PR DESCRIPTION
v0.10.x is End-of-Life since 2016-10-31 cf. https://github.com/nodejs/LTS

This will speed up CI tests