### PR TITLE
Use overflow: auto; rather than overflow: scroll; in UI

### DIFF
--- a/lib/modules/apostrophe-doc-type-manager/public/css/chooser.less
+++ b/lib/modules/apostrophe-doc-type-manager/public/css/chooser.less
@@ -14,7 +14,7 @@
     position: fixed;
     .apos-inline-block;
     height: 100%;
-    overflow-y: scroll;
+    overflow: auto;
     width: 15%;
     @media @apos-breakpoint-desktop-xl { width: 25%; }
     background-color: @apos-light;

--- a/lib/modules/apostrophe-images/public/css/grid-view.less
+++ b/lib/modules/apostrophe-images/public/css/grid-view.less
@@ -4,7 +4,7 @@
   position: relative;
 
   height: 100%;
-  overflow-y: scroll;
+  overflow: auto;
   width: 100%;
   padding-left: 1em;
   padding-right: 1em;

--- a/lib/modules/apostrophe-modal/public/css/components/modal-tabs.less
+++ b/lib/modules/apostrophe-modal/public/css/components/modal-tabs.less
@@ -9,7 +9,7 @@
     padding-bottom: 50px;
     background-color: @apos-light;
     // If tab number exceeds viewport allow scroll
-    overflow: scroll;
+    overflow: auto;
     p {
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -46,7 +46,7 @@
     width: 75%;
     @media @apos-breakpoint-desktop-xl { width: 75%; }
     height: 100%;
-    overflow-y: scroll;
+    overflow: auto;
     .apos-scrollbar;
   }
 

--- a/lib/modules/apostrophe-modal/public/css/components/modal.less
+++ b/lib/modules/apostrophe-modal/public/css/components/modal.less
@@ -49,7 +49,7 @@
 	.apos-table tbody
   { 
     height: 100%;
-    overflow-y: scroll;
+    overflow: auto;
   } 
 }
 
@@ -77,7 +77,7 @@
 .apos-modal-body
 {
 	height: 100%;
-	overflow-y: scroll;
+	overflow: auto;
   .apos-scrollbar;
   background-color: lighten(@apos-light, 5%);
 	li a {

--- a/lib/modules/apostrophe-pages/public/css/user.less
+++ b/lib/modules/apostrophe-pages/public/css/user.less
@@ -9,7 +9,7 @@
   margin-left: 220px;
   padding-top: @apos-padding-2;
   background-color: @apos-white;
-  overflow-y: scroll;
+  overflow: auto;
   .apos-scrollbar;
 }
 

--- a/lib/modules/apostrophe-schemas/public/css/components/array-editor.less
+++ b/lib/modules/apostrophe-schemas/public/css/components/array-editor.less
@@ -57,7 +57,7 @@
     position: fixed;
     .apos-inline-block;
     height: 100%;
-    overflow-y: scroll;
+    overflow: auto;
     width: 25%;
     @media @apos-breakpoint-desktop-xl { width: 25%; }
     background-color: @apos-light;

--- a/lib/modules/apostrophe-ui/public/css/components/tables.less
+++ b/lib/modules/apostrophe-ui/public/css/components/tables.less
@@ -11,7 +11,7 @@
   background-color: @apos-lighter;
   @media screen and (max-width: 960px)
   {
-    overflow: scroll;
+    overflow: auto;
 		display: block;
   }
 }


### PR DESCRIPTION
`overflow: scroll` will force browsers to always render scrollbars, while `overflow: auto` will tell them to only do it when necessary. On mac OS, this is less of an issue, since users will often have overlay scrollbars, but a lot of other platforms don't, in which case it gives a more elegant impression to use `overflow: auto`.

Reference screenshots for comparison:

`overflow: scroll`
![screenshot-2017-11-7 projects 1](https://user-images.githubusercontent.com/1101677/32516583-1351c4b6-c404-11e7-9433-beb49a3a9160.png)

`overflow: auto`
![screenshot-2017-11-7 projects](https://user-images.githubusercontent.com/1101677/32516591-1b80a95e-c404-11e7-8cba-6d43ab8bc4c7.png)

