### PR TITLE
Support for "select everything" (#1097), requires styling

### DIFF
--- a/lib/modules/apostrophe-doc-type-manager/public/js/chooser.js
+++ b/lib/modules/apostrophe-doc-type-manager/public/js/chooser.js
@@ -105,6 +105,11 @@ apos.define('apostrophe-doc-type-manager-chooser', {
       self.refresh();
       return true;
     };
+    self.clear = function() {
+      self.choices = [];
+      self.refresh();
+      return true;
+    };
     self.remove = function(_id) {
       if (self.removed) {
         // We are striking things through, not forgetting about them
@@ -378,7 +383,6 @@ apos.define('apostrophe-doc-type-manager-chooser', {
         if (!manager.parentChooser) {
           return setImmediate(callback);
         }
-        manager.enableCheckboxEventsForChooser();
           
         return manager.parentChooser.clone(
           {
@@ -394,6 +398,7 @@ apos.define('apostrophe-doc-type-manager-chooser', {
             }
             manager.chooser = chooser;
             apos.on('pieceInserted', chooser.pieceInsertedListener);
+            manager.afterEnableChooser();
             return callback(null);
           }
         );
@@ -417,49 +422,15 @@ apos.define('apostrophe-doc-type-manager-chooser', {
         });
       };
 
-      manager.enableCheckboxEventsForChooser = function() {
-        manager.$el.on('change', '[data-piece] input[type="checkbox"]', function(e) {
-          // in rare circumstances, might not be ready yet, don't crash
-          if (!manager.chooser) {
-            return;
-          }
-          var $box = $(this);
-          var id = $box.closest('[data-piece]').attr('data-piece');
-          if ($box.prop('checked')) {
-            manager.addChoice(id);
-          } else {
-            manager.removeChoice(id);
-          }
-        });
-
-        manager.$el.add(manager.$filters).on('change', 'input[type="checkbox"][name="select-all"]', function(e) {
-          var $pieces = manager.$el.find('[data-piece]');
-          var $checkboxes = $pieces.find('input[type="checkbox"]');
-          var ids = $pieces.map(function() {
-            return $(this).attr('data-piece');
-          }).get();
-          if ($checkboxes.filter(':checked').length === $checkboxes.length) {
-            $checkboxes.prop('checked', false);
-            $checkboxes.parents('[data-focus-'+ options.name +']').removeClass('apos-focus');
-            findSelectAll().prop('checked', false);
-            _.each(ids, function(id) {
-              manager.removeChoice(id);
-            });
-          } else {
-            $checkboxes.prop('checked', true);
-            $checkboxes.parents('[data-focus-'+ options.name +']').addClass('apos-focus');
-            findSelectAll().prop('checked', true);
-            _.each(ids, function(id) {
-              manager.addChoice(id);
-            });
-          }
-          function findSelectAll() {
-            return manager.$el.find('input[type="checkbox"][name="select-all"]').add(manager.$filters.find('input[type="checkbox"][name="select-all"]'));
-          }
-        });
-
+      var superEnableCheckboxEvents = manager.enableCheckboxEvents;
+      // Would run too soon, wait for chooser to load
+      manager.enableCheckboxEvents = function() {
       };
       
+      manager.afterEnableChooser = function() {
+        superEnableCheckboxEvents();
+      };
+              
       manager.addChoice = function(id) {
         var $box;
         if (!manager.chooser.add(id)) {
@@ -476,18 +447,18 @@ apos.define('apostrophe-doc-type-manager-chooser', {
           // of the checkbox.
           self.$el.find('[data-piece="' + id + '"] input[type="checkbox"]').prop('checked', true);
         }
-      };
-
-      // For bc reasons, we disable this method of the manager modal rather than attempting
-      // to extend it. Instead, see manager.enableCheckboxEventsForChooser for the implementation
-      // used when decorating the manager for the chooser.
-      manager.enableCheckboxEvents = function() {
+        manager.hideSelectEverything();
+        manager.getSelectAll().prop('checked', false);
       };
 
       // For bc reasons, we disable this method of the manager modal rather than attempting
       // to extend it. Instead, see manager.reflectChooserInCheckboxes for the implementation
       // used when decorating the manager for the chooser.
       manager.reflectChoicesInCheckboxes = function() {
+      };
+      
+      manager.clearChoices = function() {
+        self.clear();
       };
 
       manager.saveContent = function(callback) {

--- a/lib/modules/apostrophe-doc-type-manager/public/js/chooser.js
+++ b/lib/modules/apostrophe-doc-type-manager/public/js/chooser.js
@@ -431,6 +431,33 @@ apos.define('apostrophe-doc-type-manager-chooser', {
             manager.removeChoice(id);
           }
         });
+
+        manager.$el.add(manager.$filters).on('change', 'input[type="checkbox"][name="select-all"]', function(e) {
+          var $pieces = manager.$el.find('[data-piece]');
+          var $checkboxes = $pieces.find('input[type="checkbox"]');
+          var ids = $pieces.map(function() {
+            return $(this).attr('data-piece');
+          }).get();
+          if ($checkboxes.filter(':checked').length === $checkboxes.length) {
+            $checkboxes.prop('checked', false);
+            $checkboxes.parents('[data-focus-'+ options.name +']').removeClass('apos-focus');
+            findSelectAll().prop('checked', false);
+            _.each(ids, function(id) {
+              manager.removeChoice(id);
+            });
+          } else {
+            $checkboxes.prop('checked', true);
+            $checkboxes.parents('[data-focus-'+ options.name +']').addClass('apos-focus');
+            findSelectAll().prop('checked', true);
+            _.each(ids, function(id) {
+              manager.addChoice(id);
+            });
+          }
+          function findSelectAll() {
+            return manager.$el.find('input[type="checkbox"][name="select-all"]').add(manager.$filters.find('input[type="checkbox"][name="select-all"]'));
+          }
+        });
+
       };
       
       manager.addChoice = function(id) {

--- a/lib/modules/apostrophe-images/views/manageGridView.html
+++ b/lib/modules/apostrophe-images/views/manageGridView.html
@@ -6,6 +6,7 @@
   <div class="apos-manage-showing" data-result-label>
     {% include "manageResultLabel.html" %}
   </div>
+  {% include "manageSelectEverything.html" %}
   <div data-items class="apos-manage-grid-page">
     {% include "manageGridPage.html" %}
   </div>

--- a/lib/modules/apostrophe-pieces/lib/api.js
+++ b/lib/modules/apostrophe-pieces/lib/api.js
@@ -132,7 +132,11 @@ module.exports = function(self, options) {
     } else {
       cursor = self.findForEditing(req);
     }
-    cursor.perPage(self.options.perPage || 10);
+    if (filters.format === 'allIds') {
+      cursor.projection({ _id: 1 });
+    } else {
+      cursor.perPage(self.options.perPage || 10);
+    }
     cursor.queryToFilters(filters);
 
     var results = {};
@@ -140,6 +144,9 @@ module.exports = function(self, options) {
     return async.series({
 
       toCount: function(callback) {
+        if (filters.format === 'allIds') {
+          return callback(null);
+        }
         return cursor
           .toCount(function(err, count) {
             if (err) {
@@ -153,6 +160,9 @@ module.exports = function(self, options) {
       },
 
       populateFilters: function(callback) {
+        if (filters.format === 'allIds') {
+          return callback(null);
+        }
 
         // Populate manage view filters by the same technique used
         // for the `piecesFilters` option of `apostrophe-pieces-pages`
@@ -204,6 +214,10 @@ module.exports = function(self, options) {
           .toArray(function(err, pieces) {
             if (err) {
               return callback(err);
+            }
+            if (filters.format === 'allIds') {
+              results.ids = _.pluck(pieces, '_id');
+              return callback(null);
             }
             results.skip = cursor.get('skip');
             results.limit = cursor.get('limit');

--- a/lib/modules/apostrophe-pieces/lib/routes.js
+++ b/lib/modules/apostrophe-pieces/lib/routes.js
@@ -52,7 +52,11 @@ module.exports = function(self, options) {
         return self.afterList(req, results, callback);
       }
     }, function(err) {
-      if ((!err) && (req.body.format === 'managePage')) {
+      if (err) {
+        console.error(err);
+        return self.listResponse(req, res, err, results);
+      }
+      if (req.body.format === 'managePage') {
         results.options = results.options || {};
         results.options.name = self.name;
         results.options.label = self.label;
@@ -81,6 +85,11 @@ module.exports = function(self, options) {
           filters: self.render(req, 'manageFilters', results),
           view: self.render(req, viewTemplate, results),
           pager: self.render(req, 'pager', results)
+        };
+      } else if (req.body.format === 'allIds') {
+        results = {
+          ids: results.ids,
+          label: req.__('Select all %s item(s) that match this search', results.ids.length)
         };
       }
       return self.listResponse(req, res, err, results);

--- a/lib/modules/apostrophe-pieces/public/css/manager.less
+++ b/lib/modules/apostrophe-pieces/public/css/manager.less
@@ -79,3 +79,7 @@
   &.fa { .fa; }
   color: @apos-primary;
 }
+
+.apos-manage-select-everything {
+  display: none;
+}

--- a/lib/modules/apostrophe-pieces/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/manager-modal.js
@@ -496,9 +496,13 @@ apos.define('apostrophe-pieces-manager-modal', {
         }).get();
         if ($checkboxes.filter(':checked').length === $checkboxes.length) {
           $checkboxes.prop('checked', false);
+          // For image grid view
+          $checkboxes.parents('[data-focus-'+ options.name +']').removeClass('apos-focus');
           self.choices = _.difference(self.choices, ids);
         } else {
           $checkboxes.prop('checked', true);
+          // For image grid view
+          $checkboxes.parents('[data-focus-'+ options.name +']').addClass('apos-focus');
           self.choices = _.union(self.choices, ids);
         }
         self.reflectChoiceCount();

--- a/lib/modules/apostrophe-pieces/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/manager-modal.js
@@ -488,7 +488,7 @@ apos.define('apostrophe-pieces-manager-modal', {
     // own implementation.
 
     self.enableCheckboxEvents = function() {
-      self.$el.on('change', 'input[type="checkbox"][name="select-all"]', function(e) {
+      self.$el.add(self.$filters).on('change', 'input[type="checkbox"][name="select-all"]', function(e) {
         var $pieces = self.$el.find('[data-piece]');
         var $checkboxes = $pieces.find('input[type="checkbox"]');
         var ids = $pieces.map(function() {
@@ -497,15 +497,18 @@ apos.define('apostrophe-pieces-manager-modal', {
         if ($checkboxes.filter(':checked').length === $checkboxes.length) {
           $checkboxes.prop('checked', false);
           $checkboxes.parents('[data-focus-'+ options.name +']').removeClass('apos-focus');
-          self.$el.find('input[type="checkbox"][name="select-all"]').prop('checked', false);
+          findSelectAll().prop('checked', false);
           self.choices = _.difference(self.choices, ids);
         } else {
           $checkboxes.prop('checked', true);
           $checkboxes.parents('[data-focus-'+ options.name +']').addClass('apos-focus');
-          self.$el.find('input[type="checkbox"][name="select-all"]').prop('checked', true);
+          findSelectAll().prop('checked', true);
           self.choices = _.union(self.choices, ids);
         }
         self.reflectChoiceCount();
+        function findSelectAll() {
+          return self.$el.find('input[type="checkbox"][name="select-all"]').add(self.$filters.find('input[type="checkbox"][name="select-all"]'));
+        }
       });
       self.$el.on('change', '[data-piece] input[type="checkbox"]', function(e) {
         var $box = $(this);

--- a/lib/modules/apostrophe-pieces/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/manager-modal.js
@@ -496,13 +496,11 @@ apos.define('apostrophe-pieces-manager-modal', {
         }).get();
         if ($checkboxes.filter(':checked').length === $checkboxes.length) {
           $checkboxes.prop('checked', false);
-          // For image grid view
-          $checkboxes.parents('[data-focus-'+ options.name +']').removeClass('apos-focus');
+          self.$el.find('input[type="checkbox"][name="select-all"]').prop('checked', false);
           self.choices = _.difference(self.choices, ids);
         } else {
           $checkboxes.prop('checked', true);
-          // For image grid view
-          $checkboxes.parents('[data-focus-'+ options.name +']').addClass('apos-focus');
+          self.$el.find('input[type="checkbox"][name="select-all"]').prop('checked', true);
           self.choices = _.union(self.choices, ids);
         }
         self.reflectChoiceCount();

--- a/lib/modules/apostrophe-pieces/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/manager-modal.js
@@ -496,10 +496,12 @@ apos.define('apostrophe-pieces-manager-modal', {
         }).get();
         if ($checkboxes.filter(':checked').length === $checkboxes.length) {
           $checkboxes.prop('checked', false);
+          $checkboxes.parents('[data-focus-'+ options.name +']').removeClass('apos-focus');
           self.$el.find('input[type="checkbox"][name="select-all"]').prop('checked', false);
           self.choices = _.difference(self.choices, ids);
         } else {
           $checkboxes.prop('checked', true);
+          $checkboxes.parents('[data-focus-'+ options.name +']').addClass('apos-focus');
           self.$el.find('input[type="checkbox"][name="select-all"]').prop('checked', true);
           self.choices = _.union(self.choices, ids);
         }

--- a/lib/modules/apostrophe-pieces/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/manager-modal.js
@@ -43,6 +43,7 @@ apos.define('apostrophe-pieces-manager-modal', {
       self.enableCheckboxEvents();
       self.enableBatchOperations();
       self.enableInsertViaUpload();
+      self.enableSelectEverything();
       apos.on('change', self.onChange);
       self.refresh();
       return callback();
@@ -488,7 +489,13 @@ apos.define('apostrophe-pieces-manager-modal', {
     // own implementation.
 
     self.enableCheckboxEvents = function() {
-      self.$el.add(self.$filters).on('change', 'input[type="checkbox"][name="select-all"]', function(e) {
+
+      if (!$.contains(self.$el[0], self.$filters[0])) {
+        self.$filters.on('change', 'input[type="checkbox"][name="select-all"]', selectAllHandler);
+      }
+      self.$el.on('change', 'input[type="checkbox"][name="select-all"]', selectAllHandler);
+      
+      function selectAllHandler(e) {
         var $pieces = self.$el.find('[data-piece]');
         var $checkboxes = $pieces.find('input[type="checkbox"]');
         var ids = $pieces.map(function() {
@@ -497,19 +504,23 @@ apos.define('apostrophe-pieces-manager-modal', {
         if ($checkboxes.filter(':checked').length === $checkboxes.length) {
           $checkboxes.prop('checked', false);
           $checkboxes.parents('[data-focus-'+ options.name +']').removeClass('apos-focus');
-          findSelectAll().prop('checked', false);
-          self.choices = _.difference(self.choices, ids);
+          self.getSelectAll().prop('checked', false);
+          _.each(ids, function(id) {
+            self.removeChoice(id);
+          });
+          self.hideSelectEverything();
         } else {
           $checkboxes.prop('checked', true);
           $checkboxes.parents('[data-focus-'+ options.name +']').addClass('apos-focus');
-          findSelectAll().prop('checked', true);
-          self.choices = _.union(self.choices, ids);
+          self.getSelectAll().prop('checked', true);
+          _.each(ids, function(id) {
+            self.addChoice(id);
+          });
+          self.showSelectEverything();
         }
         self.reflectChoiceCount();
-        function findSelectAll() {
-          return self.$el.find('input[type="checkbox"][name="select-all"]').add(self.$filters.find('input[type="checkbox"][name="select-all"]'));
-        }
-      });
+      };
+      
       self.$el.on('change', '[data-piece] input[type="checkbox"]', function(e) {
         var $box = $(this);
         var id = $box.closest('[data-piece]').attr('data-piece');
@@ -517,6 +528,28 @@ apos.define('apostrophe-pieces-manager-modal', {
           self.addChoice(id);
         } else {
           self.removeChoice(id);
+        }
+      });
+    };
+    
+    self.getSelectAll = function() {
+      return self.$el.find('input[type="checkbox"][name="select-all"]').add(self.$filters.find('input[type="checkbox"][name="select-all"]'));
+    };
+    
+    self.enableSelectEverything = function() {
+      self.$el.on('change', 'input[name="select-everything"]', function() {
+        var checked = $(this).prop('checked');
+        if (checked) {
+          _.each(self.allIds, function(id) {
+            self.addChoice(id);
+          });
+        } else {
+          var $pieces = self.$el.find('[data-piece]');
+          var $checkboxes = $pieces.find('input[type="checkbox"]');
+          $checkboxes.prop('checked', false);
+          $checkboxes.parents('[data-focus-'+ options.name +']').removeClass('apos-focus');
+          self.getSelectAll().prop('checked', false);
+          self.clearChoices();
         }
       });
     };
@@ -536,7 +569,40 @@ apos.define('apostrophe-pieces-manager-modal', {
         self.$el.removeClass('apos-manager-modal--has-choices');
         self.$el.addClass('apos-manager-modal--has-no-choices');
       }
+      self.hideSelectEverything();
       self.reflectChoiceCount();
+      self.getSelectAll().prop('checked', false);
+    };
+    
+    self.clearChoices = function() {
+      self.choices = [];
+      self.$el.removeClass('apos-manager-modal--has-choices');
+      self.$el.addClass('apos-manager-modal--has-no-choices');
+      self.hideSelectEverything();
+      self.reflectChoiceCount();
+    };
+    
+    self.showSelectEverything = function() {
+      var listOptions = self.getListOptions({ format: 'allIds' });
+      apos.ui.globalBusy(true);
+      return self.api('list', listOptions, function(response) {
+        apos.ui.globalBusy(false);
+        if (response.status !== 'ok') {
+          return;
+        }
+        self.allIds = response.data.ids;
+        self.getSelectEverything().find('[data-label]').text(response.data.label);
+        self.getSelectEverything().show();
+      });
+    };
+    
+    self.hideSelectEverything = function() {
+      self.getSelectEverything().find('input[name="select-everything"]').prop('checked', false);
+      self.getSelectEverything().hide();
+    };
+    
+    self.getSelectEverything = function() {
+      return self.$el.find('[data-result-select-everything]');
     };
     
     // Reflect existing choices in checkboxes. Invoked by `self.refresh` after
@@ -573,16 +639,25 @@ apos.define('apostrophe-pieces-manager-modal', {
       });
     };
 
-    self.refresh = function(callback) {
-      var listOptions = {
-        format: 'managePage'
-      };
+    // Given an options object, returns a new object with
+    // those options plus standard options for the list API,
+    // such as `sort`, `search` and `manageView`. Also invokes
+    // `self.beforeList`. Called by `refresh`.
+    
+    self.getListOptions = function(options) {
+      var listOptions = _.assign({}, options);
 
       _.extend(listOptions, self.currentFilters);
       listOptions.sort = self.sort;
       listOptions.search = self.search;
       listOptions.manageView = self.viewName;
       self.beforeList(listOptions);
+      
+      return listOptions;
+    };
+
+    self.refresh = function(callback) {
+      var listOptions = self.getListOptions({ format: 'managePage' });
 
       return self.api('list', listOptions, function(response) {
         if (!response.status === 'ok') {

--- a/lib/modules/apostrophe-pieces/views/manageListView.html
+++ b/lib/modules/apostrophe-pieces/views/manageListView.html
@@ -3,6 +3,7 @@
   <div class="apos-manage-showing" data-result-label>
     {% include "manageResultLabel.html" %}
   </div>
+  {% include "manageSelectEverything.html" %}
   <table data-items class="apos-manage-table">
     <thead data-headings>
       {% include "manageHeadings.html" %}

--- a/lib/modules/apostrophe-pieces/views/manageResultLabel.html
+++ b/lib/modules/apostrophe-pieces/views/manageResultLabel.html
@@ -1,9 +1,9 @@
 <div class='apos-manage-result-label'>
-	{%- if data.filters.q -%}
-		{{ __('Showing %s results for ', data.total) }}<span>"{{ data.filters.q }}"</span>
-	{%- elif data.total == 0 -%}
-        {{ __('No results for current filters.') }}
-	{%- else -%}
-		{{ __('Showing %s - %s of %s results', data.skip + 1, data.skip + data.pieces.length, data.total) }}
-	{%- endif -%}
+  {%- if data.filters.q -%}
+    {{ __('Showing %s - %s of %s results for ', data.skip + 1, data.skip + data.pieces.length, data.total) }}<span>"{{ data.filters.q }}"</span>
+  {%- elif data.total == 0 -%}
+    {{ __('No results for current filters.') }}
+  {%- else -%}
+    {{ __('Showing %s - %s of %s results', data.skip + 1, data.skip + data.pieces.length, data.total) }}
+  {%- endif -%}
 </div>

--- a/lib/modules/apostrophe-pieces/views/manageSelectEverything.html
+++ b/lib/modules/apostrophe-pieces/views/manageSelectEverything.html
@@ -1,0 +1,2 @@
+{%- import "apostrophe-ui:components/fields.html" as fields -%}
+<div class="apos-manage-select-everything" data-result-select-everything>{{ fields.checkbox('select-everything') }} <span data-label>Select all 0 item(s) that match this search</span></div>

--- a/lib/modules/apostrophe-pieces/views/piecesMacros.html
+++ b/lib/modules/apostrophe-pieces/views/piecesMacros.html
@@ -73,10 +73,13 @@
 
 
 {%- macro filters(filters) -%}
-{#
-  Normal cursor-driven filters
-
-  #}<div class="apos-modal-filters-toggles">
+  {#
+    Normal cursor-driven filters
+  #}
+  <div class="apos-modal-filters-toggles">
+    <span class="apos-modal-filter">
+      {{ fields.checkbox('select-all') }}
+    </span>
     {%- for filter in filters.options -%}
       <span class="apos-modal-filter">
         {%- if not apos.utils.isFalse(filter.label) -%}
@@ -92,12 +95,11 @@
           {{ fields.select(filter.name, apos.utils.concat([ { label: filter.anyLabel or '—', value: "**ANY**" } ], filter.choices), filters.choices[filter.name]) }}
         {%- endif -%}
       </span>
-    {%- endfor -%}{#
-
-  Search
-
-  #}<div class="apos-modal-filters-search">
-    {# we need data.options.label & pluralLabel #}
-    {{ fields.string('search-' + data.options.name, 'Search ' + data.options.pluralLabel + '...', filters.q or '' ) }}
+    {%- endfor -%}
+    {# Search #}
+    <div class="apos-modal-filters-search">
+      {# we need data.options.label & pluralLabel #}
+      {{ fields.string('search-' + data.options.name, 'Search ' + data.options.pluralLabel + '...', filters.q or '' ) }}
+    </div>
   </div>
 {%- endmacro -%}

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -461,6 +461,8 @@ module.exports = {
         // if they are defined in the data, sanitize them normally;
         // otherwise leave them untouched. -Tom and Jimmy
         if (field.contextual && (from === 'form') && (!_.has(data, field.name))) {
+          console.log('skipping ' + field.name);
+          console.log(data);
           return setImmediate(callback);
         }
         var convert = self.fieldTypes[field.type].converters && self.fieldTypes[field.type].converters[from];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "2.35.0",
+  "version": "2.39.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1877,11 +1877,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -1891,6 +1886,11 @@
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
           }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "stringstream": {
           "version": "0.0.5",
@@ -3756,14 +3756,6 @@
         "stream-to": "0.2.2"
       }
     },
-    "string_decoder": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-      "requires": {
-        "safe-buffer": "5.0.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3772,6 +3764,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+      "requires": {
+        "safe-buffer": "5.0.1"
       }
     },
     "stringstream": {


### PR DESCRIPTION
Assigning to Bob for code review and Stuart for styling.

Stuart, note that in a grid view there is one checkbox which is currently hanging out north of the filters it's meant to be next to. In a list view, you get that, and you also get the checkbox you always got before. Both work sensibly, but feel free to hide the new one with CSS if you don't think that is a good idea.