### PR TITLE
Fixes overflowing bottom area menu

### DIFF
--- a/lib/modules/apostrophe-ui/public/css/components/dropdown.less
+++ b/lib/modules/apostrophe-ui/public/css/components/dropdown.less
@@ -64,9 +64,17 @@
 {
 	.apos-dropdown-items
 	{
+		overflow: hidden;
+		height: 0;
 		.apos-rounded-bl;
 		.apos-rounded-br;
 	}
+
+	&.apos-active .apos-dropdown-items {
+		overflow: auto;
+		height: auto;
+	}
+
 	&.apos-active>.apos-button
 	{
 		border-bottom-left-radius: 0;


### PR DESCRIPTION
Fixes the overflowing inactive dropdown area issue:
![screen shot 2017-10-19 at 2 19 54 pm](https://user-images.githubusercontent.com/1155984/31787263-2ec3eaf6-b4d9-11e7-8907-f98c0d03d211.png)