### PR TITLE
Changed page tree trashcan from utf8 icon to a simple text label

### DIFF
--- a/lib/modules/apostrophe-pages/public/js/reorganize.js
+++ b/lib/modules/apostrophe-pages/public/js/reorganize.js
@@ -362,7 +362,7 @@ apos.define('apostrophe-pages-reorganize', {
         self.$tree.tree('removeNode', trashcan);
       } else if ((!trashcan) && (trashed.length || regular.length)) {
         var trashcan = {
-          label: '🗑️',
+          label: 'Trash',
           id: apos.utils.generateId(),
           virtualTrashcan: true,
         };


### PR DESCRIPTION
I didn't make it a font awesome icon, since it was passed as a label param, and I didn't see any other precedent in the code for passing HTML as a label in the code. Plus, it was a quick fix, and we already use the text string "Home" to label the root of the tree.