### PR TITLE
TKT-919 / Position widget controls via options object in widget

### DIFF
--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -75,7 +75,7 @@
   .apos-transition;
   &:hover { z-index: @apos-z-index-6; }
 }
-.apos-area-widget-controls--context, .apos-area-widget-controls--topLeft,
+.apos-area-widget-controls--context, .apos-area-widget-controls--top-left,
 {
   top: @apos-padding-1;
   left: @apos-padding-1;
@@ -86,19 +86,19 @@
   left: @apos-padding-1;
 }
 
-.apos-area-widget-controls--topRight
+.apos-area-widget-controls--top-right
 {
   right: @apos-padding-1;
   left: initial;
 }
 
-.apos-area-widget-controls--bottomLeft
+.apos-area-widget-controls--bottom-left
 {
   top: initial;
   bottom: @apos-padding-1;
 }
 
-.apos-area-widget-controls--bottomRight
+.apos-area-widget-controls--bottom-right
 {
   top: initial;
   right: @apos-padding-1;

--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -75,7 +75,7 @@
   .apos-transition;
   &:hover { z-index: @apos-z-index-6; }
 }
-.apos-area-widget-controls--context
+.apos-area-widget-controls--context, .apos-area-widget-controls--topLeft, 
 {
   top: @apos-padding-1;
   left: @apos-padding-1;
@@ -84,6 +84,26 @@
 {
   bottom: @apos-padding-1;
   left: @apos-padding-1;
+}
+
+.apos-area-widget-controls--topRight
+{
+  right: @apos-padding-1;
+  left: initial;
+}
+
+.apos-area-widget-controls--bottomLeft
+{
+  top: initial;
+  bottom: @apos-padding-1;
+}
+
+.apos-area-widget-controls--bottomRight
+{
+  top: initial;
+  left: initial;
+  right: @apos-padding-1;
+  bottom: @apos-padding-1;
 }
 
 .apos-area-widget--contextual>.apos-ui .apos-button-group--data { display: none; }

--- a/lib/modules/apostrophe-areas/public/css/user.less
+++ b/lib/modules/apostrophe-areas/public/css/user.less
@@ -75,7 +75,7 @@
   .apos-transition;
   &:hover { z-index: @apos-z-index-6; }
 }
-.apos-area-widget-controls--context, .apos-area-widget-controls--topLeft, 
+.apos-area-widget-controls--context, .apos-area-widget-controls--topLeft,
 {
   top: @apos-padding-1;
   left: @apos-padding-1;
@@ -101,9 +101,9 @@
 .apos-area-widget-controls--bottomRight
 {
   top: initial;
-  left: initial;
   right: @apos-padding-1;
   bottom: @apos-padding-1;
+  left: initial;
 }
 
 .apos-area-widget--contextual>.apos-ui .apos-button-group--data { display: none; }

--- a/lib/modules/apostrophe-areas/views/widgetControls.html
+++ b/lib/modules/apostrophe-areas/views/widgetControls.html
@@ -2,7 +2,7 @@
 <div class="apos-ui" data-apos-widget-controls>
   <div class="apos-buttons apos-area-widget-controls apos-area-widget-controls--context
   {% if data.options.position %}
-    apos-area-widget-controls--{{ data.options.position }}
+    apos-area-widget-controls--{{ data.options.position | css }}
   {% endif %} ">
     {% set groups = apos.areas.widgetControlGroups(data.widget, data.options) %}
     {% for group in groups %}

--- a/lib/modules/apostrophe-areas/views/widgetControls.html
+++ b/lib/modules/apostrophe-areas/views/widgetControls.html
@@ -1,6 +1,9 @@
 {%- import 'apostrophe-ui:components/buttons.html' as buttons -%}
 <div class="apos-ui" data-apos-widget-controls>
-  <div class="apos-buttons apos-area-widget-controls apos-area-widget-controls--context">
+  <div class="apos-buttons apos-area-widget-controls apos-area-widget-controls--context
+  {% if data.options.position %}
+    apos-area-widget-controls--{{data.options.position}} 
+  {% endif %} ">
     {% set groups = apos.areas.widgetControlGroups(data.widget, data.options) %}
     {% for group in groups %}
       <div class="apos-button-group {{ group.classes }}">

--- a/lib/modules/apostrophe-areas/views/widgetControls.html
+++ b/lib/modules/apostrophe-areas/views/widgetControls.html
@@ -2,7 +2,7 @@
 <div class="apos-ui" data-apos-widget-controls>
   <div class="apos-buttons apos-area-widget-controls apos-area-widget-controls--context
   {% if data.options.position %}
-    apos-area-widget-controls--{{data.options.position}} 
+    apos-area-widget-controls--{{ data.options.position }}
   {% endif %} ">
     {% set groups = apos.areas.widgetControlGroups(data.widget, data.options) %}
     {% for group in groups %}


### PR DESCRIPTION
https://github.com/punkave/apostrophe/issues/919

Allows developers to position widget controls by passing in a 'position' property into a widget. The following values can be passed in:

- bottomLeft
- bottom RIght
- topRIght
- topLeft (default position, but developer may use it for granularity)

`{{ apos.singleton(data.global, 'footer', 'my-footer', { position: "bottomLeft" }) }}`


