### PR TITLE
Addition of a nunjucks block wrapping the modules calls in `outerLayoutBase.html` in `apostrophe-templates`

### DIFF
--- a/lib/modules/apostrophe-templates/views/outerLayoutBase.html
+++ b/lib/modules/apostrophe-templates/views/outerLayoutBase.html
@@ -32,8 +32,10 @@
     {{ apos.assets.templates(data.when) }}
     {{ apos.assets.scripts(data.when) }}
     <script type="text/javascript">
-      {{ data.js.globalCalls }}
-      {{ data.js.reqCalls }}
+      {% block modulesCalls %}
+        {{ data.js.globalCalls }}
+        {{ data.js.reqCalls }}
+      {% endblock %}
     </script>
     {% block extraBody %}
     {% endblock %}

--- a/lib/modules/apostrophe-templates/views/outerLayoutBase.html
+++ b/lib/modules/apostrophe-templates/views/outerLayoutBase.html
@@ -31,12 +31,12 @@
     </div>
     {{ apos.assets.templates(data.when) }}
     {{ apos.assets.scripts(data.when) }}
-    <script type="text/javascript">
-      {% block modulesCalls %}
+    {% block jsCalls %}
+      <script type="text/javascript">
         {{ data.js.globalCalls }}
         {{ data.js.reqCalls }}
-      {% endblock %}
-    </script>
+      </script>
+    {% endblock %}
     {% block extraBody %}
     {% endblock %}
   </body>


### PR DESCRIPTION
Added a Nunjucks block to allow overriding Apostrophe's `create` and `mirror` calls. The goal here is to allow overriding the modules calls to easily plug in Webpack.