### PR TITLE
Miscellaneous UI improvements

### DIFF
--- a/lib/modules/apostrophe-modal/public/css/components/modal-breadcrumbs.less
+++ b/lib/modules/apostrophe-modal/public/css/components/modal-breadcrumbs.less
@@ -2,10 +2,11 @@
 .apos-modal-breadcrumb
 {
 	width: 100%;
-	padding: 10px @apos-padding-8;
+	padding: 10px @apos-padding-3;
 
 	background-color: @apos-light;
 	list-style: none;
+	border-bottom: 2px solid @apos-mid;
 
 
 	.apos-modal-breadcrumb-item

--- a/lib/modules/apostrophe-modal/public/css/components/modal-header.less
+++ b/lib/modules/apostrophe-modal/public/css/components/modal-header.less
@@ -8,7 +8,7 @@
   background-color: @apos-white;
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
-  border-bottom: 3px solid @apos-mid;
+  border-bottom: 2px solid @apos-mid;
 
   .apos-dropdown-items
   {

--- a/lib/modules/apostrophe-modal/public/css/components/modal-tabs.less
+++ b/lib/modules/apostrophe-modal/public/css/components/modal-tabs.less
@@ -10,6 +10,8 @@
     background-color: @apos-light;
     // If tab number exceeds viewport allow scroll
     overflow: scroll;
+    border-right: 2px solid @apos-mid;
+
     p {
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -28,7 +30,7 @@
     display: -ms-flexbox;
     display: -webkit-flex;
     padding: @apos-padding-2 @apos-padding-1;
-    border-bottom: 1px solid @apos-dark;
+    border-bottom: 1px solid @apos-mid;
     font-size: 14px;
     cursor: pointer;
     @media @apos-breakpoint-desktop-xl { font-size: 16px; }


### PR DESCRIPTION
I attempted to make a few adjustments to the overlay UI for improved consistency in where borders are placed, the colors of those borders and the spacing of the breadcrumb items.

I realize that these things are always subjective, but I still felt that these changes had some pretty clear aesthetic gains.

If there is something you are unsatisfied with, then what I feel most strongly about is the bottom border of .apos-modal-breadcrumb as well as the lighter border color of the .apos-schema-tab's

I attached two before and after screenshots for reference.

Before:
![localhost_3000_ 3](https://user-images.githubusercontent.com/1101677/32517632-4f79362e-c407-11e7-8afb-5eec17326718.png)

After:
![localhost_3000_ 2](https://user-images.githubusercontent.com/1101677/32517637-5582657c-c407-11e7-9a16-76835637cb24.png)
