### PR TITLE
apostrophe-site-review accommodations 1

### DIFF
--- a/lib/modules/apostrophe-docs/lib/api.js
+++ b/lib/modules/apostrophe-docs/lib/api.js
@@ -592,13 +592,7 @@ module.exports = function(self, options) {
   // take a callback and are invoked in series.
 
   self.docBeforeSave = function(req, doc, options) {
-    if ((!doc.slug) || (doc.slug === 'none')) {
-      if (doc.title) {
-        doc.slug = self.apos.utils.slugify(doc.title);
-      } else if (doc.slug !== 'none') {
-        throw new Error('Document has neither slug nor title, giving up');
-      }
-    }
+    self.ensureSlug(doc);
     var manager = self.getManager(doc.type);
     _.each(manager.schema, function(field) {
       if (field.sortify) {
@@ -606,6 +600,18 @@ module.exports = function(self, options) {
       }
     });
     doc.updatedAt = new Date();
+  };
+
+  // If the doc does not yet have a slug, add one based on the
+  // title; throw an error if there is no title
+  self.ensureSlug = function(doc) {
+    if ((!doc.slug) || (doc.slug === 'none')) {
+      if (doc.title) {
+        doc.slug = self.apos.utils.slugify(doc.title);
+      } else if (doc.slug !== 'none') {
+        throw new Error('Document has neither slug nor title, giving up');
+      }
+    }
   };
 
   // Invoked when a MongoDB index uniqueness error

--- a/lib/modules/apostrophe-jobs/lib/api.js
+++ b/lib/modules/apostrophe-jobs/lib/api.js
@@ -9,7 +9,7 @@ module.exports = function(self, options) {
   //
   // The `ids` to be processed should be provided via `req.body.ids`.
   //
-  // Pass `req` and a `change` function that accepts `(req, id, data, callback)`,
+  // Pass `req` and a `change` function that accepts `(req, id, callback)`,
   // performs the modification on that one id and invokes its callback
   // with an error if any (if passed, this is recorded as a bad item
   // in the job, it does not stop the job) and an optional
@@ -171,6 +171,142 @@ module.exports = function(self, options) {
     }
 
   };  
+
+  // Similar to `run`, this method Starts and supervises a long-running job,
+  // however unlike `run` the `doTheWork` callback function provided is invoked just
+  // once, and when it completes the job is over. This is not the way to
+  // implement a batch operation on pieces; see the `batchSimple` method
+  // of that module.
+  //
+  // The `doTheWork` function receives `(req, reporting, callback)` and may optionally invoke
+  // `reporting.good()` and `reporting.bad()` to update the progress and error
+  // counters, and `reporting.setTotal()` to indicate the total number of
+  // counts expected so a progress meter can be rendered. This is optional and
+  // an indication of progress is still displayed without it.
+  // `reporting.setResults(object)` may also be called to pass a
+  // `results` object, which is made available to the optional `success` callback
+  // of the job's modal on the browser side. `doTheWork` may optionally
+  // return a promise rather than invoking the callback.
+  //
+  // This method will send `{ status: 'ok', jobId: 'cxxxx' }` to the
+  // browser for you. There is no callback because there is nothing more for
+  // you to do in your route.
+  //
+  // The `jobId` can then be passed to `apos.modules['apostrophe-jobs'].progress(jobId)`
+  // on the browser side to monitor progress. After the job status is `completed`,
+  // the results of the job can be obtained via the progress API as the `results`
+  // property, an object with a sub-property for each `id`.
+  //
+  // *Options*
+  //
+  // `options.label` should be passed as an object with
+  // a `title` property, to title the progress modal.
+  // A default is provided but it is not very informative.
+  //
+  // In addition, it may have `failed`, `completed` and
+  // `running` properties to label the progress modal when the job
+  // is in those states, and `good` and `bad` properties to label
+  // the count of items that were successful or had errors.
+  // All of these properties are optional and reasonable
+  // defaults are supplied.
+  //
+  // You may set `options.canStop` or `options.canCancel` to true.
+  // If you do, a "stop" or "cancel" button is presented to the user.
+  // Your code may then invoke `reporting.isCanceling()` when convenient
+  // and, if it returns a function, must cease the operation and then invoke
+  // that function **instead of** its callback. If the operation has completed
+  // in the meantime your code must take care not to invoke it afterwards.
+  //
+  // If `canCancel` was used, your code must also
+  // undo all effects of the entire job **before invoking** the function.
+
+  self.runNonBatch = function(req, doTheWork, options) {
+    var job;
+    var canceling = false;
+    var results;
+    return async.series([
+      startJob,
+      run
+    ], function(err) {
+      if (err) {
+        console.error(err);
+        return self.end(job, 'failed', function(err) {
+          if (err) {
+            // Not a lot we can do about this since we already
+            // stopped talking to the user 
+            console.error(err);
+          }
+        });
+      } else {
+        return self.end(job, 'completed', results, function(err) {
+          if (err) {
+            // Not a lot we can do about this since we already
+            // stopped talking to the user 
+            console.error(err);
+          }
+        });
+      }
+    });
+    
+    function startJob(callback) {
+      return self.start(_.assign({}, options, {
+        stop: options.canStop ? function(job, callback) {
+          canceling = callback;
+          return;
+        } : null,
+        cancel: options.canCancel ? function(job, callback) {
+          canceling = callback;
+          return;
+        } : null
+      }), function(err, _job) {
+        if (err) {
+          // Failed to insert the job. Don't continue the series,
+          // just tell the browser that.
+          return res.send({ status: 'error' });
+        }
+        job = _job;
+        // DELIBERATE FALLTHROUGH: respond to the browser
+        // *right now* with the job id, then continue the
+        // series WITHOUT ever touching `res` again. The
+        // browser will call back for progress.
+        res.send({ status: 'ok', jobId: job._id });
+        return callback(null);
+      });
+    }
+
+    function run(callback) {
+      var result = doTheWork(req, {
+        good: function(n) {
+          n = n || 1;
+          return self.good(job, n);
+        },
+        bad: function(n) {
+          n = n || 1;
+          return self.bad(job, n);
+        },
+        setTotal: function(n) {
+          return self.setTotal(job, n);
+        },
+        setResults: function(_results) {
+          results = _results;
+        },
+        isCanceling: function() {
+          return canceling;
+        }
+      }, callback);
+      // If `doTheWork` returned a promise instead,
+      // invoke the callback on its behalf when it resolves
+      if (result.then) {
+        result.then(function() {
+          return callback(null);
+        })
+        .catch(function(e) {
+          return callback(e);
+        });
+      }
+    }
+
+  };
 
   // Start tracking a long-running job. Called by routes
   // that require progress display and/or the ability to take longer

--- a/lib/modules/apostrophe-jobs/lib/api.js
+++ b/lib/modules/apostrophe-jobs/lib/api.js
@@ -5,7 +5,9 @@ module.exports = function(self, options) {
 
   // Starts and supervises a long-running job such as a
   // batch operation on pieces. Call it to implement an API route
-  // that runs a job.
+  // that runs a job involving carrying out the same action
+  // repetitively on many things. If your job doesn't look like
+  // that, check out `runNonBatch` instead.
   //
   // The `ids` to be processed should be provided via `req.body.ids`.
   //
@@ -82,7 +84,7 @@ module.exports = function(self, options) {
       if (err) {
         console.error(err);
         if (job) {
-          return self.end(job, 'failed', function(err) {
+          return self.end(job, false, function(err) {
             if (err) {
               // Not a lot we can do about this since we already
               // stopped talking to the user 
@@ -95,7 +97,7 @@ module.exports = function(self, options) {
         });
       } else {
         if (job) {
-          return self.end(job, 'completed', results, function(err) {
+          return self.end(job, true, results, function(err) {
             if (err) {
               // Not a lot we can do about this since we already
               // stopped talking to the user 
@@ -221,6 +223,7 @@ module.exports = function(self, options) {
   // undo all effects of the entire job **before invoking** the function.
 
   self.runNonBatch = function(req, doTheWork, options) {
+    var res = req.res;
     var job;
     var canceling = false;
     var results;
@@ -230,7 +233,7 @@ module.exports = function(self, options) {
     ], function(err) {
       if (err) {
         console.error(err);
-        return self.end(job, 'failed', function(err) {
+        return self.end(job, false, function(err) {
           if (err) {
             // Not a lot we can do about this since we already
             // stopped talking to the user 
@@ -238,7 +241,7 @@ module.exports = function(self, options) {
           }
         });
       } else {
-        return self.end(job, 'completed', results, function(err) {
+        return self.end(job, true, results, function(err) {
           if (err) {
             // Not a lot we can do about this since we already
             // stopped talking to the user 


### PR DESCRIPTION
Necessary accommodations to implement apostrophe-site-review. These are:

* New `runNonBatch` method of `apostrophe-jobs`. Similar to the `run` method, but it is for long-running jobs that don't just iterate doing the same exact thing to many pieces.
* Factored out an `ensureSlug` method, for modules that need that to exist in `docBeforeInsert`, before `docBeforeSave` has a chance to do it.
