### PR TITLE
in the reorganize modal attempts to drag a page above or below home, …

### DIFF
--- a/lib/modules/apostrophe-pages/lib/api.js
+++ b/lib/modules/apostrophe-pages/lib/api.js
@@ -544,6 +544,10 @@ module.exports = function(self, options) {
     if (!moved._publish) {
       return callback('forbidden');
     }
+    if (!(data.parent && data.oldParent)) {
+      // Move outside tree
+      return callback('forbidden');
+    }
     // You can always move a page into the trash. You can
     // also change the order of subpages if you can
     // edit the subpage you're moving. Otherwise you

--- a/lib/modules/apostrophe-pages/lib/routes.js
+++ b/lib/modules/apostrophe-pages/lib/routes.js
@@ -390,15 +390,26 @@ module.exports = function(self, options) {
         };
         if (page._children && page._children.length) {
           info.children = [];
-          // Sort `trash` after non-trash
+          // First non-trash, then .trash true,
+          // then the conventional trashcan itself
+          // to avoid presenting a confusing UI
           _.each(page._children, function(child) {
             if (!child.trash) {
               info.children.push(pageToJqtree(child));
             }
           });
           _.each(page._children, function(child) {
-            if (child.trash) {
+            if (child.trash && (!(child.type === 'trash'))) {
               info.children.push(pageToJqtree(child));
+            }
+          });
+          _.each(page._children, function(child) {
+            if (child.trash && (child.type === 'trash')) {
+              var forJqtree = pageToJqtree(child);
+              if (self.apos.docs.trashInSchema) {
+                forJqtree.label = self.apos.i18n.__('Legacy Trash');
+              }
+              info.children.push(forJqtree);
             }
           });
         }

--- a/lib/modules/apostrophe-pages/public/js/reorganize.js
+++ b/lib/modules/apostrophe-pages/public/js/reorganize.js
@@ -237,7 +237,22 @@ apos.define('apostrophe-pages-reorganize', {
         targetId: e.move_info.target_node.id,
         position: e.move_info.position
       };
-
+      
+      // Refuse requests to move something before the
+      // home page, or after it (as a peer). Inside it is fine
+      var target = e.move_info.target_node;
+      if (!target.parent.parent) {
+        if (e.move_info.position !== 'inside') {
+          return;
+        }
+      }
+      // You also can't move something after the conventional trashcan
+      if ((target.type === 'trash') && (!target.virtualTrashcan)) {
+        if (e.move_info.position === 'after') {
+          return;
+        }
+      }
+            
       if (apos.docs.trashInSchema) {
         if (e.move_info.target_node.virtualTrashcan) {
           if ((e.move_info.position === 'before') || (e.move_info.position === 'after')) {
@@ -371,6 +386,9 @@ apos.define('apostrophe-pages-reorganize', {
         };
         self.$tree.tree('appendNode', trashcan, node);
         trashcan = self.$tree.tree('getNodeById', trashcan.id);
+        // Reverse the array, otherwise "inside" will put the
+        // last first
+        trashed.reverse();
         _.each(trashed, function(child) {
           self.$tree.tree('moveNode', child, trashcan, 'inside');
         });

--- a/lib/modules/apostrophe-pages/public/js/reorganize.js
+++ b/lib/modules/apostrophe-pages/public/js/reorganize.js
@@ -241,14 +241,12 @@ apos.define('apostrophe-pages-reorganize', {
       // Refuse requests to move something before the
       // home page, or after it (as a peer). Inside it is fine
       var target = e.move_info.target_node;
-      if (!target.parent.parent) {
-        if (e.move_info.position !== 'inside') {
+      if ((!target.parent.parent) && (e.move_info.position !== 'inside')) {
           return;
         }
       }
       // You also can't move something after the conventional trashcan
-      if ((target.type === 'trash') && (!target.virtualTrashcan)) {
-        if (e.move_info.position === 'after') {
+      if ((target.type === 'trash') && (!target.virtualTrashcan) && (e.move_info.position === 'after')) {
           return;
         }
       }


### PR DESCRIPTION
… or below the conventional trashcan, no longer produce crashes or confusing errors, they are simply rejected. Also, if trashInSchema is active (for workflow) so that every page that is a parent has its own "virtual trashcan," the original "conventional trashcan" appears below any contextual trash, and it is given a special "legacy trash" label to clarify its status.