### PR TITLE
fixed aposPrefix to apos.prefix

### DIFF
--- a/lib/modules/apostrophe-login/views/loginBase.html
+++ b/lib/modules/apostrophe-login/views/loginBase.html
@@ -10,7 +10,7 @@
       <div class="apos-ui apos-login">
         <div class="apos-login-title apos-text-title">{% block subHeading %}{{ __('Login') }}{% endblock %}</div>
         {% block form %}
-          <form action="{% block action %}{{ aposPrefix }}/login{% endblock %}" method="post">
+          <form action="{% block action %}{{ apos.prefix }}/login{% endblock %}" method="post">
             {% if data.message %}<div class="warning">{{ __(data.message) }}</div>{% endif %}
             {% block fields %}
               <div class="apos-field apos-login-username">
@@ -28,7 +28,7 @@
             {% block forgot %}
               {% if resetAvailable %}
               <br />
-                <a class="apos-login-reset" href="{{ aposPrefix }}/apos-people/reset-request">{{ __('Reset My Password') }}</a>
+                <a class="apos-login-reset" href="{{ apos.prefix }}/apos-people/reset-request">{{ __('Reset My Password') }}</a>
               {% endif %}
             {% endblock %}
           </form>


### PR DESCRIPTION
Pull request to fix apostrophe-login/loginBase.html to use apos.prefix instead of aposPrefix.