### PR TITLE
Moving the apostrophe buttons and menu above the WYSWYG editor.

### DIFF
--- a/lib/modules/apostrophe-ui/public/css/components/admin-bar.less
+++ b/lib/modules/apostrophe-ui/public/css/components/admin-bar.less
@@ -4,7 +4,7 @@
   height: 60px;
   top: @apos-padding-2;
   left: @apos-padding-2;
-  z-index: @apos-z-index-5;
+  z-index: @apos-z-index-7;
   background-color: @apos-base;
   color: @apos-white;
   .apos-button-border(@apos-white);
@@ -35,7 +35,6 @@
   .apos-inline-block();
   
   cursor: pointer;
-  z-index: 1; // todo bobo
 
   svg
   {

--- a/lib/modules/apostrophe-ui/public/css/components/context-menu.less
+++ b/lib/modules/apostrophe-ui/public/css/components/context-menu.less
@@ -8,7 +8,7 @@
     bottom: @apos-padding-4;
     left: @apos-padding-4;
   }
-  z-index: @apos-z-index-5;
+  z-index: @apos-z-index-7;
 
   .apos-context-menu
   {


### PR DESCRIPTION
Specifically fixes a Michelin bug #73, found in their workflow testing.