### PR TITLE
support for the .njk file extension, which is preferred if both exist…

### DIFF
--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -393,7 +393,7 @@ module.exports = {
 
     self.newLoader = function(moduleName, dirs) {
       var NunjucksLoader = require('./lib/nunjucksLoader.js');
-      return new NunjucksLoader(moduleName, dirs, undefined, self);
+      return new NunjucksLoader(moduleName, dirs, undefined, self, self.options.loader);
     };
 
     self.addStandardFilters = function(env) {

--- a/lib/modules/apostrophe-templates/lib/nunjucksLoader.js
+++ b/lib/modules/apostrophe-templates/lib/nunjucksLoader.js
@@ -7,20 +7,18 @@
 // Note that if apostrophe-templates has a project-level override
 // of outerLayout.html, that will be loaded instead. This is
 // intentional.
-//
-// The third argument is a reference to the apostrophe-templates
-// module, which constructs this loader once for each module
-// that loads templates.
 
 var fs = require('fs');
 var path = require('path');
 var _ = require('lodash');
 
-module.exports = function(moduleName, searchPaths, noWatch, templates) {
+module.exports = function(moduleName, searchPaths, noWatch, templates, options) {
 
   var self = this;
+  options = options || {};
+  var extensions = options.extensions || [ 'njk', 'html' ];
   self.moduleName = moduleName;
-  self.templates = templates;
+  self.templates = templates;  
 
   self.init = function(searchPaths, noWatch) {
     self.pathsToNames = {};
@@ -81,6 +79,7 @@ module.exports = function(moduleName, searchPaths, noWatch, templates) {
     var modulePath;
 
     var matches;
+    var i, j;
 
     if (!name.match(/:/)) {
       name = self.moduleName + ':' + name;
@@ -100,18 +99,32 @@ module.exports = function(moduleName, searchPaths, noWatch, templates) {
 
     var dirs = self.templates.getViewFolders(self.templates.apos.modules[moduleName]);
 
-    var result;
-
-    var i = 0;
-    while (i < dirs.length) {
-      var fullpath = dirs[i] + '/' + modulePath;
-      if (fs.existsSync(fullpath)) {
-        self.pathsToNames[fullpath] = name;
-        var src = fs.readFileSync(fullpath, 'utf-8');
-
-        return { src: src, path: name };
+    for (i = 0; (i < dirs.length); i++) {
+      fullpath = dirs[i] + '/' + modulePath;
+      matches = fullpath.match(/\.([^\/\.]+)$/);
+      if (matches) {
+        if (!_.contains(extensions, matches[1])) {
+          // Custom extensions shouldn't fall back to njk/html,
+          // that would not be bc. It's do or die for these
+          if (fs.existsSync(fullpath)) {
+            self.pathsToNames[fullpath] = name;
+            var src = fs.readFileSync(fullpath, 'utf-8');
+            return { src: src, path: name };
+          }
+          return null;
+        }
       }
-      i++;
+      // Try all the configured extensions, regardless
+      // of which of them was actually requested,
+      // so that developers have a choice
+      for (j = 0; (j < extensions.length); j++) {
+        fullpath = fullpath.replace(/\.[^\/\.]+$/, '.' + extensions[j]);
+        if (fs.existsSync(fullpath)) {
+          self.pathsToNames[fullpath] = name;
+          var src = fs.readFileSync(fullpath, 'utf-8');
+          return { src: src, path: name };
+        }
+      }
     }
     return null;
   };


### PR DESCRIPTION
… for the same template. To allow the use of njk as a substitute extension for existing templates, it does not matter whether the developer requests .html or .njk when calling render().

Implements #685 