### PR TITLE
Removing slash from @fa-font-path variable

### DIFF
--- a/lib/modules/apostrophe-ui/public/css/vendor/font-awesome/variables.less
+++ b/lib/modules/apostrophe-ui/public/css/vendor/font-awesome/variables.less
@@ -1,7 +1,7 @@
 // Variables
 // --------------------------
 
-@fa-font-path:        '/modules/apostrophe-ui/fonts/';
+@fa-font-path:        '/modules/apostrophe-ui/fonts';
 @fa-font-size-base:   14px;
 @fa-line-height-base: 1;
 //@fa-font-path:        "//netdna.bootstrapcdn.com/font-awesome/4.4.0/fonts"; // for referencing Bootstrap CDN font files directly


### PR DESCRIPTION
There is a conflict between this variable **@fa-font-path** which finish with a slash, and urls inside **paths.less** which are beginning with a slash.
Exemple -> 
`@fa-font-path: '/modules/apostrophe-ui/fonts/';`
`url('@{fa-font-path}/fontawesome-webfont.eot?v=@{fa-version}');`
