### PR TITLE
accommodations for batch operations in workflow and general improveme…

### DIFF
--- a/lib/modules/apostrophe-pieces/lib/api.js
+++ b/lib/modules/apostrophe-pieces/lib/api.js
@@ -678,6 +678,11 @@ module.exports = function(self, options) {
       if (batchOperation.requiredField && (!_.find(self.schema, { name: batchOperation.requiredField }))) {
         return false;
       }
+      if (batchOperation.onlyIf) {
+        if (!batchOperation.onlyIf(self.name)) {
+          return false;
+        }
+      }
       return true;
     });
   };
@@ -841,6 +846,12 @@ module.exports = function(self, options) {
   self.getEditControls = function(req) {
     var controls = _.cloneDeep(self.editControls);
     return controls;
+  };
+  
+  self.modulesReady = function() {
+    // We delay this until late so it is easier for third party
+    // modules to have a say
+    self.composeBatchOperations();
   };
 
 };

--- a/lib/modules/apostrophe-pieces/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/manager-modal.js
@@ -228,7 +228,7 @@ apos.define('apostrophe-pieces-manager-modal', {
     
     self.enableBatchOperation = function(batchOperation, callback) {
       self.batchOperations[batchOperation.name] = batchOperation;
-      batchOperation.handler = self['batch' + apos.utils.capitalizeFirst(batchOperation.name)];
+      batchOperation.handler = self['batch' + apos.utils.capitalizeFirst(apos.utils.camelName(batchOperation.name))];
       if (!batchOperation.schema) {
         return setImmediate(callback);
       }
@@ -397,8 +397,24 @@ apos.define('apostrophe-pieces-manager-modal', {
     // Carry out a named batch operation, such as `trash`, displaying the
     // provided prompt and, if confirmed by the user, invoking the
     // corresponding verb in this module's API.
-
+    //
+    // `options.dataSource` can be used to specify a function
+    // to be invoked to gather more input before calling the API.
+    // It receives `(data, callback)`, where `data.ids` and any
+    // input gathered from the schema are already present, and
+    // should update `data` and invoke `callback` with
+    // null on success or with an error on failure.
+    //
+    // `options.success` is invoked only if the operation
+    // succeeds. It receives `(result, callback)` where
+    // `result` is the response from the API and `callback`
+    // *must* be invoked by the success function after
+    // completing its additional operations, even if the user
+    // chooses to cancel or skip those operations.
+    
     self.batchSimple = function(operationName, confirmationPrompt, options) {
+
+      var operation = self.batchOperations[operationName];
 
       if (!confirm(confirmationPrompt)) {
         return;
@@ -408,7 +424,7 @@ apos.define('apostrophe-pieces-manager-modal', {
         ids: self.choices
       };
 
-      return async.series([ convert, save ], function(err) {
+      return async.series([ convert, dataSource, save ], function(err) {
         if (err) {
           if (Array.isArray(err)) {
             // Schemas module already highlighted it
@@ -422,27 +438,37 @@ apos.define('apostrophe-pieces-manager-modal', {
       });
       
       function convert(callback) {
-        if (!self.batchOperations[operationName].schema) {
+        if (!operation.schema) {
           return callback(null);
         }
         return apos.schemas.convert(
           self.$batch.find('[data-apos-batch-operation-form="' + operationName + '"]'),
-          self.batchOperations[operationName].schema,
+          operation.schema,
           data,
           {},
           callback
         );
       }
       
+      function dataSource(callback) {
+        if (!options.dataSource) {
+          return callback(null);
+        }
+        return options.dataSource(data, callback);
+      }
+      
       function save(callback) {
         apos.ui.globalBusy(true);
-
-        return self.api(operationName, data, function(result) {
+        return self.api(operation.route || operationName, data, function(result) {
           apos.ui.globalBusy(false);
           if (result.status !== 'ok') {
             return callback('An error occurred. Please try again.');
           }
-          return callback(null);
+          if (options.success) {
+            return options.success(result, callback);
+          } else {
+            return callback(null);
+          }
         }, function() {
           apos.ui.globalBusy(false);
           return callback('An error occurred. Please try again.');

--- a/lib/modules/apostrophe-ui/public/js/context.js
+++ b/lib/modules/apostrophe-ui/public/js/context.js
@@ -50,10 +50,11 @@ apos.define('apostrophe-context', {
 
     };
 
-    // Invoke $.jsonCall with the URL
-    // self.action + '/' + verb.
-    //
-    // "options" and "failure" may be omitted entirely.
+    // Invoke a JSON API route implemented by the Apostrophe module
+    // associated with this object, or by another module if the
+    // ":" syntax is used, like: `module-name:verb`
+    // 
+    // `options` and `failure` may be omitted entirely.
     //
     // Typical example:
     //
@@ -61,19 +62,29 @@ apos.define('apostrophe-context', {
     //   if (result.status === 'ok') { ... }
     // });
     //
-    // See $.jsonCall for details.
+    // See $.jsonCall for details of how the call is made.
 
-    self.api = function(verb, data, options, success, failure) {
+    self.api = function(route, data, options, success, failure) {
       var args = Array.prototype.slice.call(arguments);
-      args[0] = self.action + '/' + verb;
+      var module = self;
+      var matches = route.match(/^(.*)?\:(.*)$/);
+      var verb = route;
+      if (matches) {
+        module = apos.modules[matches[1]];
+        verb = matches[2];
+      }
+      args[0] = module.action + '/' + verb;
       return $.jsonCall.apply($, args);
     };
 
-    // Invoke $.jsonCall with the URL self.action + '/' + verb
-    // and always add { dataType: 'html' } to the options. For
-    // fetching HTML fragments asynchronously. Since $.jsonCall
-    // is always POST, there is no limit to the size of the
-    // data object and no risk of a stale cached result coming back.
+    // Invoke an API route implemented by the Apostrophe module
+    // associated with this object, or by another module if the
+    // ":" syntax is used, like: `module-name:verb`
+    //
+    // The response is expected to be markup, not JSON. Otherwise
+    // this method is very similar to the `api` method.
+    // 
+    // `options` and `failure` may be omitted entirely.
     //
     // Typical example:
     //
@@ -85,7 +96,7 @@ apos.define('apostrophe-context', {
     //
     // See $.jsonCall for details.
 
-    self.html = function(verb, options, data, success, failure) {
+    self.html = function(route, options, data, success, failure) {
       if (typeof(data) === 'function') {
         // No options argument passed, shift the others over
         failure = success;
@@ -95,10 +106,18 @@ apos.define('apostrophe-context', {
       }
       var _options = {};
       if (options) {
-        _.extend(_options, options);
+        _.assign(_options, options);
       }
       _options.dataType = 'html';
-      return $.jsonCall(self.action + '/' + verb, _options, data, success, failure);
+      var module = self;
+      var verb = route;
+      var matches = route.match(/^(.*)?\:(.*)$/);
+      var moduleName;
+      if (matches) {
+        module = apos.modules[matches[1]];
+        verb = matches[2];
+      }
+      return $.jsonCall(module.action + '/' + verb, _options, data, success, failure);
     };
   }
 


### PR DESCRIPTION
…nts to batch operations. The new onlyIf property can be used to specify a function that can check the type to see if it makes sense to offer a batch operation for that type. The requiredField property now works properly. Multiword action names are properly camelcased when looking for the implementation method in the manager modal. The batchSimple method now accepts "success" and "dataSource" options, giving more ways to extend it without starting from scratch. Batch operations are composed late to give third party modules a chance to append some. The commonly used .api and .html methods of apostrophe-context and modals now support cross-module API calls with the same : syntax used elsewhere.