### PR TITLE
fix: fill attachment length on insert

### DIFF
--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -48,7 +48,6 @@ module.exports = function(self, options) {
     var image = group.image;
     var info = {
       _id: self.apos.utils.generateId(),
-      length: file.length,
       group: group.name,
       createdAt: new Date(),
       name: self.apos.utils.slugify(path.basename(file.name, path.extname(file.name))),
@@ -62,6 +61,16 @@ module.exports = function(self, options) {
         return callback(null);
       }
       return callback(self.apos.permissions.can(req, 'edit-attachment') ? null : 'forbidden');
+    }
+
+    function length(callback) {
+      return self.apos.utils.fileSizeInBytes(file.path, function(err, size) {
+        if (err) {
+          return callback(err);
+        }
+        info.length = size;
+        return callback(null);
+      });
     }
 
     function md5(callback) {
@@ -107,7 +116,7 @@ module.exports = function(self, options) {
       return self.db.insert(info, callback);
     }
 
-    return async.series([ permissions, md5, upload, remember ], function(err) {
+    return async.series([ permissions, length, md5, upload, remember ], function(err) {
       return callback(err, info);
     });
   };
@@ -153,6 +162,18 @@ module.exports = function(self, options) {
         function(callback) {
           self.uploadfs.copyImageIn(tempFile, croppedFile, { crop: crop }, callback);
         },
+        // Question: enable this is if we needed length for cropped images
+        // function (callback) {
+        //   // TODO: is localPath correct when using alternate backend: s3 or others ?
+        //   var localPath = self.uploadfsSettings.uploadsPath + croppedFile;
+        //   return self.apos.utils.fileSizeInBytes(localPath, function(err, size) {
+        //     if (err) {
+        //       return callback(err);
+        //     }
+        //     crop.length = size;
+        //     return callback(null);
+        //   });
+        // },
         function(callback) {
           info.crops.push(crop);
           self.db.update({ _id: info._id }, info, callback);

--- a/lib/modules/apostrophe-schemas/index.js
+++ b/lib/modules/apostrophe-schemas/index.js
@@ -880,7 +880,7 @@ module.exports = {
         }
       },
       isEmpty: function(field, value) {
-        return self.apos.areas.isEmpty({ area: area });
+        return self.apos.areas.isEmpty({ area: value });
       },
       bless: function(req, field) {
         if (field.options && field.options.widgets) {
@@ -895,7 +895,7 @@ module.exports = {
       name: 'singleton',
       extend: 'area',
       isEmpty: function(field, value) {
-        return self.apos.areas.isEmptySingleton({ area: area, type: field.widgetType });
+        return self.apos.areas.isEmptySingleton({ area: value, type: field.widgetType });
       },
       bless: function(req, field) {
         self.apos.utils.bless(req, field.options || {}, 'widget', field.widgetType);

--- a/lib/modules/apostrophe-utils/lib/api.js
+++ b/lib/modules/apostrophe-utils/lib/api.js
@@ -232,6 +232,16 @@ module.exports = function(self, options) {
     });
   };
 
+  // get file size in bytes. Delivers `null`, `integer` to callback.
+  self.fileSizeInBytes = function(filename, callback) {
+    return fs.stat(filename, function(err, stats) {
+      if (err) {
+        return callback(err);
+      }
+      return callback(null, stats.size);
+    });
+  };
+
   // Turn the provided string into a string suitable for use as a slug.
   // ONE punctuation character normally forbidden in slugs may
   // optionally be permitted by specifying it via options.allow.


### PR DESCRIPTION
Hello,

I was giving a try to your amazing framework, and I have seen that there was something missing in attachment insertion (upload or copy), from what I could test, I saw that the file length was present in data returned by uploadfs (as size field and not length), but in case of a copy, this info is not present, so I have added an utility function to get file size in bytes (in utils) and use it to fill the length property before inserting.

I also notice that there was a typo in schema for area and singleton field type in the isEmpty method.
