### PR TITLE
Use reference tracking to make attachments inaccessible when none of …

### DIFF
--- a/lib/modules/apostrophe-attachments/index.js
+++ b/lib/modules/apostrophe-attachments/index.js
@@ -91,6 +91,7 @@ module.exports = {
       self.pushCreateSingleton();
       self.enableHelpers();
       self.addTypeMigration();
+      self.addDocReferencesMigration();
       self.addPermissions();
       self.apos.tasks.add('apostrophe-attachments', 'rescale',
         'Usage: node app apostrophe-attachments:rescale\n\n' +
@@ -163,6 +164,8 @@ module.exports = {
       }
     ]).concat(options.addImageSizes || []);
 
+    self.sizeAvailableInTrash = options.sizeAvailableInTrash || 'one-sixth';
+
     var uploadfsDefaultSettings = {
       backend: 'local',
       uploadsPath: self.apos.rootDir + '/public/uploads',
@@ -198,10 +201,19 @@ module.exports = {
     };
 
     self.enableCollection = function(callback) {
-      self.apos.db.collection('aposAttachments', function(err, collection) {
-        self.db = collection;
-        return callback(err);
-      });
+      return async.series([ collection, indexDocIds, indexTrashDocIds ], callback);
+      function collection(callback) {
+        return self.apos.db.collection('aposAttachments', function(err, collection) {
+          self.db = collection;
+          return callback(err);
+        });
+      }
+      function indexDocIds(callback) {
+        return self.db.ensureIndex({ docIds: 1 }, callback);
+      }
+      function indexTrashDocIds(callback) {
+        return self.db.ensureIndex({ trashDocIds: 1 }, callback);
+      }
     };
 
     self.enableHelpers = function() {

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -832,11 +832,12 @@ module.exports = function(self, options) {
       var method = trash ? self.uploadfs.disable : self.uploadfs.enable;
       return async.series([
         original,
-        scaled,
         crops,
         update
       ], callback);
 
+      // Handle the original image and its scaled versions
+      // here ("original" means "not cropped")
       function original(callback) {
         if ((!trash) && (attachment.trash === undefined)) {
           // Trash status not set at all yet means
@@ -844,27 +845,13 @@ module.exports = function(self, options) {
           // skip extra API calls
           return callback(null);
         }
-        var path = self.url(attachment, { uploadfsPath: true, size: 'original' });
-        return method(path, function(err) {
-          if (err) {
-            // afterSave is not a good place for fatal errors
-            console.warn('Unable to set permissions on ' + path + ', possibly it does not exist');
-          }
-          return callback(null);
-        });
-      }
-
-      function scaled(callback) {
-        if ((!trash) && (attachment.trash === undefined)) {
-          // Trash status not set at all yet means
-          // it'll be a live file as of this point,
-          // skip extra API calls
-          return callback(null);
-        }
+        var sizes;
         if (!_.contains([ 'gif', 'jpg', 'png' ], attachment.extension)) {
-          return callback(null);
+          sizes = [ 'original' ];
+        } else {
+          sizes = self.imageSizes.concat([ 'original' ]);
         }
-        return async.eachSeries(self.imageSizes, function(size) {
+        return async.eachSeries(sizes, function(size) {
           if (size.name === self.sizeAvailableInTrash) {
             // This size is always kept accessible for preview
             // in the media library
@@ -888,11 +875,11 @@ module.exports = function(self, options) {
           // skip extra API calls
           return callback(null);
         }
-        return async.eachSeries(attachment.crops, cropOne, callback);
+        return async.eachSeries(attachment.crops || [], cropOne, callback);
       }
 
       function cropOne(crop, callback) {
-        return async.eachSeries(self.imageSizes, function(size) {
+        return async.eachSeries(self.imageSizes.concat([ 'original' ]), function(size) {
           if (size.name === self.sizeAvailableInTrash) {
             // This size is always kept accessible for preview
             // in the media library

--- a/lib/modules/apostrophe-attachments/lib/api.js
+++ b/lib/modules/apostrophe-attachments/lib/api.js
@@ -3,6 +3,7 @@ var async = require('async');
 var crypto = require('crypto');
 var path = require('path');
 var fs = require('fs');
+var Promise = require('bluebird');
 
 module.exports = function(self, options) {
 
@@ -26,99 +27,119 @@ module.exports = function(self, options) {
   // The `options` argument may be omitted completely.
   // If `options.permissions` is explicitly set to `false`,
   // permissions are not checked.
+  //
+  // `callback` is invoked with `(null, attachment)` where
+  // `attachment` is an attachment object, suitable
+  // for passing to the `url` API and for use as the value
+  // of an `type: 'attachment'` schema field.
+  //
+  // If `callback` is omitted completely, a promise is returned.
+  // The promise resolves to an attachment object.
 
   self.insert = function(req, file, options, callback) {
 
-    if (arguments.length === 3) {
+    if (typeof(arguments[2]) !== 'object') {
       callback = arguments[2];
       options = {};
     }
 
-    var extension = path.extname(file.name);
-    if (extension && extension.length) {
-      extension = extension.substr(1);
+    if (callback) {
+      return body(callback);
+    } else {
+      return Promise.promisify(body)();
     }
-    extension = extension.toLowerCase();
-    // Do we accept this file extension?
-    var group = self.getFileGroup(extension);
-    if (!group) {
-      var accepted = _.union(_.pluck(self.fileGroups, 'extensions'));
-      return callback("File extension not accepted. Acceptable extensions: " + accepted.join(","));
-    }
-    var image = group.image;
-    var info = {
-      _id: self.apos.utils.generateId(),
-      group: group.name,
-      createdAt: new Date(),
-      name: self.apos.utils.slugify(path.basename(file.name, path.extname(file.name))),
-      title: self.apos.utils.sortify(path.basename(file.name, path.extname(file.name))),
-      extension: extension,
-      type: 'attachment'
-    };
 
-    function permissions(callback) {
-      if (options && (options.permissions === false)) {
-        return callback(null);
+    function body(callback) {
+
+      var extension = path.extname(file.name);
+      if (extension && extension.length) {
+        extension = extension.substr(1);
       }
-      return callback(self.apos.permissions.can(req, 'edit-attachment') ? null : 'forbidden');
-    }
+      extension = extension.toLowerCase();
+      // Do we accept this file extension?
+      var group = self.getFileGroup(extension);
+      if (!group) {
+        var accepted = _.union(_.pluck(self.fileGroups, 'extensions'));
+        return callback("File extension not accepted. Acceptable extensions: " + accepted.join(","));
+      }
+      var image = group.image;
+      var info = {
+        _id: self.apos.utils.generateId(),
+        group: group.name,
+        createdAt: new Date(),
+        name: self.apos.utils.slugify(path.basename(file.name, path.extname(file.name))),
+        title: self.apos.utils.sortify(path.basename(file.name, path.extname(file.name))),
+        extension: extension,
+        type: 'attachment',
+        docIds: [],
+        trashDocIds: []
+      };
 
-    function length(callback) {
-      return self.apos.utils.fileLength(file.path, function(err, size) {
-        if (err) {
-          return callback(err);
+      function permissions(callback) {
+        if (options && (options.permissions === false)) {
+          return callback(null);
         }
-        info.length = size;
-        return callback(null);
-      });
-    }
+        return callback(self.apos.permissions.can(req, 'edit-attachment') ? null : 'forbidden');
+      }
 
-    function md5(callback) {
-      return self.apos.utils.md5File(file.path, function(err, md5) {
-        if (err) {
-          return callback(err);
-        }
-        info.md5 = md5;
-        return callback(null);
-      });
-    }
-
-    function upload(callback) {
-      if (image) {
-        // For images we correct automatically for common file extension mistakes
-        return self.uploadfs.copyImageIn(file.path, '/attachments/' + info._id + '-' + info.name, function(err, result) {
+      function length(callback) {
+        return self.apos.utils.fileLength(file.path, function(err, size) {
           if (err) {
             return callback(err);
           }
-          info.extension = result.extension;
-          info.width = result.width;
-          info.height = result.height;
-          if (info.width > info.height) {
-            info.landscape = true;
-          } else {
-            info.portrait = true;
-          }
+          info.length = size;
           return callback(null);
         });
-      } else {
-        // For non-image files we have to trust the file extension
-        // (but we only serve it as that content type, so this should
-        // be reasonably safe)
-        return self.uploadfs.copyIn(file.path, '/attachments/' + info._id + '-' + info.name + '.' + info.extension, callback);
       }
+
+      function md5(callback) {
+        return self.apos.utils.md5File(file.path, function(err, md5) {
+          if (err) {
+            return callback(err);
+          }
+          info.md5 = md5;
+          return callback(null);
+        });
+      }
+
+      function upload(callback) {
+        if (image) {
+          // For images we correct automatically for common file extension mistakes
+          return self.uploadfs.copyImageIn(file.path, '/attachments/' + info._id + '-' + info.name, function(err, result) {
+            if (err) {
+              return callback(err);
+            }
+            info.extension = result.extension;
+            info.width = result.width;
+            info.height = result.height;
+            if (info.width > info.height) {
+              info.landscape = true;
+            } else {
+              info.portrait = true;
+            }
+            return callback(null);
+          });
+        } else {
+          // For non-image files we have to trust the file extension
+          // (but we only serve it as that content type, so this should
+          // be reasonably safe)
+          return self.uploadfs.copyIn(file.path, '/attachments/' + info._id + '-' + info.name + '.' + info.extension, callback);
+        }
+      }
+
+      function remember(callback) {
+        if (!options || options && options.permissions !== false) {
+          info.ownerId = self.apos.permissions.getEffectiveUserId(req);
+        }
+        info.createdAt = new Date();
+        return self.db.insert(info, callback);
+      }
+
+      return async.series([ permissions, length, md5, upload, remember ], function(err) {
+        return callback(err, info);
+      });
     }
 
-    function remember(callback) {
-      if (!options || options && options.permissions !== false) {
-        info.ownerId = self.apos.permissions.getEffectiveUserId(req);
-      }
-      info.createdAt = new Date();
-      return self.db.insert(info, callback);
-    }
-
-    return async.series([ permissions, length, md5, upload, remember ], function(err) {
-      return callback(err, info);
-    });
   };
 
   self.getFileGroup = function(extension) {
@@ -603,6 +624,302 @@ module.exports = function(self, options) {
       safe: true
     });
 
+  };
+
+  self.addDocReferencesMigration = function() {
+    
+    self.apos.migrations.add(self.__meta.name + '.docReferences', function(callback) {
+
+      var needed;
+
+      return async.series([ needed, docs, attachments ], callback);
+
+      function needed(callback) {
+        return self.db.findOne({ docIds: { $exists: 0 } }, function(err, found) {
+          if (err) {
+            return callback(err);
+          }
+          needed = !!found;
+          return callback(null);
+        });
+      }
+
+      function docs(callback) {
+        if (!needed) {
+          return setImmediate(callback);
+        }
+        return self.apos.migrations.eachDoc({}, self.updateDocReferences, callback);
+      }
+
+      function attachments(callback) {
+        if (!needed) {
+          return setImmediate(callback);
+        }
+        return async.series([ docIds, trashDocIds ], callback);
+        function docIds(callback) {
+          return self.db.update({
+            docIds: { $exists: 0 }
+          }, {
+            $set: {
+              docIds: []
+            }
+          }, {
+            multi: true
+          }, callback);
+        }
+        function trashDocIds(callback) {
+          return self.db.update({
+            trashDocIds: { $exists: 0 }
+          }, {
+            $set: {
+              trashDocIds: []
+            }
+          }, {
+            multi: true
+          }, callback);
+        }
+      }
+
+    }, {
+      safe: true
+    });
+
+  };
+
+  self.docAfterSave = function(req, doc, options, callback) {
+    return self.updateDocReferences(doc, callback);
+  };
+
+  self.docAfterTrash = function(req, doc, callback) {
+    return self.updateDocReferences(doc, callback);
+  };
+
+  self.docAfterRescue = function(req, doc, callback) {
+    return self.updateDocReferences(doc, callback);
+  };
+
+  // When the last doc that contains this attachment goes to the
+  // trash, its permissions should change to reflect that so
+  // it is no longer web-accessible to those who know the URL.
+  //
+  // This method is invoked after any doc is inserted, updated, trashed
+  // or rescued.
+
+  self.updateDocReferences = function(doc, callback) {
+
+    var attachments = self.all(doc);
+    var ids = _.uniq(_.pluck(attachments, '_id'));
+
+    // Build an array of mongo commands to run. Each
+    // entry in the array is a 2-element array. Element 0
+    // is the criteria, element 1 is the command
+
+    var commands = [];
+
+    if (!doc.trash) {
+      commands.push([
+        {
+          _id: { $in: ids }
+        },
+        {
+          $addToSet: { docIds: doc._id }
+        }
+      ],
+      [
+        {
+          _id: { $in: ids }
+        },
+        {
+          $pull: { trashDocIds: doc._id }
+        }
+      ]);
+    } else {
+      commands.push([
+        {
+          _id: { $in: ids }
+        },
+        {
+          $addToSet: { trashDocIds: doc._id }
+        }
+      ],
+      [
+        {
+          _id: { $in: ids }
+        },
+        {
+          $pull: { docIds: doc._id }
+        }
+      ]);
+    }
+
+    commands.push([
+      {
+        $or: [
+          {
+            trashDocIds: { $in: [ doc._id ] }
+          },
+          {
+            docIds: { $in: [ doc._id ] }
+          }
+        ],
+        _id: { $nin: ids }
+      },
+      {
+        $pull: {
+          trashDocIds: doc._id,
+          docIds: doc._id
+        }
+      }
+    ], [
+      {
+        _id: { $in: ids }
+      },
+      {
+        $set: {
+          utilized: true
+        }
+      }
+    ]);
+
+    return async.series([
+      updateCounts,
+      hide,
+      show
+    ], callback);
+
+    function updateCounts(callback) {
+      return async.eachSeries(commands, function(command, callback) {
+        return self.db.update(command[0], command[1], callback);
+      }, callback);
+    }
+
+    function hide(callback) {
+      return self.db.find({
+        utilized: true,
+        'docIds.0': { $exists: 0 },
+        trash: { $ne: true }
+      }).toArray(function(err, attachments) {
+        if (err) {
+          return callback(err);
+        }
+        return async.eachSeries(attachments, hideOne, callback);
+      });
+    }
+
+    function show(callback) {
+      return self.db.find({
+        utilized: true,
+        'docIds.0': { $exists: 1 },
+        trash: { $ne: false }
+      }).toArray(function(err, attachments) {
+        if (err) {
+          return callback(err);
+        }
+        return async.eachSeries(attachments, showOne, callback);
+      });
+    }
+
+    function hideOne(attachment, callback) {
+      return permissionsOne(attachment, true, callback);
+    }
+
+    function showOne(attachment, callback) {
+      return permissionsOne(attachment, false, callback);
+    }
+
+    function permissionsOne(attachment, trash, callback) {
+
+      var method = trash ? self.uploadfs.disable : self.uploadfs.enable;
+      return async.series([
+        original,
+        scaled,
+        crops,
+        update
+      ], callback);
+
+      function original(callback) {
+        if ((!trash) && (attachment.trash === undefined)) {
+          // Trash status not set at all yet means
+          // it'll be a live file as of this point,
+          // skip extra API calls
+          return callback(null);
+        }
+        var path = self.url(attachment, { uploadfsPath: true, size: 'original' });
+        return method(path, function(err) {
+          if (err) {
+            // afterSave is not a good place for fatal errors
+            console.warn('Unable to set permissions on ' + path + ', possibly it does not exist');
+          }
+          return callback(null);
+        });
+      }
+
+      function scaled(callback) {
+        if ((!trash) && (attachment.trash === undefined)) {
+          // Trash status not set at all yet means
+          // it'll be a live file as of this point,
+          // skip extra API calls
+          return callback(null);
+        }
+        if (!_.contains([ 'gif', 'jpg', 'png' ], attachment.extension)) {
+          return callback(null);
+        }
+        return async.eachSeries(self.imageSizes, function(size) {
+          if (size.name === self.sizeAvailableInTrash) {
+            // This size is always kept accessible for preview
+            // in the media library
+            method = self.uploadfs.enable;
+          }
+          var path = self.url(attachment, { uploadfsPath: true, size: size.name });
+          return method(path, function(err) {
+            if (err) {
+              // afterSave is not a good place for fatal errors
+              console.warn('Unable to set permissions on ' + path + ', possibly it does not exist');
+            }
+            return callback(null);
+          });
+        }, callback);
+      }
+
+      function crops(callback) {
+        if ((!trash) && (attachment.trash === undefined)) {
+          // Trash status not set at all yet means
+          // it'll be a live file as of this point,
+          // skip extra API calls
+          return callback(null);
+        }
+        return async.eachSeries(attachment.crops, cropOne, callback);
+      }
+
+      function cropOne(crop, callback) {
+        return async.eachSeries(self.imageSizes, function(size) {
+          if (size.name === self.sizeAvailableInTrash) {
+            // This size is always kept accessible for preview
+            // in the media library
+            method = self.uploadfs.enable;
+          }
+          var path = self.url(attachment, { crop: crop, uploadfsPath: true, size: size.name });
+          return method(path, function(err) {
+            if (err) {
+              // afterSave is not a good place for fatal errors
+              console.warn('Unable to set permissions on ' + path + ', possibly it does not exist');
+            }
+            return callback(null);
+          });
+        }, callback);
+      }
+
+      function update(callback) {
+        return self.db.update({
+          _id: attachment._id
+        }, {
+          $set: {
+            trash: trash
+          }
+        }, callback);
+      }
+    }
+      
   };
 
 }

--- a/lib/modules/apostrophe-pieces/lib/api.js
+++ b/lib/modules/apostrophe-pieces/lib/api.js
@@ -381,40 +381,59 @@ module.exports = function(self, options) {
 
   };
 
-  // Move a piece to the trash by id.
+  // Move a piece to the trash by id. If `callback` is omitted,
+  // a promise is returned.
 
   self.trash = function(req, id, callback) {
     var permission = 'edit-doc';
-    if (self.apos.permissions.can(req, 'admin-' + self.name)) {
-      // This user has blanket permission for this piece type
-      permission = false;
+
+    if (arguments.length === 2) {
+      return Promise.promisify(body)();
+    } else {
+      return body(callback);
     }
-    return self.apos.docs.trash(req, id, {
-      permission: permission
-    }, function(err, piece) {
-      if (err) {
-        return callback(err);
+    function body(callback) {
+      if (self.apos.permissions.can(req, 'admin-' + self.name)) {
+        // This user has blanket permission for this piece type
+        permission = false;
       }
-      return self.deduplicateTrash(req, piece, callback);
-    });
+      return self.apos.docs.trash(req, id, {
+        permission: permission
+      }, function(err, piece) {
+        if (err) {
+          return callback(err);
+        }
+        return self.deduplicateTrash(req, piece, callback);
+      });
+    }
   };
 
-  // Rescue a piece from the trash by id.
+  // Rescue a piece from the trash by id. If `callback` is omitted,
+  // a promise is returned.
 
   self.rescue = function(req, id, callback) {
     var permission = 'edit-doc';
-    if (self.apos.permissions.can(req, 'admin-' + self.name)) {
-      // Blanket permission for this piece type
-      permission = false;
+
+    if (arguments.length === 2) {
+      return Promise.promisify(body)();
+    } else {
+      return body(callback);
     }
-    return self.apos.docs.rescue(req, id, {
-      permission: permission
-    }, function(err, piece) {
-      if (err) {
-        return callback(err);
+
+    function body(callback) {
+      if (self.apos.permissions.can(req, 'admin-' + self.name)) {
+        // Blanket permission for this piece type
+        permission = false;
       }
-      return self.deduplicateRescue(req, piece, callback);
-    });
+      return self.apos.docs.rescue(req, id, {
+        permission: permission
+      }, function(err, piece) {
+        if (err) {
+          return callback(err);
+        }
+        return self.deduplicateRescue(req, piece, callback);
+      });
+    }
   };
 
   // Convert the data supplied in `req.body` via the schema and


### PR DESCRIPTION
…the docs that directly contain them are outside the trash. Also, added promise support to pieces.trash, pieces.rescue and attachments.insert.