### PR TITLE
The apostrophe controls should always be on top. Specifically fixes a…

### DIFF
--- a/lib/modules/apostrophe-ui/public/css/components/admin-bar.less
+++ b/lib/modules/apostrophe-ui/public/css/components/admin-bar.less
@@ -35,7 +35,7 @@
   .apos-inline-block();
   
   cursor: pointer;
-  z-index: 1; // todo bobo
+  z-index: @apos-z-index-max;
 
   svg
   {

--- a/lib/modules/apostrophe-ui/public/css/components/context-menu.less
+++ b/lib/modules/apostrophe-ui/public/css/components/context-menu.less
@@ -8,7 +8,7 @@
     bottom: @apos-padding-4;
     left: @apos-padding-4;
   }
-  z-index: @apos-z-index-5;
+  z-index: @apos-z-index-max;
 
   .apos-context-menu
   {


### PR DESCRIPTION
… Michelin bug #73, found in their workflow testing