### PR TITLE
Fix error in apostrophe-assets documentation for self.pushAsset method

### DIFF
--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -7,9 +7,9 @@
 // the [apostrophe-module](../apostrophe-module/index.html) base class.
 //
 // Apostrophe implements two "asset scenes," `anon` and `user`. When
-// you call `self.pushAsset('script', 'myfile', { scene: 'user' })`, that
+// you call `self.pushAsset('script', 'myfile', { when: 'user' })`, that
 // script is normally pushed only to logged-in users. When you call
-// `self.pushAsset('script', 'myfile', { scene: 'always' })`, that script is
+// `self.pushAsset('script', 'myfile', { when: 'always' })`, that script is
 // pushed to everyone, logged in or not.
 //
 // If you want assets that are normally available only to logged-in users
@@ -292,7 +292,7 @@ module.exports = {
         self.fromBundle = true;
       }
     };
-    
+
     // Clean up old asset bundles in uploadfs, if any, after a
     // suitably safe interval allowing services such as Heroku to
     // shut down old instances that might be using them
@@ -343,7 +343,7 @@ module.exports = {
             return callback(err);
           });
         }
-        
+
         function remove(callback) {
           var current = _.find(generations, { _id: self.generation });
           return async.eachSeries(generations, function(generation, callback) {
@@ -353,13 +353,13 @@ module.exports = {
             return removeGeneration(generation, callback);
           });
         }
-        
+
         function removeGeneration(generation, callback) {
           return async.series([
             removeFiles,
             removeIt
           ], callback);
-          
+
           function removeFiles(callback) {
             return async.eachLimit(generation.copies, 5, function(copy, callback) {
               return self.apos.attachments.uploadfs.remove(copy.to, function(err) {
@@ -371,7 +371,7 @@ module.exports = {
               });
             }, callback);
           }
-          
+
           function removeIt(callback) {
             return self.generations.remove({ _id: generation._id }, callback);
           }
@@ -475,7 +475,7 @@ module.exports = {
       } else if (fs.existsSync(filePath)) {
         exists = true;
       }
-      
+
       if (exists) {
         self.pushed[self.assetTypes[type].key].push({ type: type, file: filePath, web: webPath, data: data, preshrunk: options.preshrunk, when: when, minify: options.minify });
       }
@@ -764,7 +764,7 @@ module.exports = {
           to: toFile
         });
       }
-                        
+
       function performCopies(callback) {
         return async.eachLimit(copies, 5, function(copy, callback) {
           return self.apos.attachments.uploadfs.copyIn(copy.from, copy.to, callback);
@@ -833,7 +833,7 @@ module.exports = {
           self.purgeExcept('/apos-minified/' + scene + '-*.' + self.typeMap[type], '-' + self.generation);
           var file = self.getAssetRoot() + '/public/apos-minified/' + scene + '-' + self.generation + '.' + self.typeMap[type];
           if (fs.existsSync(file)) {
-            // Someone has already compiled it for the 
+            // Someone has already compiled it for the
             // current deployment's asset generation!
             // No startup delay! Booyeah!
             self.minified[scene] = self.minified[scene] || {};
@@ -1050,7 +1050,7 @@ module.exports = {
       // We run ALL CSS through the LESS compiler, because
       // it fixes relative paths for us so that a combined file
       // will still have valid paths to background images etc.
-      
+
       var lessOptions = {
         filename: src,
         paths: [],
@@ -1287,7 +1287,7 @@ module.exports = {
         }
       };
       _.merge(lessMiddlewareOptions.render, self.options.less || {});
-      
+
       self.apos.app.use(lessMiddleware(self.apos.rootDir + '/public', lessMiddlewareOptions,
         {
           // parser options
@@ -1302,7 +1302,7 @@ module.exports = {
     self.prefixCssUrls = function(css) {
       return self.prefixCssUrlsWith(css, self.apos.prefix);
     };
-    
+
     // Prefix all URLs in CSS with a particular string
     self.prefixCssUrlsWith = function(css, prefix) {
       css = css.replace(/url\(([^'"].*?)\)/g, function(s, url) {
@@ -1340,7 +1340,7 @@ module.exports = {
       }
       return self.apos.prefix + web;
     };
-    
+
     self.getCoreAposProperties = function(when) {
       return _.assign(
         _.pick(self.apos, 'prefix', 'csrfCookieName'),
@@ -1352,7 +1352,7 @@ module.exports = {
         } : {}
       )
     };
-    
+
     // This task is primarily implemented by the logic in afterInit, however
     // if we are sending a bundle to uploadfs this is a fine time to do
     // that part.


### PR DESCRIPTION
It seems that previously, the docs have instructed to use the `options.scene` property rather than `options.when`. I believe this was just a plain error, let me know if not.

Some trailing whitespace was also removed in the diff, didn't think it would be much of an issue.