### PR TITLE
DGAD 266: batch operations now run via the new apostrophe-jobs module

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -21,6 +21,7 @@ module.exports = {
     'apostrophe-ui': {},
     'apostrophe-schemas': {},
     'apostrophe-docs': {},
+    'apostrophe-jobs': {},
     'apostrophe-versions': {},
     'apostrophe-tags': {},
     'apostrophe-modal': {},
@@ -44,6 +45,7 @@ module.exports = {
     'apostrophe-images-widgets': {},
     'apostrophe-files': {},
     'apostrophe-files-widgets': {},
+    // ALWAYS LAST FOREVER
     'apostrophe-service-bridge': {}
   }
 };

--- a/lib/modules/apostrophe-jobs/index.js
+++ b/lib/modules/apostrophe-jobs/index.js
@@ -8,6 +8,7 @@ module.exports = {
   afterConstruct: function(self, callback) {
     self.addRoutes();
     self.pushAssets();
+    self.pushCreateSingleton();
     return self.ensureCollection(callback);
   },
 

--- a/lib/modules/apostrophe-jobs/index.js
+++ b/lib/modules/apostrophe-jobs/index.js
@@ -1,3 +1,29 @@
+// The `apostrophe-jobs` module runs long-running jobs in response
+// to user actions. Batch operations on pieces are a good example.
+//
+// The `apostrophe-jobs` module makes it simple to implement
+// progress display, avoid server timeouts during long operations,
+// and implement a "stop" button.
+//
+// See the `run` method for the easiest way to use this module.
+// The `run` method allows you to implement routes that are designed
+// to be paired with the `progress` method of this module on
+// the browser side. All you need to do is make sure the
+// ids are posted to your route and then write a function that
+// can carry out the operation on one id.
+//
+// If you just want to add a new batch operation for pieces,
+// see the examples already in `apostrophe-pieces` and those added
+// by the `apostrophe-workflow` module. You don't need to go
+// directly to this module for that case.
+//
+// If your operation doesn't break down neatly into repeated operations
+// on single documents, look into calling the `start` method and friends
+// directly from your code.
+//
+// The `apostrophe-jobs` module DOES NOT have anything to do with
+// cron jobs or command line tasks.
+
 var _ = require('lodash');
 var async = require('async');
 

--- a/lib/modules/apostrophe-jobs/index.js
+++ b/lib/modules/apostrophe-jobs/index.js
@@ -2,16 +2,12 @@ var _ = require('lodash');
 var async = require('async');
 
 module.exports = {
+
   collectionName: 'aposJobs',
 
   afterConstruct: function(self, callback) {
-    // Make sure it's enabled for this particular subclass of pieces
-    if (!self.options.import) {
-      return setImmediate(callback);
-    }
     self.addRoutes();
     self.pushAssets();
-    self.pushDefineRelatedTypes();
     return self.ensureCollection(callback);
   },
 
@@ -20,6 +16,7 @@ module.exports = {
     require('./lib/routes.js')(self, options);
     require('./lib/api.js')(self, options);
     require('./lib/implementation.js')(self, options);
+    require('./lib/browser.js')(self, options);
         
   }
 };

--- a/lib/modules/apostrophe-jobs/index.js
+++ b/lib/modules/apostrophe-jobs/index.js
@@ -1,0 +1,25 @@
+var _ = require('lodash');
+var async = require('async');
+
+module.exports = {
+  collectionName: 'aposJobs',
+
+  afterConstruct: function(self, callback) {
+    // Make sure it's enabled for this particular subclass of pieces
+    if (!self.options.import) {
+      return setImmediate(callback);
+    }
+    self.addRoutes();
+    self.pushAssets();
+    self.pushDefineRelatedTypes();
+    return self.ensureCollection(callback);
+  },
+
+  construct: function(self, options) {
+
+    require('./lib/routes.js')(self, options);
+    require('./lib/api.js')(self, options);
+    require('./lib/implementation.js')(self, options);
+        
+  }
+};

--- a/lib/modules/apostrophe-jobs/lib/api.js
+++ b/lib/modules/apostrophe-jobs/lib/api.js
@@ -1,8 +1,182 @@
+var async = require('async');
+var _ = require('lodash');
+
 module.exports = function(self, options) {
+
+  // Starts and supervises a long-running job such as a
+  // batch operation on pieces. Call it to implement an API route
+  // that runs a job.
+  //
+  // The `ids` to be processed should be provided via `req.body.ids`.
+  //
+  // Pass `req` and a `change` function that accepts `(req, id, data, callback)`,
+  // performs the modification on that one id and invokes its callback
+  // with an error if any (if passed, this is recorded as a bad item
+  // in the job, it does not stop the job) and an optional
+  // `result` object.
+  //
+  // If `req.body.job` is truthy, sends an immediate JSON response to `req.res` with
+  // `{ status: 'ok', jobId: 'cxxxx' }`.
+  //
+  // The `jobId` can then be passed to `apos.modules['apostrophe-jobs'].progress(jobId)`
+  // on the browser side to monitor progress. After the job status is `completed`,
+  // the results of the job can be obtained via the progress API as the `results`
+  // property, an object with a sub-property for each `id`.
+  //
+  // Jobs run in this way support the stop operation. They do not currently support
+  // the cancel (undo/rollback) operation.
+  //
+  // Note that this method does not actually care if `id` is a doc id or not.
+  // It is just a unique identifier for one item to be processed that your
+  // `change` function must understand.
+  //
+  // The `batchSimple` method of `apostrophe-pieces` is an even
+  // simpler wrapper for this method if you are implementing a batch operation
+  // on a single type of piece.
+  //
+  // *Options*
+  //
+  // `options.label` should be passed as an object with
+  // a `title` property, to title the progress modal.
+  // A default is provided but it is not very informative.
+  //
+  // In addition, it may have `failed`, `completed` and
+  // `running` properties to label the progress modal when the job
+  // is in those states, and `good` and `bad` properties to label
+  // the count of items that were successful or had errors.
+  // All of these properties are optional and reasonable
+  // defaults are supplied.
+  //
+  // *Backwards compatibility*
+  //
+  // For bc a single id can be provided via `req.body._id`.
+  //
+  // If `req.body.job` is not truthy, the entire job is processed and
+  // a single HTTP response is sent, like:
+  //
+  // `{ status: 'ok', data: firstResult }` on success.
+  //
+  // `firstResult` is an empty object if `ids` was passed rather than `id`.
+  //
+  // This alternative approach is for bc only. Proxy timeouts are bad. Don't use it.
+
+  self.run = function(req, change, options) {
+    var query;
+    var single;
+    var res = req.res;
+    var data;
+    var job;
+    var stopping = false;
+    var results = {};
+    if (req.body._id) {
+      ids = [ self.apos.launder.id(req.body._id) ];
+    } else if (req.body.ids) {
+      ids = self.apos.launder.ids(req.body.ids);
+    } else {
+      return res.send({ status: 'invalid' });
+    }
+    return async.series([
+      startJob,
+      run
+    ], function(err) {
+      if (err) {
+        console.error(err);
+        if (job) {
+          return self.end(job, 'failed', function(err) {
+            if (err) {
+              // Not a lot we can do about this since we already
+              // stopped talking to the user 
+              console.error(err);
+            }
+          });
+        }
+        return res.send({
+          status: 'error'
+        });
+      } else {
+        if (job) {
+          return self.end(job, 'completed', results, function(err) {
+            if (err) {
+              // Not a lot we can do about this since we already
+              // stopped talking to the user 
+              console.error(err);
+            }
+          });
+        }
+        return res.send({
+          status: 'ok',
+          // legacy
+          data: single || {},
+          // preferred
+          results: results
+        });
+      }
+    });
+    
+    function startJob(callback) {
+      if (!req.body.job) {
+        return callback(null);
+      }
+      return self.start(_.assign({}, options, {
+        stop: function(job, callback) {
+          stopping = callback;
+          return;
+        }
+      }), function(err, _job) {
+        if (err) {
+          // Failed to insert the job. Don't continue the series,
+          // just tell the browser that.
+          return res.send({ status: 'error' });
+        }
+        job = _job;
+        self.setTotal(job, ids.length);
+        // DELIBERATE FALLTHROUGH: respond to the browser
+        // *right now* with the job id, then continue the
+        // series WITHOUT ever touching `res` again. The
+        // browser will call back for progress.
+        res.send({ status: 'ok', jobId: job._id });
+        return callback(null);
+      });
+    }
+
+    function run(callback) {
+      return async.eachSeries(ids, function(id, callback) {
+        if (stopping) {
+          // That's it, abandon the eachSeries
+          return stopping(null);
+        }
+        return change(req, id, function(err, result) {
+          if (job) {
+            if (err) {
+              self.bad(job);
+            } else {
+              self.good(job);
+              results[id] = result;
+              if (req.body._id && (!single)) {
+                single = piece;
+              }
+            }
+            return callback(null);
+          }
+          // Fallback implementation without job progress
+          if (!err) {
+            return callback(err);
+          }
+          if (req.body._id && (!single)) {
+            single = piece;
+          }
+          results[id] = result;
+        });
+      }, callback); 
+    }
+
+  };  
 
   // Start tracking a long-running job. Called by routes
   // that require progress display and/or the ability to take longer
   // than the server might permit a single HTTP request to last.
+  // *You usually won't call this yourself. The easy way is usually
+  // to call the `run` method, above.*
   //
   // On success this method invokes its callback with `(null, job)`.
   // You can then invoke the `setTotal`, `success`, `error`,
@@ -104,7 +278,9 @@ module.exports = function(self, options) {
         processed: n
       }
     }, function(err) {
-      console.error(err);
+      if (err) {
+        console.error(err);
+      }
     });
   };
 
@@ -128,7 +304,9 @@ module.exports = function(self, options) {
         processed: n
       }
     }, function(err) {
-      console.error(err);
+      if (err) {
+        console.error(err);
+      }
     });
   };
   
@@ -149,7 +327,9 @@ module.exports = function(self, options) {
     self.db.update({
       _id: job._id
     }, {
-      total: total
+      $set: {
+        total: total
+      }
     }, function(err) {
       if (err) {
         console.error(err);
@@ -163,8 +343,16 @@ module.exports = function(self, options) {
   // is reported as an overall failure.
   // Either way the user can still see the
   // count of "good" and "bad" items.
+  //
+  // If the results parameter is not omitted entirely,
+  // it is added to the job object in the database
+  // as the `results` property.
   
-  self.end = function(job, success, callback) {
+  self.end = function(job, success, results, callback) {
+    if (!callback) {
+      callback = results;
+      results = null;
+    }
     // context object gets an update to avoid a
     // race condition with checkStopped
     job.ended = true;
@@ -173,7 +361,8 @@ module.exports = function(self, options) {
     }, {
       $set: {
         ended: true,
-        status: success ? 'completed' : 'failed'
+        status: success ? 'completed' : 'failed',
+        results: results
       }
     }, callback);
   };  

--- a/lib/modules/apostrophe-jobs/lib/api.js
+++ b/lib/modules/apostrophe-jobs/lib/api.js
@@ -1,0 +1,180 @@
+module.exports = function(self, options) {
+
+  // Start tracking a long-running job. Called by routes
+  // that require progress display and/or the ability to take longer
+  // than the server might permit a single HTTP request to last.
+  //
+  // On success this method invokes its callback with `(null, job)`.
+  // You can then invoke the `setTotal`, `success`, `error`,
+  // and `end` methods with the job object. *For convenience,
+  // only `start` and `end` require a callback.*
+  //
+  // Once you successfully call `start`, you *must* eventually call
+  // `end` with a `job` object and a callback. In addition, 
+  // you *may* call `success(job)` and `error(job)` any number of times
+  // to indicate the success or failure of one "row" or other item
+  // processed, and you *may* call `setTotal(job, n)` to indicate
+  // how many rows to expect for better progress display.
+  //
+  // *Canceling and stopping jobs*
+  //
+  // If `options.cancel` is passed, the user may cancel (undo) the job.
+  // If they do `options.cancel` will be invoked with `(job, callback)` and
+  // it *must undo what was done*. You must invoke the callback *after the
+  // undo operation*. If you pass an error to the callback, the job will be stopped
+  // with no further progress in the undo operation.
+  //
+  // If `options.stop` is passed, the user may stop (halt) the operation.
+  // If they do `options.stop` will be invoked with `(job, callback)` and
+  // it *must stop processing new items*. You must invoke the callback
+  // *after all operations have stopped*.
+  //
+  // The difference between stop and cancel is the lack of undo with "stop".
+  // Implement the one that is practical for you. Users like to be able to
+  // undo things fully, of course.
+  //
+  // You should not offer both. If you do, only "Cancel" is presented
+  // to the user.
+  //
+  // *Labeling the progress modal: `options.label`*
+  //
+  // `options.label` should be passed as an object with
+  // a `title` property, to title the progress modal.
+  //
+  // In addition, it may have `failed`, `completed` and
+  // `running` properties to label the progress modal when the job
+  // is in those states, and `good` and `bad` properties to label
+  // the count of items that were successful or had errors.
+  // All of these properties are optional and reasonable
+  // defaults are supplied.
+  
+  self.start = function(options, callback) {
+        
+    var job = {
+      _id: self.apos.utils.generateId(),
+      good: 0,
+      bad: 0,
+      processed: 0,
+      status: 'running',
+      ended: false,
+      canceling: false,
+      labels: options.labels || {},
+      when: new Date(),
+      canCancel = !!options.cancel,
+      canStop = !!options.stop
+    };
+    
+    var context = {
+      _id: job._id,
+      options: options
+    };
+
+    if (options.cancel || options.stop) {
+       context.interval = setInterval(function() {
+         self.checkStop(context);
+       }, 250);
+    }
+
+    return self.db.insert(job, function(err) {
+      if (err) {
+        return callback(err);
+      }
+      return callback(null, context);
+    }
+
+  };
+  
+  // Call this to report that n items were good
+  // (successfully processed).
+  //
+  // If the second argument is completely omitted,
+  // the default is `1`.
+  //
+  // For simplicity there is no callback,
+  // since the reporting is noncritical. Just
+  // call it and move on.
+  
+  self.good = function(job, n) {
+    var n = (n === undefined) ? 1 : n;
+    self.db.update({
+      _id: job._id
+    }, {
+      $inc: {
+        good: n,
+        processed: n
+      }
+    }, function(err) {
+      console.error(err);
+    });
+  };
+
+  // Call this to report that n items were bad
+  // (not successfully processed).
+  //
+  // If the second argument is completely omitted,
+  // the default is 1.
+  //
+  // For simplicity there is no callback,
+  // since the reporting is noncritical. Just
+  // call it and move on.
+
+  self.bad = function(job, n) {
+    var n = (n === undefined) ? 1 : n;
+    self.db.update({
+      _id: job._id
+    }, {
+      $inc: {
+        bad: n,
+        processed: n
+      }
+    }, function(err) {
+      console.error(err);
+    });
+  };
+  
+  // Call this to indicate the total number
+  // of items expected. Until and unless this is called
+  // a different type of progress display is used.
+  // If you do call this, the total of all calls
+  // to success() and error() should not exceed it.
+  //
+  // It is OK not to call this, however the progress
+  // display will be less informative.
+  //
+  // For simplicity there is no callback,
+  // since the reporting is noncritical. Just
+  // call it and move on.
+  
+  self.setTotal = function(job, total) {
+    self.db.update({
+      _id: job._id
+    }, {
+      total: total
+    }, function(err) {
+      if (err) {
+        console.error(err);
+      }
+    });
+  };
+  
+  // Mark the given job as ended. If `success`
+  // is true the job is reported as an overall
+  // success, if `failed` is true the job
+  // is reported as an overall failure.
+  // Either way the user can still see the
+  // count of "good" and "bad" items.
+  
+  self.end = function(job, success, callback) {
+    // context object gets an update to avoid a
+    // race condition with checkStopped
+    job.ended = true;
+    return self.db.update({
+      _id: job._id
+    }, {
+      $set: {
+        ended: true,
+        status: success ? 'completed' : 'failed'
+      }
+    }, callback);
+  };  
+};

--- a/lib/modules/apostrophe-jobs/lib/api.js
+++ b/lib/modules/apostrophe-jobs/lib/api.js
@@ -60,8 +60,8 @@ module.exports = function(self, options) {
       canceling: false,
       labels: options.labels || {},
       when: new Date(),
-      canCancel = !!options.cancel,
-      canStop = !!options.stop
+      canCancel: !!options.cancel,
+      canStop: !!options.stop
     };
     
     var context = {
@@ -80,7 +80,7 @@ module.exports = function(self, options) {
         return callback(err);
       }
       return callback(null, context);
-    }
+    });
 
   };
   

--- a/lib/modules/apostrophe-jobs/lib/browser.js
+++ b/lib/modules/apostrophe-jobs/lib/browser.js
@@ -1,0 +1,7 @@
+module.exports = function(self, options) {
+  self.pushAssets = function() {
+    self.pushAsset('script', 'user', { when: 'user' });
+    self.pushAsset('script', 'modal', { when: 'user' });
+  };
+};
+

--- a/lib/modules/apostrophe-jobs/lib/browser.js
+++ b/lib/modules/apostrophe-jobs/lib/browser.js
@@ -2,6 +2,7 @@ module.exports = function(self, options) {
   self.pushAssets = function() {
     self.pushAsset('script', 'user', { when: 'user' });
     self.pushAsset('script', 'modal', { when: 'user' });
+    self.pushAsset('stylesheet', 'user', { when: 'user' });
   };
 };
 

--- a/lib/modules/apostrophe-jobs/lib/implementation.js
+++ b/lib/modules/apostrophe-jobs/lib/implementation.js
@@ -25,10 +25,15 @@ module.exports = function(self, options) {
     
     context.checkingStop = true;
 
-    return self.db.findOne({ _id: id }, function(err, job) {
+    return self.db.findOne({ _id: context._id }, function(err, job) {
       if (err) {
         console.error(err);
         // We'll retry automatically
+        context.checkingStop = false;
+        return;
+      }
+      if (!job) {
+        console.error('job never found');
         context.checkingStop = false;
         return;
       }
@@ -42,6 +47,7 @@ module.exports = function(self, options) {
       if (job.ended) {
         clearInterval(context.interval);
       }
+      context.checkingStop = false;
 
       function halt(verb, status) {
         return context.options[verb](job, function(err) {
@@ -53,9 +59,9 @@ module.exports = function(self, options) {
           var $set = {
             ended: true,
             canceling: false,
-            status: after
+            status: status
           };
-          return self.db.update({ _id: id }, {
+          return self.db.update({ _id: job._id }, {
             $set: $set
           }, function(err) {
             if (err) {

--- a/lib/modules/apostrophe-jobs/lib/implementation.js
+++ b/lib/modules/apostrophe-jobs/lib/implementation.js
@@ -1,4 +1,10 @@
 module.exports = function(self, options) {
+
+  self.ensureCollection = function(callback) {
+    self.db = self.apos.db.collection(self.options.collectionName);
+    return setImmediate(callback);
+  };
+
   // Periodically invoked to check whether
   // a request to cancel or stop the job has been made.
   // If it has we invoke options.cancel or options.stop to
@@ -59,7 +65,7 @@ module.exports = function(self, options) {
             }
             context.checkingStop = false;
           });
-        }
+        });
       }
     });
   };  

--- a/lib/modules/apostrophe-jobs/lib/implementation.js
+++ b/lib/modules/apostrophe-jobs/lib/implementation.js
@@ -1,0 +1,66 @@
+module.exports = function(self, options) {
+  // Periodically invoked to check whether
+  // a request to cancel or stop the job has been made.
+  // If it has we invoke options.cancel or options.stop to
+  // actually cancel it, preferably the former. This method is invoked
+  // by an interval timer installed by `self.start`.
+  // This allows a possibly different apostrophe process
+  // to request a cancellation by setting the `canceling` property;
+  // the original process actually running the job
+  // cancels and then acknowledges this by setting status to `canceled`
+  // or `stopped` according to which operation is
+  // actually supported by the job.
+  
+  self.checkStop = function(context) {
+    
+    if (context.checkingStop || context.ended) {
+      return;
+    }
+    
+    context.checkingStop = true;
+
+    return self.db.findOne({ _id: id }, function(err, job) {
+      if (err) {
+        console.error(err);
+        // We'll retry automatically
+        context.checkingStop = false;
+        return;
+      }
+      if (job.canceling) {
+        if (job.canCancel) {
+          return halt('cancel', 'canceled');
+        } else if (job.canStop) {
+          return halt('stop', 'stopped');
+        }
+      }
+      if (job.ended) {
+        clearInterval(context.interval);
+      }
+
+      function halt(verb, status) {
+        return context.options[verb](job, function(err) {
+          if (err) {
+            console.error(err);
+            context.checkingStop = false;
+            return;
+          }
+          var $set = {
+            ended: true,
+            canceling: false,
+            status: after
+          };
+          return self.db.update({ _id: id }, {
+            $set: $set
+          }, function(err) {
+            if (err) {
+              console.error(err);
+              context.checkingStop = false;
+              return;
+            }
+            context.checkingStop = false;
+          });
+        }
+      }
+    });
+  };  
+};

--- a/lib/modules/apostrophe-jobs/lib/implementation.js
+++ b/lib/modules/apostrophe-jobs/lib/implementation.js
@@ -53,8 +53,20 @@ module.exports = function(self, options) {
         return context.options[verb](job, function(err) {
           if (err) {
             console.error(err);
-            context.checkingStop = false;
-            return;
+            // If "stop" or "cancel" fails, that's bad news.
+            // Fail the job
+            return self.db.update({
+              _id: context._id
+            }, {
+              $set: {
+                ended: true,
+                canceling: false,
+                status: 'failed'
+              }
+            }, function(err) {
+              console.error(err);
+              context.checkingStop = false;
+            });
           }
           var $set = {
             ended: true,

--- a/lib/modules/apostrophe-jobs/lib/routes.js
+++ b/lib/modules/apostrophe-jobs/lib/routes.js
@@ -1,0 +1,52 @@
+module.exports = function(self, options) {
+
+  self.addRoutes = function() {
+  
+  self.route('post', 'cancel', function(req, res) {
+    var _id = self.apos.launder.id(req.body._id);
+    return self.db.update({ _id: _id }, { $set: { canceling: true } }, function(err, count) {
+      if (err) {
+        console.error(err);
+        return res.send({ status: 'error' });
+      }
+      if (!count) {
+        return res.send({ status: 'notfound' });
+      }
+      return res.send({ status: 'ok' });
+    });
+  });
+    
+  self.route('post', 'modal', function(req, res) {
+    var _id = self.apos.launder.id(req.body._id);
+    return self.db.findOne({ _id: _id }, function(err, job) {
+      return res.send(self.render(req, 'managerModal', { options: self.options, job: job }));    
+    });
+  });
+
+  self.route('post', 'progress', function(req, res) {
+    var _id = self.apos.launder.id(req.body._id);
+    return self.db.findOne({ _id: _id }, function(err, job) {
+      if (err) {
+        console.error(err);
+        return res.status(500).send('error');
+      }
+      if (!job) {
+        return respond({ notfound: true });
+      }
+      // % of completion rounded off to 2 decimal places
+      if (!job.total) {
+        job.percentage = 0;
+      } else {
+        job.percentage = (job.processed / job.total * 100).toFixed(2);
+      }
+      return respond({
+        job: job
+      });
+    });
+
+    function respond(info) {
+      return res.send(self.render(req, 'progress', info));
+    }
+  });
+
+};

--- a/lib/modules/apostrophe-jobs/lib/routes.js
+++ b/lib/modules/apostrophe-jobs/lib/routes.js
@@ -1,7 +1,7 @@
 module.exports = function(self, options) {
 
   self.addRoutes = function() {
-  
+    
     self.route('post', 'cancel', function(req, res) {
       var _id = self.apos.launder.id(req.body._id);
       return self.db.update({ _id: _id }, { $set: { canceling: true } }, function(err, count) {

--- a/lib/modules/apostrophe-jobs/lib/routes.js
+++ b/lib/modules/apostrophe-jobs/lib/routes.js
@@ -2,51 +2,51 @@ module.exports = function(self, options) {
 
   self.addRoutes = function() {
   
-  self.route('post', 'cancel', function(req, res) {
-    var _id = self.apos.launder.id(req.body._id);
-    return self.db.update({ _id: _id }, { $set: { canceling: true } }, function(err, count) {
-      if (err) {
-        console.error(err);
-        return res.send({ status: 'error' });
-      }
-      if (!count) {
-        return res.send({ status: 'notfound' });
-      }
-      return res.send({ status: 'ok' });
-    });
-  });
-    
-  self.route('post', 'modal', function(req, res) {
-    var _id = self.apos.launder.id(req.body._id);
-    return self.db.findOne({ _id: _id }, function(err, job) {
-      return res.send(self.render(req, 'managerModal', { options: self.options, job: job }));    
-    });
-  });
-
-  self.route('post', 'progress', function(req, res) {
-    var _id = self.apos.launder.id(req.body._id);
-    return self.db.findOne({ _id: _id }, function(err, job) {
-      if (err) {
-        console.error(err);
-        return res.status(500).send('error');
-      }
-      if (!job) {
-        return respond({ notfound: true });
-      }
-      // % of completion rounded off to 2 decimal places
-      if (!job.total) {
-        job.percentage = 0;
-      } else {
-        job.percentage = (job.processed / job.total * 100).toFixed(2);
-      }
-      return respond({
-        job: job
+    self.route('post', 'cancel', function(req, res) {
+      var _id = self.apos.launder.id(req.body._id);
+      return self.db.update({ _id: _id }, { $set: { canceling: true } }, function(err, count) {
+        if (err) {
+          console.error(err);
+          return res.send({ status: 'error' });
+        }
+        if (!count) {
+          return res.send({ status: 'notfound' });
+        }
+        return res.send({ status: 'ok' });
       });
     });
-
-    function respond(info) {
-      return res.send(self.render(req, 'progress', info));
-    }
-  });
-
+      
+    self.route('post', 'modal', function(req, res) {
+      var _id = self.apos.launder.id(req.body._id);
+      return self.db.findOne({ _id: _id }, function(err, job) {
+        return res.send(self.render(req, 'managerModal', { options: self.options, job: job }));    
+      });
+    });
+  
+    self.route('post', 'progress', function(req, res) {
+      var _id = self.apos.launder.id(req.body._id);
+      return self.db.findOne({ _id: _id }, function(err, job) {
+        if (err) {
+          console.error(err);
+          return res.status(500).send('error');
+        }
+        if (!job) {
+          return respond({ notfound: true });
+        }
+        // % of completion rounded off to 2 decimal places
+        if (!job.total) {
+          job.percentage = 0;
+        } else {
+          job.percentage = (job.processed / job.total * 100).toFixed(2);
+        }
+        return respond({
+          job: job
+        });
+      });
+  
+      function respond(info) {
+        return res.send(self.render(req, 'progress', info));
+      }
+    });
+  };
 };

--- a/lib/modules/apostrophe-jobs/lib/routes.js
+++ b/lib/modules/apostrophe-jobs/lib/routes.js
@@ -19,7 +19,7 @@ module.exports = function(self, options) {
     self.route('post', 'modal', function(req, res) {
       var _id = self.apos.launder.id(req.body._id);
       return self.db.findOne({ _id: _id }, function(err, job) {
-        return res.send(self.render(req, 'managerModal', { options: self.options, job: job }));    
+        return res.send(self.render(req, 'modal', { options: self.options, job: job }));    
       });
     });
   
@@ -28,7 +28,7 @@ module.exports = function(self, options) {
       return self.db.findOne({ _id: _id }, function(err, job) {
         if (err) {
           console.error(err);
-          return res.status(500).send('error');
+          return res.send({ status: 'error' });
         }
         if (!job) {
           return respond({ notfound: true });
@@ -39,13 +39,11 @@ module.exports = function(self, options) {
         } else {
           job.percentage = (job.processed / job.total * 100).toFixed(2);
         }
-        return respond({
-          job: job
-        });
+        return respond(job);
       });
   
-      function respond(info) {
-        return res.send(self.render(req, 'progress', info));
+      function respond(job) {
+        return res.send({ status: 'ok', job: job, html: self.render(req, 'progress', { job: job }) });
       }
     });
   };

--- a/lib/modules/apostrophe-jobs/public/css/user.less
+++ b/lib/modules/apostrophe-jobs/public/css/user.less
@@ -1,0 +1,30 @@
+.apos-ui .apos-job-progress-container {
+  width: 50%;
+  margin: auto;
+  h3 {
+    font-size: 24px;
+    margin: 1em 0;
+  }
+  td, th {
+    padding: 0 1em 0.5em 0;
+    text-align: left;
+  }
+  .apos-job-progress {
+    text-align: center;
+    position: relative;
+    height: 2em;
+  }
+  .apos-job-progress-indicator {
+    height: 1.5em;
+    position: absolute;
+    background-color: @apos-red;
+    z-index: 0;
+  }
+  .apos-job-progress-percentage {
+    position: absolute;
+    z-index: 2;
+    color: @apos-blue;
+    text-align: center;
+    width: 100%;
+  }
+}

--- a/lib/modules/apostrophe-jobs/public/js/modal.js
+++ b/lib/modules/apostrophe-jobs/public/js/modal.js
@@ -13,6 +13,7 @@ apos.define('apostrophe-jobs-modal', {
     self.beforeShow = function(callback) {
       self._id = options.body._id;
       self.$el.find('[data-apos-job-done]').hide();
+      self.enableJobCancel();
       self.startProgress();
       return setImmediate(callback);
     };
@@ -42,6 +43,7 @@ apos.define('apostrophe-jobs-modal', {
     self.afterHide = function() {
       if (self.progressInterval) {
         clearInterval(self.progressInterval);
+        self.progressInterval = null;
       }
       if (self.options.change) {
         apos.change(self.options.change);
@@ -53,29 +55,36 @@ apos.define('apostrophe-jobs-modal', {
       }
     };
     
-    self.hideForm = function() {
-      self.$el.find('[data-apos-form]').hide();
-    };
-
     self.beforeCancel = function(callback) {
-      if ((!self._id) || (self.finished)) {
-        // Easy to cancel when we haven't even started yet;
-        // impossible to cancel once we're finished
-        return setImmediate(callback);
+      if (self.progressInterval) {
+        return callback('running');
+      }
+      return callback(null);
+    };
+    
+    self.halt = function() {
+      if (!self.progressInterval) {
+        return;
       }
       apos.ui.globalBusy(true);
       self.canceling = true;
-      if (self.progressInterval) {
-        clearInterval(self.progressInterval);
-      }
       return self.api('cancel', { _id: self._id }, function(data) {
+        if (data.status !== 'ok') {
+          return fail();
+        }
         apos.ui.globalBusy(false);
-        return callback(null);
       }, function(err) {
-        // Even if some sort of network error occurs we can't do anything useful
-        // at this point by keeping the modal up in this situation
+        return fail();
+      });
+      function fail() {
         apos.ui.globalBusy(false);
-        return callback(null);
+        apos.notify('An error occurred canceling the operation. Please try again.', { type: 'error' });
+      }
+    }
+    
+    self.enableJobCancel = function() {
+      self.link('apos-job-cancel', function() {
+        self.halt();
       });
     };
 

--- a/lib/modules/apostrophe-jobs/public/js/modal.js
+++ b/lib/modules/apostrophe-jobs/public/js/modal.js
@@ -31,6 +31,9 @@ apos.define('apostrophe-jobs-modal', {
             self.$el.find('[data-apos-job-done]').show();
             clearInterval(self.progressInterval);
             self.progressInterval = null;
+            if (data.job.status === 'completed') {
+              self.results = data.job.results;
+            }
           }
         }
       });
@@ -42,6 +45,11 @@ apos.define('apostrophe-jobs-modal', {
       }
       if (self.options.change) {
         apos.change(self.options.change);
+      }
+      if (self.results !== undefined) {
+        if (self.options.success) {
+          self.options.success(self.results);
+        }
       }
     };
     

--- a/lib/modules/apostrophe-jobs/public/js/modal.js
+++ b/lib/modules/apostrophe-jobs/public/js/modal.js
@@ -1,0 +1,73 @@
+// A modal for importing pieces
+
+apos.define('apostrophe-jobs-modal', {
+
+  extend: 'apostrophe-modal',
+
+  source: 'modal',
+
+  construct: function(self, options) {
+
+    self.canceling = false;
+
+    self.beforeShow = function(callback) {
+      self.jobId = options.body.jobId;
+      self.startProgress();
+      return setImmediate(callback);
+    };
+    
+    self.startProgress = function() {
+      self.progressInterval = setInterval(self.updateProgress, 1000);
+      self.updateProgress();
+    };
+    
+    self.updateProgress = function() {
+      return self.api('progress', { _id: self.jobId }, function(data) {
+        if (data.status === 'ok') {
+          self.$el.find('[data-apos-jobs-progress-container]').html(data.html);
+        }
+        if (data.job.finished) {
+          self.$el.find('.apos-jobs-cancel').hide();
+          self.$el.find('.apos-jobs-done').show();
+          self.finished = true;
+        }
+      });
+    };
+    
+    self.afterHide = function() {
+      if (self.progressInterval) {
+        clearInterval(self.progressInterval);
+      }
+      if (self.finished) {
+        apos.change(self.manager.name);
+      }
+    };
+    
+    self.hideForm = function() {
+      self.$el.find('[data-apos-form]').hide();
+    };
+
+    self.beforeCancel = function(callback) {
+      if ((!self.jobId) || (self.finished)) {
+        // Easy to cancel when we haven't even started yet;
+        // impossible to cancel once we're finished
+        return setImmediate(callback);
+      }
+      apos.ui.globalBusy(true);
+      self.canceling = true;
+      if (self.progressInterval) {
+        clearInterval(self.progressInterval);
+      }
+      return self.api('import-cancel', { _id: self.jobId }, function(data) {
+        apos.ui.globalBusy(false);
+        return callback(null);
+      }, function(err) {
+        // Even if some sort of network error occurs we can't do anything useful
+        // at this point by keeping the modal up in this situation
+        apos.ui.globalBusy(false);
+        return callback(null);
+      });
+    };
+
+  }
+});

--- a/lib/modules/apostrophe-jobs/public/js/modal.js
+++ b/lib/modules/apostrophe-jobs/public/js/modal.js
@@ -11,7 +11,8 @@ apos.define('apostrophe-jobs-modal', {
     self.canceling = false;
 
     self.beforeShow = function(callback) {
-      self.jobId = options.body.jobId;
+      self._id = options.body._id;
+      self.$el.find('[data-apos-job-done]').hide();
       self.startProgress();
       return setImmediate(callback);
     };
@@ -22,14 +23,15 @@ apos.define('apostrophe-jobs-modal', {
     };
     
     self.updateProgress = function() {
-      return self.api('progress', { _id: self.jobId }, function(data) {
+      return self.api('progress', { _id: self._id }, function(data) {
         if (data.status === 'ok') {
-          self.$el.find('[data-apos-jobs-progress-container]').html(data.html);
-        }
-        if (data.job.finished) {
-          self.$el.find('.apos-jobs-cancel').hide();
-          self.$el.find('.apos-jobs-done').show();
-          self.finished = true;
+          self.$el.find('[data-apos-job-progress-container]').html(data.html);
+          if (data.job.ended) {
+            self.$el.find('[data-apos-job-cancel],[data-apos-job-stop]').hide();
+            self.$el.find('[data-apos-job-done]').show();
+            clearInterval(self.progressInterval);
+            self.progressInterval = null;
+          }
         }
       });
     };
@@ -38,8 +40,8 @@ apos.define('apostrophe-jobs-modal', {
       if (self.progressInterval) {
         clearInterval(self.progressInterval);
       }
-      if (self.finished) {
-        apos.change(self.manager.name);
+      if (self.options.change) {
+        apos.change(self.options.change);
       }
     };
     
@@ -48,7 +50,7 @@ apos.define('apostrophe-jobs-modal', {
     };
 
     self.beforeCancel = function(callback) {
-      if ((!self.jobId) || (self.finished)) {
+      if ((!self._id) || (self.finished)) {
         // Easy to cancel when we haven't even started yet;
         // impossible to cancel once we're finished
         return setImmediate(callback);
@@ -58,7 +60,7 @@ apos.define('apostrophe-jobs-modal', {
       if (self.progressInterval) {
         clearInterval(self.progressInterval);
       }
-      return self.api('import-cancel', { _id: self.jobId }, function(data) {
+      return self.api('cancel', { _id: self._id }, function(data) {
         apos.ui.globalBusy(false);
         return callback(null);
       }, function(err) {

--- a/lib/modules/apostrophe-jobs/public/js/user.js
+++ b/lib/modules/apostrophe-jobs/public/js/user.js
@@ -1,0 +1,11 @@
+apos.define('apostrophe-jobs', {
+  construct: function(self, options) {
+    self.progress = function(jobId) {
+      apos.create(self.__meta.name + '-modal', {
+        body: {
+          jobId: jobId
+        }
+      });
+    };
+  }
+});

--- a/lib/modules/apostrophe-jobs/public/js/user.js
+++ b/lib/modules/apostrophe-jobs/public/js/user.js
@@ -1,11 +1,17 @@
 apos.define('apostrophe-jobs', {
+  extend: 'apostrophe-context',
   construct: function(self, options) {
-    self.progress = function(jobId) {
-      apos.create(self.__meta.name + '-modal', {
+    // Start a progress display for the given job id. 
+    // If options.change is set, an `apos.change` call is
+    // made with that argument when the progress display
+    // is dismissed.
+    self.progress = function(jobId, options) {
+      apos.create(self.__meta.name + '-modal', _.assign({
         body: {
-          jobId: jobId
-        }
-      });
+          _id: jobId
+        },
+        change: options && options.change
+      }, self.options));
     };
   }
 });

--- a/lib/modules/apostrophe-jobs/public/js/user.js
+++ b/lib/modules/apostrophe-jobs/public/js/user.js
@@ -2,16 +2,24 @@ apos.define('apostrophe-jobs', {
   extend: 'apostrophe-context',
   construct: function(self, options) {
     // Start a progress display for the given job id. 
-    // If options.change is set, an `apos.change` call is
+    // If `options.change` is set, an `apos.change` call is
     // made with that argument when the progress display
     // is dismissed.
+    //
+    // If `options.success` is set, it is
+    // invoked after all items have been processed and
+    // receives the `results` property provided by
+    // the server at the end of the job; it is not invoked
+    // if the operation was stopped or canceled by the user.
+    // Note that `options.success` does not take a callback
+    // because the modal has already been dismissed.
+    
     self.progress = function(jobId, options) {
       apos.create(self.__meta.name + '-modal', _.assign({
         body: {
           _id: jobId
         },
-        change: options && options.change
-      }, self.options));
+      }, self.options, options || {}));
     };
   }
 });

--- a/lib/modules/apostrophe-jobs/views/modal.html
+++ b/lib/modules/apostrophe-jobs/views/modal.html
@@ -1,0 +1,33 @@
+{%- extends "apostrophe-modal:base.html" -%}
+{%- import 'apostrophe-ui:components/buttons.html' as buttons -%}
+
+{%- block modalClass -%}
+  apos-job-modal apos-ui-modal-no-sidebar
+{%- endblock -%}
+
+{%- block controls -%}
+  {% if data.job.canCancel %}
+    {{ buttons.base('Cancel', { action: 'cancel' }, 'apos-button--minor apos-job-cancel') }}
+  {% elif data.job.canStop %}
+  {{ buttons.base('Stop', { action: 'cancel' }, 'apos-button--minor apos-job-stop') }}
+  {% endif %}
+  {{ buttons.major('Done', { action: 'cancel' }, 'apos-button--major apos-job-done') }}
+{%- endblock -%}
+
+{%- block label -%}
+  {# Default is not great, you should supply a title! #}
+  {{ __(data.options.title or 'Progress') }}
+{%- endblock -%}
+
+{%- block body -%}
+  {# ajax constantly repopulates me, see progress.html #}
+  <div data-apos-job-progress-container class="apos-job-progress-container">
+    {% include "progress.html" %}
+  </div>
+  </div>
+{%- endblock -%}
+
+{%- block instructions -%}
+  {# Often none needed #}
+  {{ data.options.instructions }}
+{%- endblock -%}

--- a/lib/modules/apostrophe-jobs/views/modal.html
+++ b/lib/modules/apostrophe-jobs/views/modal.html
@@ -17,7 +17,7 @@
 
 {%- block label -%}
   {# Default is not great, you should supply a title! #}
-  {{ __(data.options.title or 'Progress') }}
+  {{ __(data.job.labels.title or 'Progress') }}
 {%- endblock -%}
 
 {%- block body -%}

--- a/lib/modules/apostrophe-jobs/views/modal.html
+++ b/lib/modules/apostrophe-jobs/views/modal.html
@@ -7,10 +7,10 @@
 
 {%- block controls -%}
   {% if data.job.canCancel %}
-  {{ buttons.minor('Cancel', { action: 'cancel' }) }}
-    {{ buttons.minor('Cancel', { action: 'cancel', attributes: 'data-apos-job-cancel' }) }}
+    {{ buttons.minor('Cancel', { action: 'job-cancel', attributes: 'data-apos-job-cancel' }) }}
   {% elif data.job.canStop %}
-  {{ buttons.minor('Stop', { action: 'cancel', attributes: 'data-apos-job-stop' }) }}
+    {# It is correct to say job-cancel here, the backend will know which #}
+    {{ buttons.minor('Stop', { action: 'job-cancel', attributes: 'data-apos-job-stop' }) }}
   {% endif %}
   {{ buttons.major('Done', { action: 'cancel', attributes: 'data-apos-job-done' }) }}
 {%- endblock -%}
@@ -30,5 +30,5 @@
 
 {%- block instructions -%}
   {# Often none needed #}
-  {{ data.options.instructions }}
+  {{ data.job.labels.instructions }}
 {%- endblock -%}

--- a/lib/modules/apostrophe-jobs/views/modal.html
+++ b/lib/modules/apostrophe-jobs/views/modal.html
@@ -7,11 +7,12 @@
 
 {%- block controls -%}
   {% if data.job.canCancel %}
-    {{ buttons.base('Cancel', { action: 'cancel' }, 'apos-button--minor apos-job-cancel') }}
+  {{ buttons.minor('Cancel', { action: 'cancel' }) }}
+    {{ buttons.minor('Cancel', { action: 'cancel', attributes: 'data-apos-job-cancel' }) }}
   {% elif data.job.canStop %}
-  {{ buttons.base('Stop', { action: 'cancel' }, 'apos-button--minor apos-job-stop') }}
+  {{ buttons.minor('Stop', { action: 'cancel', attributes: 'data-apos-job-stop' }) }}
   {% endif %}
-  {{ buttons.major('Done', { action: 'cancel' }, 'apos-button--major apos-job-done') }}
+  {{ buttons.major('Done', { action: 'cancel', attributes: 'data-apos-job-done' }) }}
 {%- endblock -%}
 
 {%- block label -%}

--- a/lib/modules/apostrophe-jobs/views/progress.html
+++ b/lib/modules/apostrophe-jobs/views/progress.html
@@ -1,0 +1,24 @@
+{% if data.notfound %}
+  {# Unlikely in production, but likely in development where dbs get reset #}
+  <h3 class="apos-job-failed">{{ __('The job no longer exists') }}</h3>
+{% elif data.job.status == 'failed' %}
+  <h3 class="apos-job-failed">{{ __(data.job.labels.failed or 'Failed') }}</h3>
+{% elif data.job.status == 'completed' %}
+  <h3>{{ __(data.job.labels.completed or 'Completed') }}</h3>
+  <table class="apos-job-results">
+    <tr>
+      <th>{{ __(data.job.labels.good or 'Successful') }}</th><td>{{ data.job.good }}</td>
+    </tr>
+    <tr class="{{ 'apos-job-errors' if data.job.errors }}">
+      <th>{{ __(data.job.labels.bad or 'Errors') }}</th><td>{{ data.job.bad }}</td>
+    </tr>
+  </table>
+{% else %}
+  <h3>{{ __(data.job.labels.running or 'In Progress...') }}</h3>
+  <div class="apos-job-progress" data-apos-progress>
+    <div class="apos-job-progress-percentage">{{ data.job.percentage }}%</div>
+    <div class="apos-job-progress-indicator"
+      data-apos-progress-indicator
+      style="width: {{ data.job.percentage }}%"></div>
+  </div>
+{% endif %}

--- a/lib/modules/apostrophe-jobs/views/progress.html
+++ b/lib/modules/apostrophe-jobs/views/progress.html
@@ -1,10 +1,16 @@
-{% if data.notfound %}
+{% if data.job.notfound %}
   {# Unlikely in production, but likely in development where dbs get reset #}
   <h3 class="apos-job-failed">{{ __('The job no longer exists') }}</h3>
 {% elif data.job.status == 'failed' %}
   <h3 class="apos-job-failed">{{ __(data.job.labels.failed or 'Failed') }}</h3>
 {% elif data.job.status == 'completed' %}
   <h3>{{ __(data.job.labels.completed or 'Completed') }}</h3>
+{% else %}
+  <h3>{{ __(data.job.labels.running or 'In Progress...') }}</h3>
+{% endif %}
+{# Different jobs might give us more or less to work with. #}
+{# Don't display a table unless we have info on processed items #}
+{% if data.job.processed %}
   <table class="apos-job-results">
     <tr>
       <th>{{ __(data.job.labels.good or 'Successful') }}</th><td>{{ data.job.good }}</td>
@@ -13,8 +19,9 @@
       <th>{{ __(data.job.labels.bad or 'Errors') }}</th><td>{{ data.job.bad }}</td>
     </tr>
   </table>
-{% else %}
-  <h3>{{ __(data.job.labels.running or 'In Progress...') }}</h3>
+{% endif %}
+{# Don't display a progress bar unless we can compute it from a known total #}
+{% if data.job.total %}
   <div class="apos-job-progress" data-apos-progress>
     <div class="apos-job-progress-percentage">{{ data.job.percentage }}%</div>
     <div class="apos-job-progress-indicator"

--- a/lib/modules/apostrophe-jobs/views/progress.html
+++ b/lib/modules/apostrophe-jobs/views/progress.html
@@ -1,8 +1,18 @@
 {% if data.job.notfound %}
   {# Unlikely in production, but likely in development where dbs get reset #}
   <h3 class="apos-job-failed">{{ __('The job no longer exists') }}</h3>
+{% elif data.job.canceling %}
+  {% if data.job.canCancel %}
+    <h3 class="apos-job-failed">{{ __(data.job.labels.canceling or 'Canceling...') }}</h3>
+  {% else %}
+    <h3 class="apos-job-failed">{{ __(data.job.labels.stopping or 'Stopping...') }}</h3>
+  {% endif %}
 {% elif data.job.status == 'failed' %}
   <h3 class="apos-job-failed">{{ __(data.job.labels.failed or 'Failed') }}</h3>
+{% elif data.job.status == 'canceled' %}
+  <h3 class="apos-job-failed">{{ __(data.job.labels.canceled or 'Canceled') }}</h3>
+{% elif data.job.status == 'stopped' %}
+  <h3 class="apos-job-failed">{{ __(data.job.labels.stopped or 'Stopped') }}</h3>
 {% elif data.job.status == 'completed' %}
   <h3>{{ __(data.job.labels.completed or 'Completed') }}</h3>
 {% else %}

--- a/lib/modules/apostrophe-jobs/views/progress.html
+++ b/lib/modules/apostrophe-jobs/views/progress.html
@@ -16,16 +16,16 @@
       <th>{{ __(data.job.labels.good or 'Successful') }}</th><td>{{ data.job.good }}</td>
     </tr>
     <tr class="{{ 'apos-job-errors' if data.job.errors }}">
-      <th>{{ __(data.job.labels.bad or 'Errors') }}</th><td>{{ data.job.bad }}</td>
+      <th>{{ __(data.job.labels.bad or 'Errors') }}</th><td>{{ data.job.bad or 0 }}</td>
     </tr>
   </table>
 {% endif %}
 {# Don't display a progress bar unless we can compute it from a known total #}
 {% if data.job.total %}
   <div class="apos-job-progress" data-apos-progress>
-    <div class="apos-job-progress-percentage">{{ data.job.percentage }}%</div>
     <div class="apos-job-progress-indicator"
       data-apos-progress-indicator
       style="width: {{ data.job.percentage }}%"></div>
+    <div class="apos-job-progress-percentage">{{ data.job.percentage }}%</div>
   </div>
 {% endif %}

--- a/lib/modules/apostrophe-pieces/index.js
+++ b/lib/modules/apostrophe-pieces/index.js
@@ -138,7 +138,7 @@ module.exports = {
         unlessFilter: { 
           published: true
         },
-        requiredField: 'publish'
+        requiredField: 'published'
       },
       {
         name: 'unpublish',
@@ -146,7 +146,7 @@ module.exports = {
         unlessFilter: {
           published: false
         },
-        requiredField: 'publish'
+        requiredField: 'published'
       },
       {
         name: 'tag',

--- a/lib/modules/apostrophe-pieces/lib/api.js
+++ b/lib/modules/apostrophe-pieces/lib/api.js
@@ -711,7 +711,12 @@ module.exports = function(self, options) {
   // for the batch operation. If there is no schema it will be
   // an empty object.
   //
-  // Replies to the request with { status: 'ok', data: piece }
+  // If `req.body.job` is truthy, replies immediately to the request with
+  // `{ status: 'ok', jobId: 'cxxxx' }`. The `jobId` can then
+  // be passed to `apos.jobs.start()` on the browser side to
+  // monitor progress.
+  //
+  // Otherwise, replies to the request with { status: 'ok', data: piece }
   // on success. If `ids` rather than `_id` were specified,
   // `data` is an empty object.
   //
@@ -726,6 +731,8 @@ module.exports = function(self, options) {
     var singlePiece;
     var res = req.res;
     var data;
+    var job;
+    var stopping = false;
     if (req.body._id) {
       ids = [ self.apos.launder.id(req.body._id) ];
     } else if (req.body.ids) {
@@ -734,16 +741,60 @@ module.exports = function(self, options) {
       return self.apiResponse(res, 'invalid');
     }
     return async.series([
+      startJob,
       convert,
       run
     ], function(err) {
       if (err) {
         console.error(err);
+        if (job) {
+          return self.apos.jobs.end(job, 'failed', function(err) {
+            if (err) {
+              // Not a lot we can do about this since we already
+              // stopped talking to the user 
+              console.error(err);
+            }
+          });
+        }
         return self.apiResponse(res, 'error');
       } else {
+        if (job) {
+          return self.apos.jobs.end(job, 'completed', function(err) {
+            if (err) {
+              // Not a lot we can do about this since we already
+              // stopped talking to the user 
+              console.error(err);
+            }
+          });
+        }
         return self.updateResponse(req, res, null, singlePiece || {});
       }
     });
+    
+    function startJob(callback) {
+      if (!req.body.job) {
+        return callback(null);
+      }
+      return self.apos.jobs.start({
+        stop: function(callback) {
+          stopping = callback;
+          return callback(null);
+        }
+      }, function(err, _job) {
+        if (err) {
+          // Failed to insert the job. Don't continue the series,
+          // just tell the browser that.
+          return res.send({ status: 'error' });
+        }
+        job = _job;
+        // DELIBERATE FALLTHROUGH: respond to the browser
+        // *right now* with the job id, then continue the
+        // series WITHOUT ever touching `res` again. The
+        // browser will call back for progress.
+        res.send({ status: 'ok', jobId: job._id });
+        return callback(null);
+      });
+    }
 
     function convert(callback) {
       data = self.apos.schemas.newInstance(schema);
@@ -752,19 +803,41 @@ module.exports = function(self, options) {
     
     function run(callback) {
       return async.eachSeries(ids, function(id, callback) {
+        if (stopping) {
+          // That's it, abandon the eachSeries
+          return stopping(null);
+        }
         return self.findForEditing(req, { _id: id })
           .toObject(function(err, piece) {
             if (err) {
+              console.error(err);
+              if (job) {
+                job.bad();
+                return callback(null);
+              }
               return callback(err);
             }
             if (!piece) {
+              if (job) {
+                job.bad();
+              }
               // Don't flag the whole thing if something no longer exists
               return callback(null);
             }
             if (req.body._id && (!singlePiece)) {
               singlePiece = piece;
             }
-            return change(req, piece, data, callback);
+            return change(req, piece, data, function(err) {
+              if (job) {
+                if (err) {
+                  job.bad();
+                } else {
+                  job.good();
+                }
+                return callback(null);
+              }
+              return callback(err);
+            });
           }
         );
       }, callback); 

--- a/lib/modules/apostrophe-pieces/lib/api.js
+++ b/lib/modules/apostrophe-pieces/lib/api.js
@@ -713,7 +713,7 @@ module.exports = function(self, options) {
   //
   // If `req.body.job` is truthy, replies immediately to the request with
   // `{ status: 'ok', jobId: 'cxxxx' }`. The `jobId` can then
-  // be passed to `apos.jobs.start()` on the browser side to
+  // be passed to `apos.modules['apostrophe-jobs'].start()` on the rowser side to
   // monitor progress.
   //
   // Otherwise, replies to the request with { status: 'ok', data: piece }
@@ -733,6 +733,7 @@ module.exports = function(self, options) {
     var data;
     var job;
     var stopping = false;
+    var jobs = self.apos.modules['apostrophe-jobs'];
     if (req.body._id) {
       ids = [ self.apos.launder.id(req.body._id) ];
     } else if (req.body.ids) {
@@ -748,7 +749,7 @@ module.exports = function(self, options) {
       if (err) {
         console.error(err);
         if (job) {
-          return self.apos.jobs.end(job, 'failed', function(err) {
+          return jobs.end(job, 'failed', function(err) {
             if (err) {
               // Not a lot we can do about this since we already
               // stopped talking to the user 
@@ -759,7 +760,7 @@ module.exports = function(self, options) {
         return self.apiResponse(res, 'error');
       } else {
         if (job) {
-          return self.apos.jobs.end(job, 'completed', function(err) {
+          return jobs.end(job, 'completed', function(err) {
             if (err) {
               // Not a lot we can do about this since we already
               // stopped talking to the user 
@@ -775,7 +776,7 @@ module.exports = function(self, options) {
       if (!req.body.job) {
         return callback(null);
       }
-      return self.apos.jobs.start({
+      return jobs.start({
         stop: function(callback) {
           stopping = callback;
           return callback(null);
@@ -812,14 +813,14 @@ module.exports = function(self, options) {
             if (err) {
               console.error(err);
               if (job) {
-                job.bad();
+                jobs.bad(job);
                 return callback(null);
               }
               return callback(err);
             }
             if (!piece) {
               if (job) {
-                job.bad();
+                jobs.bad(job);
               }
               // Don't flag the whole thing if something no longer exists
               return callback(null);
@@ -830,9 +831,9 @@ module.exports = function(self, options) {
             return change(req, piece, data, function(err) {
               if (job) {
                 if (err) {
-                  job.bad();
+                  jobs.bad(job);
                 } else {
-                  job.good();
+                  jobs.good(job);
                 }
                 return callback(null);
               }

--- a/lib/modules/apostrophe-pieces/lib/api.js
+++ b/lib/modules/apostrophe-pieces/lib/api.js
@@ -702,7 +702,7 @@ module.exports = function(self, options) {
   };
 
   // Implements a simple batch operation like publish or unpublish.
-  // Pass `req`, the `name` of a configurated batch operation, and
+  // Pass `req`, the `name` of a configured batch operation, and
   // and a function that accepts (req, piece, data, callback),
   // performs the modification on that one piece (including calling
   // `update` if appropriate), and invokes its callback.
@@ -727,125 +727,35 @@ module.exports = function(self, options) {
   self.batchSimpleRoute = function(req, name, change) {
     var batchOperation = _.find(self.options.batchOperations, { name: name });
     var schema = batchOperation.schema || [];
-    var query;
-    var singlePiece;
-    var res = req.res;
-    var data;
-    var job;
-    var stopping = false;
-    var jobs = self.apos.modules['apostrophe-jobs'];
-    if (req.body._id) {
-      ids = [ self.apos.launder.id(req.body._id) ];
-    } else if (req.body.ids) {
-      ids = self.apos.launder.ids(req.body.ids);
-    } else {
-      return self.apiResponse(res, 'invalid');
-    }
-    return async.series([
-      startJob,
-      convert,
-      run
-    ], function(err) {
+
+    var data = self.apos.schemas.newInstance(schema);
+    return self.apos.schemas.convert(req, schema, 'form', req.body, data, function(err) {
       if (err) {
-        console.error(err);
-        if (job) {
-          return jobs.end(job, 'failed', function(err) {
-            if (err) {
-              // Not a lot we can do about this since we already
-              // stopped talking to the user 
-              console.error(err);
-            }
-          });
-        }
-        return self.apiResponse(res, 'error');
-      } else {
-        if (job) {
-          return jobs.end(job, 'completed', function(err) {
-            if (err) {
-              // Not a lot we can do about this since we already
-              // stopped talking to the user 
-              console.error(err);
-            }
-          });
-        }
-        return self.updateResponse(req, res, null, singlePiece || {});
+        return res.send({ status: 'invalid' });
       }
+      return runJob();
     });
     
-    function startJob(callback) {
-      if (!req.body.job) {
-        return callback(null);
-      }
-      return jobs.start({
-        stop: function(job, callback) {
-          stopping = callback;
-          return;
+    function runJob() {
+      return self.apos.modules['apostrophe-jobs'].run(req, one, {
+        labels: {
+          title: batchOperation.progressLabel || batchOperation.buttonLabel || batchOperation.label
         }
-      }, function(err, _job) {
-        if (err) {
-          // Failed to insert the job. Don't continue the series,
-          // just tell the browser that.
-          return res.send({ status: 'error' });
-        }
-        job = _job;
-        // DELIBERATE FALLTHROUGH: respond to the browser
-        // *right now* with the job id, then continue the
-        // series WITHOUT ever touching `res` again. The
-        // browser will call back for progress.
-        res.send({ status: 'ok', jobId: job._id });
-        return callback(null);
       });
     }
-
-    function convert(callback) {
-      data = self.apos.schemas.newInstance(schema);
-      return self.apos.schemas.convert(req, schema, 'form', req.body, data, callback);
+    
+    function one(req, id, callback) {
+      return self.findForEditing(req, { _id: id }).toObject(function(err, piece) {
+        if (err) {
+          return callback(err);
+        }
+        if (!piece) {
+          return callback('notfound');
+        }
+        return change(req, piece, data, callback);
+      });
     }
     
-    function run(callback) {
-      return async.eachSeries(ids, function(id, callback) {
-        if (stopping) {
-          // That's it, abandon the eachSeries
-          return stopping(null);
-        }
-        return self.findForEditing(req, { _id: id })
-          .toObject(function(err, piece) {
-            if (err) {
-              console.error(err);
-              if (job) {
-                jobs.bad(job);
-                return callback(null);
-              }
-              return callback(err);
-            }
-            if (!piece) {
-              if (job) {
-                jobs.bad(job);
-              }
-              // Don't flag the whole thing if something no longer exists
-              return callback(null);
-            }
-            if (req.body._id && (!singlePiece)) {
-              singlePiece = piece;
-            }
-            return change(req, piece, data, function(err) {
-              return setTimeout(function() {
-                if (job) {
-                  if (err) {
-                    jobs.bad(job);
-                  } else {
-                    jobs.good(job);
-                  }
-                  return callback(null);
-                }
-                return callback(err);
-              }, 2000);
-            });
-          }
-        );
-      }, callback); 
-    }
-
   };
 
   // Accept a piece found at `req.body`, via

--- a/lib/modules/apostrophe-pieces/lib/api.js
+++ b/lib/modules/apostrophe-pieces/lib/api.js
@@ -777,9 +777,9 @@ module.exports = function(self, options) {
         return callback(null);
       }
       return jobs.start({
-        stop: function(callback) {
+        stop: function(job, callback) {
           stopping = callback;
-          return callback(null);
+          return;
         }
       }, function(err, _job) {
         if (err) {
@@ -829,15 +829,17 @@ module.exports = function(self, options) {
               singlePiece = piece;
             }
             return change(req, piece, data, function(err) {
-              if (job) {
-                if (err) {
-                  jobs.bad(job);
-                } else {
-                  jobs.good(job);
+              return setTimeout(function() {
+                if (job) {
+                  if (err) {
+                    jobs.bad(job);
+                  } else {
+                    jobs.good(job);
+                  }
+                  return callback(null);
                 }
-                return callback(null);
-              }
-              return callback(err);
+                return callback(err);
+              }, 2000);
             });
           }
         );

--- a/lib/modules/apostrophe-pieces/lib/routes.js
+++ b/lib/modules/apostrophe-pieces/lib/routes.js
@@ -180,15 +180,36 @@ module.exports = function(self, options) {
   };
 
   // Trash one piece (via req.body._id) or many (via req.body.ids).
+  // Responds as a job if req.body.job is truthy
 
   self.routes.trash = function(req, res) {
+
     var ids;
+
+    if (req.body.job) {
+      // New way
+      return self.apos.modules['apostrophe-jobs'].run(req, function(req, id, callback) {
+        return one(id, callback);
+      }, {
+        label: {
+          title: 'Trash'
+        }
+      });
+    }
+
+    // bc and single id case
+
     if (Array.isArray(req.body.ids)) {
       ids = self.apos.launder.ids(req.body.ids);
     } else {
       ids = [ self.apos.launder.id(req.body._id) ];
     }
-    return async.eachSeries(ids, function(id, callback) {
+
+    return async.eachSeries(ids, one, function(err) {
+      return self.trashResponse(req, res, err, {});
+    });
+    
+    function one(id, callback) {
       return async.series({
         before: function(callback) {
           return self.beforeTrash(req, id, callback);
@@ -200,21 +221,38 @@ module.exports = function(self, options) {
           return self.afterTrash(req, id, callback)
         }
       }, callback);
-    }, function(err) {
-      return self.trashResponse(req, res, err, {});
-    });
+    }
+
   };
 
   // Rescue one piece (via req.body._id) or many (via req.body.ids).
+  // Responds as a job if req.body.job is truthy
 
   self.routes.rescue = function(req, res) {
+
     var ids;
+
+    if (req.body.job) {
+      // New way
+      return self.apos.modules['apostrophe-jobs'].run(req, function(req, id, callback) {
+        return one(id, callback);
+      }, {
+        label: {
+          title: 'Rescue'
+        }
+      });
+    }
+
     if (Array.isArray(req.body.ids)) {
       ids = self.apos.launder.ids(req.body.ids);
     } else {
       ids = [ self.apos.launder.id(req.body._id) ];
     }
-    return async.eachSeries(ids, function(id, callback) {
+    return async.eachSeries(ids, one, function(err) {
+      return self.rescueResponse(req, res, err, {});
+    });
+
+    function one(id, callback) {
       return async.series({
         before: function(callback) {
           return self.beforeRescue(req, id, callback);
@@ -226,9 +264,8 @@ module.exports = function(self, options) {
           return self.afterRescue(req, id, callback)
         }
       }, callback);
-    }, function(err) {
-      return self.rescueResponse(req, res, err, {});
-    });
+    }
+
   };
   
   // Create one new piece via file upload, without the completion of other

--- a/lib/modules/apostrophe-pieces/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/manager-modal.js
@@ -422,7 +422,8 @@ apos.define('apostrophe-pieces-manager-modal', {
       }
 
       var data = {
-        ids: self.choices
+        ids: self.choices,
+        job: true
       };
 
       return async.series([ convert, dataSource, save ], function(err) {

--- a/lib/modules/apostrophe-pieces/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/manager-modal.js
@@ -465,6 +465,11 @@ apos.define('apostrophe-pieces-manager-modal', {
           if (result.status !== 'ok') {
             return callback('An error occurred. Please try again.');
           }
+          if (result.jobId) {
+            return apos.jobs.start(jobId, {
+              success: options.success
+            });
+          }
           if (options.success) {
             return options.success(result, callback);
           } else {

--- a/lib/modules/apostrophe-pieces/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/manager-modal.js
@@ -185,19 +185,20 @@ apos.define('apostrophe-pieces-manager-modal', {
         var disable = false;
         var $option;
         _.each(batchOperation.unlessFilter, function(val, key) {
+          var filterVal = self.currentFilters[key];
           if (val === true) {
-            if (self.currentFilters[key] === '1') {
+            if ((filterVal === true) || (filterVal === '1')) {
               disable = true;
             }
           } else if (val === false) {
-            if (self.currentFilters[key] === '0') {
+            if ((filterVal === false) || (filterVal === '0')) {
               disable = true;
             }
           } else if (val === null) {
-            if (self.currentFilters[key] === 'any') {
+            if (filterVal === 'any') {
               disable = true;
             }
-          } else if (val === self.currentFilters[key]) {
+          } else if (val === filterVal) {
             disable = true;
           }
         });
@@ -426,6 +427,10 @@ apos.define('apostrophe-pieces-manager-modal', {
         ids: self.choices,
         job: true
       };
+      
+      // So we don't still say "unpublish (4)" when there are
+      // now 0 visible things after unpublishing all 4
+      self.clearChoices();
 
       return async.series([ convert, dataSource, save ], function(err) {
         if (err) {

--- a/lib/modules/apostrophe-pieces/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-pieces/public/js/manager-modal.js
@@ -11,6 +11,7 @@ apos.define('apostrophe-pieces-manager-modal', {
 
     self.page = 1;
     self.schema = self.options.schema;
+    var jobs = apos.modules['apostrophe-jobs'];
 
     self.decorate = function() {
       if (options.decorate) {
@@ -467,8 +468,9 @@ apos.define('apostrophe-pieces-manager-modal', {
             return callback('An error occurred. Please try again.');
           }
           if (result.jobId) {
-            return apos.jobs.start(jobId, {
-              success: options.success
+            return jobs.progress(result.jobId, {
+              success: options.success,
+              change: self.options.name
             });
           }
           if (options.success) {

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -461,8 +461,6 @@ module.exports = {
         // if they are defined in the data, sanitize them normally;
         // otherwise leave them untouched. -Tom and Jimmy
         if (field.contextual && (from === 'form') && (!_.has(data, field.name))) {
-          console.log('skipping ' + field.name);
-          console.log(data);
           return setImmediate(callback);
         }
         var convert = self.fieldTypes[field.type].converters && self.fieldTypes[field.type].converters[from];


### PR DESCRIPTION
From the apostrophe-jobs docs:

The `apostrophe-jobs` module runs long-running jobs in response
to user actions. Batch operations on pieces are a good example.

The `apostrophe-jobs` module makes it simple to implement
progress display, avoid server timeouts during long operations,
and implement a "stop" button.

See the `run` method for the easiest way to use this module.
The `run` method allows you to implement routes that are designed
to be paired with the `progress` method of this module on
the browser side. All you need to do is make sure the
ids are posted to your route and then write a function that
can carry out the operation on one id.

If you just want to add a new batch operation for pieces,
see the examples already in `apostrophe-pieces` and those added
by the `apostrophe-workflow` module. You don't need to go
directly to this module for that case.

If your operation doesn't break down neatly into repeated operations
on single documents, look into calling the `start` method and friends
directly from your code.

The `apostrophe-jobs` module DOES NOT have anything to do with
cron jobs or command line tasks.
