### PR TITLE
for video widgets, display a clear error message and do not crash if …

### DIFF
--- a/lib/modules/apostrophe-oembed/index.js
+++ b/lib/modules/apostrophe-oembed/index.js
@@ -76,17 +76,23 @@ module.exports = {
       // Simple API to self.query, with caching. Accepts url and
       // alwaysIframe parameters; alwaysIframe is assumed false
       // if not provided. The response is a JSON object as returned
-      // by apos.oembed. You may use GET or POST
+      // by apos.oembed.
       self.route('get', 'query', function(req, res) {
         var url = self.apos.launder.string(req.query.url);
         var options = {
           alwaysIframe: self.apos.launder.boolean(req.query.alwaysIframe),
-          iframeHeight: self.apos.launder.integer(req.query.iframeHeight)
+          iframeHeight: self.apos.launder.integer(req.query.iframeHeight),
+          neverOpenGraph: self.apos.launder.boolean(req.query.neverOpenGraph)
         };
         return self.query(req, url, options, function(err, result) {
           if (err) {
-            res.statusCode = 404;
-            return res.send('not found');
+            if ((typeof(err) === 'number') && ((err >= 400) && (err < 600))) {
+              // Disclose the HTTP error from upstream
+              return res.status(err).send('error');
+            } else {
+              // Doesn't look like a clean HTTP status code
+              return res.status(404).send('error');
+            }
           }
           return res.send(result);
         });

--- a/lib/modules/apostrophe-oembed/lib/api.js
+++ b/lib/modules/apostrophe-oembed/lib/api.js
@@ -8,7 +8,8 @@ module.exports = function(self, options) {
   // representation via `oembetter`, and on success invokes its callback with null
   // and an object containing the oembed API response from the service provider.
   //
-  // If `oembetter` has no luck, open graph is used as a fallback.
+  // If `oembetter` has no luck, open graph is used as a fallback,
+  // unless `options.neverOpenGraph` is set.
   //
   // If `options.alwaysIframe` is true, the result is a simple
   // iframe of the URL. If `options.iframeHeight` is set, the iframe
@@ -58,6 +59,9 @@ module.exports = function(self, options) {
         }
         return self.oembetter.fetch(url, options, function(err, _response) {
           if (err) {
+            if (options.neverOpenGraph) {
+              return callback(err);
+            }
             // Try open graph as a fallback
             return self.openGraph(req, url, function(err, _response) {
               if (err) {

--- a/lib/modules/apostrophe-oembed/public/js/always.js
+++ b/lib/modules/apostrophe-oembed/public/js/always.js
@@ -28,7 +28,7 @@ apos.define('apostrophe-oembed', {
       }
       return self.query(options, function(err, result) {
         if (err || (options.type && (result.type !== options.type))) {
-          return fail(err);
+          return fail(err || 'inappropriate');
         }
         $el.removeClass('apos-oembed-busy');
         return self.play($el, result, callback);
@@ -55,8 +55,8 @@ apos.define('apostrophe-oembed', {
       // A situation where we actually do want a cacheable GET request
       return $.getJSON(self.options.action + '/query', options, function(html) {
         return callback(null, html);
-      }).error(function() {
-        return callback('invalid');
+      }).error(function(jqXHR) {
+        return callback(jqXHR.status || 'error');
       });
     };
 

--- a/lib/modules/apostrophe-video-fields/public/css/user.less
+++ b/lib/modules/apostrophe-video-fields/public/css/user.less
@@ -15,6 +15,11 @@
       }
     }
   }
+  .apos-video-error {
+    color: @apos-red;
+    display: none;
+    text-align: center;
+  }
 }
 
 // SPINNER =====================

--- a/lib/modules/apostrophe-video-fields/public/js/user.js
+++ b/lib/modules/apostrophe-video-fields/public/js/user.js
@@ -58,13 +58,16 @@ apos.define('apostrophe-video-fields', {
 
     self.preview = function($fieldset, value, field) {
       $fieldset.data('busy', true);
+      $fieldset.find('[data-apos-video-error]').hide();
       return apos.oembed.queryAndPlay(
         $fieldset.find('[data-apos-video-player]'),
         {
           url: value && value.url,
-          type: self.oembedType
+          type: self.oembedType,
+          neverOpenGraph: (self.oembedType === 'video') ? 1 : undefined
         }, function(err, result) {
         if (err) {
+          $fieldset.find('[data-apos-video-error="' + err + '"]').show();
           $fieldset.data('busy', false);
           $fieldset.data('valid', false);
           return;

--- a/lib/modules/apostrophe-video-fields/views/video.html
+++ b/lib/modules/apostrophe-video-fields/views/video.html
@@ -5,6 +5,7 @@
 {% macro video(field) %}
   {% if not field.readOnly %}<input type="text" class="apos-field-input apos-field-input-text" name="{{ field.name }}" />{% endif %}
   <div class="apos-video-player" data-apos-video-player></div>
+  <div class="apos-video-error" data-apos-video-error="401">Embedding is not allowed for this video.</div>
 {% endmacro %}
 
 {{ schemas.fieldset(data, video) }}

--- a/lib/modules/apostrophe-video-fields/views/video.html
+++ b/lib/modules/apostrophe-video-fields/views/video.html
@@ -1,11 +1,11 @@
 {%- import "apostrophe-schemas:macros.html" as schemas -%}
 {%- import "apostrophe-ui:components/buttons.html" as buttons -%}
 
-
 {% macro video(field) %}
   {% if not field.readOnly %}<input type="text" class="apos-field-input apos-field-input-text" name="{{ field.name }}" />{% endif %}
   <div class="apos-video-player" data-apos-video-player></div>
-  <div class="apos-video-error" data-apos-video-error="401">Embedding is not allowed for this video.</div>
+  <div class="apos-video-error" data-apos-video-error="401">{{ __('Embedding is not allowed for this video.') }}</div>
+  <div class="apos-video-error" data-apos-video-error="404">{{ __('That video was not found. Paste a URL to the video\'s page.') }}</div>
 {% endmacro %}
 
 {{ schemas.fieldset(data, video) }}

--- a/lib/modules/apostrophe-video-widgets/public/js/always.js
+++ b/lib/modules/apostrophe-video-widgets/public/js/always.js
@@ -2,7 +2,8 @@ apos.define('apostrophe-video-widgets', {
   extend: 'apostrophe-widgets',
   construct: function(self, options) {
     self.play = function($widget, data, options) {
-      return apos.oembed.queryAndPlay($widget.find('[data-apos-video-player]'), data.video);
+      var request = _.assign({}, data.video, { neverOpenGraph: 1 });
+      return apos.oembed.queryAndPlay($widget.find('[data-apos-video-player]'), request);
     };
   }
 });


### PR DESCRIPTION
…there is a 401 response from the upstream oembed server. Also, do not waste time on open graph for a video widget (although it would be allowed for an embed widget, if we get around to one).